### PR TITLE
Capistrano deploy for ursus

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,0 +1,16 @@
+# Load DSL and set up stages
+require "capistrano/setup"
+
+# Include default deployment tasks
+require "capistrano/deploy"
+
+# Use bundler to install gem requirements
+require 'capistrano/bundler'
+require 'capistrano/rails'
+require 'capistrano/sidekiq'
+require 'capistrano/passenger'
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
+
+# Load custom tasks from `lib/capistrano/tasks` if you have any defined
+Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-
+gem 'dotenv-rails'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.6'
 # Use sqlite3 as the database for Active Record
@@ -16,6 +16,8 @@ gem 'puma', '~> 3.7'
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
+gem 'pg'
+gem 'sidekiq'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 
@@ -49,6 +51,12 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'capistrano'
+  gem 'capistrano-bundler', '~> 1.3'
+  gem 'capistrano-ext'
+  gem 'capistrano-passenger'
+  gem 'capistrano-rails'
+  gem 'capistrano-sidekiq', '~> 0.20.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    airbrussh (1.3.0)
+      sshkit (>= 1.6.1, != 1.7.0)
     arel (8.0.0)
     autoprefixer-rails (9.1.4)
       execjs
@@ -60,6 +62,24 @@ GEM
       sass (>= 3.3.4)
     builder (3.2.3)
     byebug (10.0.2)
+    capistrano (3.11.0)
+      airbrussh (>= 1.0.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    capistrano-bundler (1.3.0)
+      capistrano (~> 3.1)
+      sshkit (~> 1.2)
+    capistrano-ext (1.2.1)
+      capistrano (>= 1.0.0)
+    capistrano-passenger (0.2.0)
+      capistrano (~> 3.0)
+    capistrano-rails (1.4.0)
+      capistrano (~> 3.1)
+      capistrano-bundler (~> 1.1)
+    capistrano-sidekiq (0.20.0)
+      capistrano (>= 3.9.0)
+      sidekiq (>= 3.4)
     capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -77,6 +97,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
+    connection_pool (2.2.2)
     crass (1.0.4)
     deprecation (1.0.0)
       activesupport
@@ -88,6 +109,10 @@ GEM
       warden (~> 1.2.3)
     devise-guests (0.6.1)
       devise
+    dotenv (2.5.0)
+    dotenv-rails (2.5.0)
+      dotenv (= 2.5.0)
+      railties (>= 3.2, < 6.0)
     erubi (1.7.1)
     execjs (2.7.0)
     faraday (0.15.2)
@@ -131,13 +156,19 @@ GEM
     minitest (5.11.3)
     multi_json (1.13.1)
     multipart-post (2.0.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (5.0.2)
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
+    pg (0.21.0)
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.5)
+    rack-protection (2.0.4)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.6)
@@ -167,6 +198,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    redis (4.0.2)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -191,6 +223,10 @@ GEM
     selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
+    sidekiq (5.2.2)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     solr_wrapper (2.0.0)
       faraday
       retriable
@@ -209,6 +245,9 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
+    sshkit (1.17.0)
+      net-scp (>= 1.1.2)
+      net-ssh (>= 2.8.0)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -242,18 +281,27 @@ PLATFORMS
 DEPENDENCIES
   blacklight (>= 6.1)
   byebug
+  capistrano
+  capistrano-bundler (~> 1.3)
+  capistrano-ext
+  capistrano-passenger
+  capistrano-rails
+  capistrano-sidekiq (~> 0.20.0)
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
   devise
   devise-guests (~> 0.6)
+  dotenv-rails
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  pg
   puma (~> 3.7)
   rails (~> 5.1.6)
   rsolr (>= 1.0)
   sass-rails (~> 5.0)
   selenium-webdriver
+  sidekiq
   solr_wrapper (>= 0.3)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -2,13 +2,13 @@
 # each environment can have a jetty_path with absolute or relative
 # (to app root) path to a jetty/solr install. This is used
 # by the rake tasks that start up solr automatically for testing
