### PR TITLE
Add specs for turning off user login display

### DIFF
--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -3,7 +3,7 @@
   <li class="nav-item"><a class="nav-link" href="http://digital2.library.ucla.edu">UCLA Library Digital Collections</a></li>
 
   <%# This is the string 'true' or 'false' not the bool because it can be used with dotenv %>
-  <% if config.user_account_ui_enabled == 'true' %>
+  <% if Rails.application.config.user_account_ui_enabled == 'true' %>
     <%= render_nav_actions do |config, action|%>
       <li class="nav-item"><%= action %></li>
     <% end %>

--- a/app/views/catalog/_bookmark_control.html.erb
+++ b/app/views/catalog/_bookmark_control.html.erb
@@ -1,5 +1,5 @@
 <%# Check for the string true not boolean because it can be configured with dotenv %>
-<% if config.user_account_ui_enabled == 'true' %>
+<% if Rails.application.config.user_account_ui_enabled == 'true' %>
   <% if current_or_guest_user %>
     <%-
     # Note these two forms are pretty similar but for different :methods, classes, and labels.

--- a/spec/views/_user_util_links.html.erb_spec.rb
+++ b/spec/views/_user_util_links.html.erb_spec.rb
@@ -2,27 +2,23 @@
 
 require 'rails_helper'
 
-RSpec.describe 'catalog/_bookmark_control.html.erb' do
-  let(:document) { SolrDocument.new id: 'xyz', format: 'a' }
+RSpec.describe '_user_util_links.html.erb' do
   let(:blacklight_config) { Blacklight::Configuration.new }
 
   before do
-    assign :document, document
     allow(view).to receive(:blacklight_config).and_return blacklight_config
-    allow(view).to receive(:document) { document }
-    allow(view).to receive(:documents) { [document] }
-    allow(view).to receive(:bookmarked?) { false }
+    allow(view).to receive(:has_user_authentication_provider?).and_return(true)
   end
 
   it 'does not display if turned off' do
     Rails.application.config.user_account_ui_enabled = 'false'
     render
-    expect(rendered).to eq('')
+    expect(rendered).not_to match(/Login/)
   end
 
   it 'displays if it is turned on' do
     Rails.application.config.user_account_ui_enabled = 'true'
     render
-    expect(rendered).to match(/bookmark-toggle/)
+    expect(rendered).to match(/Login/)
   end
 end

--- a/spec/views/_user_util_links.html.erb_spec.rb
+++ b/spec/views/_user_util_links.html.erb_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe '_user_util_links.html.erb' do
   end
 
   it 'does not display if turned off' do
-    Rails.application.config.user_account_ui_enabled = 'false'
+    allow(Rails.application.config).to receive(:user_account_ui_enabled).and_return('false')
     render
     expect(rendered).not_to match(/Login/)
   end
 
   it 'displays if it is turned on' do
-    Rails.application.config.user_account_ui_enabled = 'true'
+    allow(Rails.application.config).to receive(:user_account_ui_enabled).and_return('true')
     render
     expect(rendered).to match(/Login/)
   end

--- a/spec/views/catalog/_bookmark_control.html.erb_spec.rb
+++ b/spec/views/catalog/_bookmark_control.html.erb_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe 'catalog/_bookmark_control.html.erb' do
   end
 
   it 'does not display if turned off' do
-    Rails.application.config.user_account_ui_enabled = 'false'
+    allow(Rails.application.config).to receive(:user_account_ui_enabled).and_return('false')
     render
     expect(rendered).to eq('')
   end
 
   it 'displays if it is turned on' do
-    Rails.application.config.user_account_ui_enabled = 'true'
+    allow(Rails.application.config).to receive(:user_account_ui_enabled).and_return('true')
     render
     expect(rendered).to match(/bookmark-toggle/)
   end


### PR DESCRIPTION
This adds view specs that cover cases where
the login links are turned on or off via
configuration. It also updates the path
in the views to the configuation by adding
`Rails.application` when accessing the property.
This was needed when running the specs.