### PR TITLE
Turn off bookmark controls in search results

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,9 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
+  gem 'equivalent-xml'
+  gem 'rspec-collection_matchers'
+  gem 'rspec-its'
   gem 'rspec-rails', '~> 3.8'
   gem 'selenium-webdriver'
   gem 'solr_wrapper', '>= 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
       railties (>= 3.2, < 6.0)
+    equivalent-xml (0.6.0)
+      nokogiri (>= 1.4.3)
     erubi (1.7.1)
     execjs (2.7.0)
     faraday (0.15.3)
@@ -208,11 +210,16 @@ GEM
     rsolr (2.2.1)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
+    rspec-collection_matchers (1.1.3)
+      rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
@@ -316,6 +323,7 @@ DEPENDENCIES
   devise
   devise-guests (~> 0.6)
   dotenv-rails
+  equivalent-xml
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
@@ -324,6 +332,8 @@ DEPENDENCIES
   puma (~> 3.7)
   rails (~> 5.1.6)
   rsolr (>= 1.0)
+  rspec-collection_matchers
+  rspec-its
   rspec-rails (~> 3.8)
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,4 +1,28 @@
 <ul class="navbar-nav navbar-right nav">
   <li class="nav-item"><a class="nav-link" href="http://www.library.ucla.edu">UCLA Library</a></li>
-  <li class="nav-item"><a class="nav-link" href="http://digital2.library.ucla.edus">UCLA Library Digital Collections</a></li>
+  <li class="nav-item"><a class="nav-link" href="http://digital2.library.ucla.edu">UCLA Library Digital Collections</a></li>
+
+  <%# This is the string 'true' or 'false' not the bool because it can be used with dotenv %>
+  <% if config.user_account_ui_enabled == 'true' %>
+    <%= render_nav_actions do |config, action|%>
+      <li class="nav-item"><%= action %></li>
+    <% end %>
+
+    <% if has_user_authentication_provider? %>
+      <% if current_user %>
+        <li class="nav-item">
+          <%= link_to t('blacklight.header_links.logout'), destroy_user_session_path, class: 'nav-link' %>
+        </li>
+        <% unless current_user.to_s.blank? -%>
+          <li class="nav-item">
+            <%= link_to current_user, edit_user_registration_path, class: 'nav-link' %>
+          </li>
+        <% end %>
+      <% else %>
+        <li class="nav-item">
+          <%= link_to t('blacklight.header_links.login'), new_user_session_path, class: 'nav-link' %>
+        </li>
+      <% end %>
+    <% end %>
 </ul>
+  <% end %>

--- a/app/views/catalog/_bookmark_control.html.erb
+++ b/app/views/catalog/_bookmark_control.html.erb
@@ -1,0 +1,41 @@
+<%# Check for the string true not boolean because it can be configured with dotenv %>
+<% if config.user_account_ui_enabled == 'true' %>
+  <% if current_or_guest_user %>
+    <%-
+    # Note these two forms are pretty similar but for different :methods, classes, and labels.
+      # but it was simpler to leave them seperate instead of DRYing them, got confusing trying that.
+      # the data-doc-id attribute is used by our JS that converts to a checkbox/label.
+    -%>
+    <% unless bookmarked? document %>
+      <%= form_tag(bookmark_path(document),
+                   method: :put,
+                   class: 'bookmark-toggle',
+                   data: {
+                     'doc-id' => document.id,
+                     present: t('blacklight.search.bookmarks.present'),
+                     absent: t('blacklight.search.bookmarks.absent'),
+                     inprogress: t('blacklight.search.bookmarks.inprogress')
+                   }) do %>
+        <%= submit_tag(t('blacklight.bookmarks.add.button'),
+                       id: "bookmark_toggle_#{document.id.to_s.parameterize}",
+                       class: "bookmark-add btn btn-outline-secondary") %>
+      <% end %>
+    <% else %>
+      <%= form_tag(bookmark_path(document),
+                   method: :delete,
+                   class: "bookmark-toggle",
+                   data: {
+                     'doc-id' => document.id,
+                     present: t('blacklight.search.bookmarks.present'),
+                     absent: t('blacklight.search.bookmarks.absent'),
+                     inprogress: t('blacklight.search.bookmarks.inprogress')
+                   }) do %>
+        <%= submit_tag(t('blacklight.bookmarks.remove.button'),
+                       id: "bookmark_toggle_#{document.id.to_s.parameterize}",
+                       class: "bookmark-remove btn btn-outline-secondary") %>
+      <% end %>
+    <% end %>
+  <% else %>
+    &nbsp;
+  <% end %>
+<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.user_account_ui_enabled = ENV['USER_ACCOUNT_UI_ENABLED'] || 'false'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,4 +88,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.user_account_ui_enabled = ENV['USER_ACCOUNT_UI_ENABLED'] || 'false'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  config.user_account_ui_enabled = ENV['USER_ACCOUNT_UI_ENABLED'] || 'false'
 end

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -15,6 +15,9 @@ DATABASE_MIN_MESSAGES=warning
 RAILS_SERVE_STATIC_FILES=true
 RAILS_HOST=localhost
 
+
 # The solr for the Californica environment that this Ursus environment will use as its data source
 SOLR_URL=http://127.0.0.1:8983/solr/californica
 
+# Controls whether or not the login and bookmarks UI show up
+USER_ACCOUNT_UI_ENABLED=false


### PR DESCRIPTION
These are visible by default. This adds a config
variable that can be set with dotenv to turn the
user account UI on or off.

Connected to UCLALibrary/amalgamated-samvera#129