-# and by rake solr:marc:index.  
+# and by rake solr:marc:index.
 #
 # jetty_path is not used by a running Blacklight application
 # at all. In general you do NOT need to deploy solr in Jetty, you can deploy it
-# however you want.  
+# however you want.
 # jetty_path is only required for rake tasks that need to know
-# how to start up solr, generally for automated testing. 
+# how to start up solr, generally for automated testing.
 
 development:
   adapter: solr
@@ -17,5 +17,4 @@ test: &test
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 8983}/solr/blacklight-core" %>
 production:
-  adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
+  url: <%= ENV['SOLR_URL'] %>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+# config valid for current version and patch releases of Capistrano
+lock "~> 3.11.0"
+
+set :application, "ursus"
+set :repo_url, "https://github.com/UCLALibrary/ursus.git"
+
+set :deploy_to, '/opt/ursus'
+
+set :log_level, :debug
+set :bundle_flags, '--deployment'
+set :bundle_env_variables, nokogiri_use_system_libraries: 1
+
+set :keep_releases, 5
+set :assets_prefix, "#{shared_path}/public/assets"
+
+SSHKit.config.command_map[:rake] = 'bundle exec rake'
+
+set :branch, ENV['REVISION'] || ENV['BRANCH_NAME'] || 'master'
+
+append :linked_dirs, "log"
+append :linked_dirs, "public/assets"
+
+append :linked_files, ".env.production"
+append :linked_files, "config/database.yml"
+append :linked_files, "config/secrets.yml"
+
+# We have to re-define capistrano-sidekiq's tasks to work with
+# systemctl in production. Note that you must clear the previously-defined
+# tasks before re-defining them.
+Rake::Task["sidekiq:stop"].clear_actions
+Rake::Task["sidekiq:start"].clear_actions
+Rake::Task["sidekiq:restart"].clear_actions
+namespace :sidekiq do
+ task :stop do
+   on roles(:app) do
+     execute :sudo, :systemctl, :stop, :sidekiq
+   end
+ end
+ task :start do
+   on roles(:app) do
+     execute :sudo, :systemctl, :start, :sidekiq
+   end
+ end
+ task :restart do
+   on roles(:app) do
+     execute :sudo, :systemctl, :restart, :sidekiq
+   end
+ end
+end

--- a/config/deploy/localhost.rb
+++ b/config/deploy/localhost.rb
@@ -1,0 +1,2 @@
+set :rails_env, 'production'
+server '127.0.0.1', user: 'deploy', roles: [:web, :app, :db]

--- a/config/deploy/sandbox.rb
+++ b/config/deploy/sandbox.rb
@@ -1,0 +1,2 @@
+set :rails_env, 'production'
+server 'ursus.curationexperts.com', user: 'deploy', roles: [:web, :app, :db]

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -1,0 +1,21 @@
+PROJECT_NAME=ursus
+DATABASE_ADAPTER=mysql2
+
+### NOTE: only uncomment/provide the DATABASE_NAME below *if* this is an environment-specific dotenv file (like .env.development or .env.test)
+# DATABASE_NAME=ursus_development
+# DATABASE_NAME=ursus_test
+
+ADMIN_PASSWORD=password
+CABLE_CHANNEL_PREFIX=ursus_development
+DATABASE_HOST=localhost
+DATABASE_USERNAME=ursus
+DATABASE_PASSWORD=ursus
+DATABASE_POOL=25
+DATABASE_MIN_MESSAGES=warning
+RAILS_SERVE_STATIC_FILES=true
+RAILS_HOST=localhost
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_CABLE_DB=1
+SIDEKIQ_WORKERS=7
+SOLR_URL=http://127.0.0.1:8983/solr/ursus


### PR DESCRIPTION
* Use dotenv to set environment variables
* Initial capistrano deploy

Note: This will need to be switched to mysql when UCLA servers are ready

Deployed at https://ursus.curationexperts.com/

Fixes #1 