### PR TITLE
Specify terms that are searched by default

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
+
 require 'solrizer'
 
 class CatalogController < ApplicationController
-
   include Blacklight::Catalog
 
   configure_blacklight do |config|
@@ -153,11 +153,11 @@ class CatalogController < ApplicationController
     # This one uses all the defaults set by the solr request handler. Which
     # solr request handler? The one set in config[:default_solr_parameters][:qt],
     # since we aren't specifying it otherwise.
+    search_field_service = ::SearchFieldService.instance
     config.add_search_field('all_fields', label: 'All Fields') do |field|
-      all_names = config.show_fields.values.map(&:field).join(' ')
       title_name = ::Solrizer.solr_name('title', :stored_searchable)
       field.solr_parameters = {
-        qf: "#{all_names} file_format_tesim all_text_timv",
+        qf: search_field_service.search_fields,
         pf: title_name.to_s
       }
     end

--- a/app/services/search_field_service.rb
+++ b/app/services/search_field_service.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class SearchFieldService
+  include Singleton
+
+  SEARCH_FIELDS = 'title_tesim subject_tesim named_subject_tesim location_tesim description_tesim caption_tesim identifier_tesim local_identifier_tesim normalized_date_tesim photographer_tesim'.freeze
+  def search_fields
+    SEARCH_FIELDS
+  end
+end

--- a/spec/services/search_field_service_spec.rb
+++ b/spec/services/search_field_service_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SearchFieldService do
+  let(:search_field_service) { described_class.instance }
+
+  it 'returns the correct list of search fields' do
+    expect(search_field_service.search_fields).to eq('title_tesim subject_tesim named_subject_tesim location_tesim description_tesim caption_tesim identifier_tesim local_identifier_tesim normalized_date_tesim photographer_tesim')
+  end
+end


### PR DESCRIPTION
This adds a service that is used in the catalog
controller to specify what terms are searched
by default.

Connected to UCLALibrary/ursus#19