### PR TITLE
Add travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: ruby
+cache: bundler
+dist: trusty
+sudo: false
+
+jdk:
+- oraclejdk8
+
+rvm:
+  - 2.5.1
+script:
+  - bundle exec rake spec
+notifications:
+  email: false


### PR DESCRIPTION
This commit adds the basic travis
yml to configure builds for ursus.

The build command is the basic spec command.

In the future this will probably become a
specific rake task depending on the complexity
of the test suite