### PR TITLE
Add ActiveFedora fields to Solr schema

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -600,6 +600,23 @@
    <copyField source="*_t" dest="suggest"/>
    <copyField source="*_facet" dest="suggest"/>
 
+
+   <!-- Wildcards used by Samvera/ActiveFedora -->
+   <copyField source="*_dtsi"  dest="*_dt" />
+   <copyField source="*_teim"  dest="*_t"  />
+   <copyField source="*_si"    dest="*_t"  />
+   <copyField source="*_sim"   dest="*_t"  />
+   <copyField source="*_ssi"   dest="*_t"  />
+   <copyField source="*_ssim"  dest="*_t"  />
+   <copyField source="*_dtsi"  dest="*_t"  />
+   <copyField source="*_dtsim" dest="*_t"  />
+   <copyField source="*_ssm"   dest="*_display" />
+   <copyField source="*_ssi"   dest="*_display" />
+   <copyField source="*_ssim"  dest="*_display" />
+   <copyField source="*_dtsi"  dest="*_display" />
+   <copyField source="*_dtsim" dest="*_display" />
+
+
    <!-- Above, multiple source fields are copied to the [text] field.
 	  Another way to map multiple source fields to the same
 	  destination field is to use the dynamic field syntax.


### PR DESCRIPTION
This adds the dynamic fields that are used
by ActiveFedora to the solr schema. If they
aren't present and you try to copy data
over from Hyrax, you will get errors because
there are fields present in the document that
aren't in the default schema.