### PR TITLE
Header Links

### DIFF
--- a/app/assets/stylesheets/ursus/_navbar.scss
+++ b/app/assets/stylesheets/ursus/_navbar.scss
@@ -9,6 +9,12 @@
   .nav-item-dlp {
     font-size: 125%;
   }
+  
+  .navbar-nav {
+    .nav-link:hover{
+      color: $ucla-gold;
+    }
+  }
 }
 
 .navbar-brand {

--- a/app/assets/stylesheets/ursus/_navbar.scss
+++ b/app/assets/stylesheets/ursus/_navbar.scss
@@ -1,5 +1,16 @@
 @import 'colors';
 
+.navbar-header {
+  .nav-item-uclalibrary {
+    font-size: 150%;
+    font-weight: 450;
+  }
+
+  .nav-item-dlp {
+    font-size: 125%;
+  }
+}
+
 .navbar-brand {
   margin-top: 1em;
   margin-left: 0 !important;

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,0 +1,35 @@
+<div id="header-navbar" class="navbar navbar-inverse navbar-static-top" role="navigation">
+  <div class="<%= container_classes %>">
+    <div class="navbar-header">
+    <%#=<button type="button" class="navbar-toggle btn collapsed" data-toggle="collapse" data-target="#user-util-collapse">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>%>
+    <ul class="nav navbar-nav">
+      <li class="nav-item nav-item-uclalibrary">
+        <a class="nav-link" href="http://library.ucla.edu">
+          <%#= image_tag("logo.svg", :alt => "UCLA Library") %>
+          UCLA Library
+        </a>
+      </li>
+      <li class="nav-item nav-item-dlp">
+        <a class="nav-link" href="http://digital2.library.ucla.edu">
+          Digital Collections</a>
+      </li>
+    </ul>
+    <%#= link_to application_name, root_path, class: "navbar-brand" %>
+    </div>
+
+    <%#= <div class="collapse navbar-collapse" id="user-util-collapse"> %>
+      <%#= render :partial=>'/user_util_links' %>
+    <%#= </div> %>
+  </div>
+</div>
+
+<div id="search-navbar" class="navbar navbar-default navbar-static-top" role="navigation">
+  <div class="<%= container_classes %>">
+    <%= render_search_bar  %>
+  </div>
+</div>


### PR DESCRIPTION
to close https://github.com/UCLALibrary/ursus/issues/15

Keeps header very minimal, per @emcaulay's suggestion in comments. Most items are moved to footer.