### PR TITLE
Add service to set URL for thumbnails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :development do
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
   gem 'capistrano-sidekiq', '~> 0.20.0'
+  gem 'xray-rails'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,6 +305,8 @@ GEM
     xml-simple (1.1.5)
     xpath (3.1.0)
       nokogiri (~> 1.8)
+    xray-rails (0.3.1)
+      rails (>= 3.1.0)
 
 PLATFORMS
   ruby
@@ -347,6 +349,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  xray-rails
 
 BUNDLED WITH
    1.16.5

--- a/app/services/thumbnail_url_service.rb
+++ b/app/services/thumbnail_url_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ThumbnailUrlService
+  # @param url [String] the URL you want to append to the thumbnail src tag
+  # @param html [String] the html that contains the img tag
+  def initialize(url:, html:)
+    @url = url
+    @html = html
+  end
+
+  # @return [String] HTML string with the URL appended
+  def markup_with_full_url
+    html_doc = Nokogiri::HTML(@html)
+    img = html_doc.at_css 'img'
+    img[:src] = @url + img[:src]
+    html_doc.xpath('//body').to_html
+  end
+end

--- a/app/views/catalog/_thumbnail_default.html.erb
+++ b/app/views/catalog/_thumbnail_default.html.erb
@@ -1,0 +1,7 @@
+<%- if has_thumbnail?(document) && tn = render_thumbnail_tag(document, {}, :counter => document_counter_with_offset(document_counter)) %>
+  <div class="document-thumbnail">
+    <% require 'thumbnail_url_service' %>
+    <% thumbnail_service = ::ThumbnailUrlService.new(html: tn, url: Rails.application.config.thumbnail_url) %>
+    <%= raw(thumbnail_service.markup_with_full_url)  %>
+  </div>
+<%- end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,4 +53,5 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.user_account_ui_enabled = ENV['USER_ACCOUNT_UI_ENABLED'] || 'false'
+  config.thumbnail_url = ENV['THUMBNAIL_BASE_URL'] || ''
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,4 +90,5 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.user_account_ui_enabled = ENV['USER_ACCOUNT_UI_ENABLED'] || 'false'
+  config.thumbnail_url = ENV['THUMBNAIL_BASE_URL'] || ''
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,4 +40,5 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   config.user_account_ui_enabled = ENV['USER_ACCOUNT_UI_ENABLED'] || 'false'
+  config.thumbnail_url = ENV['THUMBNAIL_BASE_URL'] || ''
 end

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -21,3 +21,5 @@ SOLR_URL=http://127.0.0.1:8983/solr/californica
 
 # Controls whether or not the login and bookmarks UI show up
 USER_ACCOUNT_UI_ENABLED=false
+
+THUMBNAIL_BASE_URL=''


### PR DESCRIPTION
This adds a service which is used in the
`thumbnail_default` view to append a URL
to the thumbnail `src` path. This is
configured with the `ENV['THUMBNAIL_BASE_URL']`
env variable.

Connected to UCLALibrary/amalgamated-samvera#121