### PR TITLE
Revise index fields in catalog controller to match requirements

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -85,21 +85,8 @@ class CatalogController < ApplicationController
     #   The   config.add_index_field ::Solrizer.solr_name('title', :stored_searchable), label: 'Title', itemprop: 'name', if: false
 
     config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description'
-    config.add_index_field ::Solrizer.solr_name('keyword', :stored_searchable), itemprop: 'keywords', link_to_search: ::Solrizer.solr_name('keyword', :facetable)
-    config.add_index_field ::Solrizer.solr_name('subject', :stored_searchable), itemprop: 'about', helper_method: :values_with_line_breaks
-    config.add_index_field ::Solrizer.solr_name('creator', :stored_searchable), itemprop: 'creator', link_to_search: ::Solrizer.solr_name('creator', :facetable)
-    config.add_index_field ::Solrizer.solr_name('contributor', :stored_searchable), itemprop: 'contributor', link_to_search: ::Solrizer.solr_name('contributor', :facetable)
-    config.add_index_field ::Solrizer.solr_name('publisher', :stored_searchable), itemprop: 'publisher', link_to_search: ::Solrizer.solr_name('publisher', :facetable)
-    config.add_index_field ::Solrizer.solr_name('based_near_label', :stored_searchable), itemprop: 'contentLocation', link_to_search: ::Solrizer.solr_name('based_near_label', :facetable)
-    config.add_index_field ::Solrizer.solr_name('language', :stored_searchable), itemprop: 'inLanguage', link_to_search: ::Solrizer.solr_name('language', :facetable)
-    config.add_index_field ::Solrizer.solr_name('date_uploaded', :stored_sortable, type: :date), itemprop: 'datePublished'
-    config.add_index_field ::Solrizer.solr_name('date_modified', :stored_sortable, type: :date), itemprop: 'dateModified'
     config.add_index_field ::Solrizer.solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
-    config.add_index_field ::Solrizer.solr_name('rights_statement', :stored_searchable)
-    config.add_index_field ::Solrizer.solr_name('license', :stored_searchable)
     config.add_index_field ::Solrizer.solr_name('resource_type', :stored_searchable), label: 'Resource Type', link_to_search: ::Solrizer.solr_name('resource_type', :facetable)
-    config.add_index_field ::Solrizer.solr_name('file_format', :stored_searchable), link_to_search: ::Solrizer.solr_name('file_format', :facetable)
-    config.add_index_field ::Solrizer.solr_name('identifier', :stored_searchable)
 
     # solr fields to be displayed in the show (single result) view
     # The ordering of the field names is the order of the display

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CatalogController, type: :controller do
+  # describe 'facets' do
+  #   let(:facets) do
+  #     controller
+  #       .blacklight_config
+  #       .facet_fields.keys
+  #       .map { |field| field.gsub(/\_s+im$/, '') }
+  #   end
+  #
+  #   let(:expected_facets) do
+  #     ['human_readable_type',
+  #      'resource_type',
+  #      'creator',
+  #      'contributor',
+  #      'degree',
+  #      'institution',
+  #      'school',
+  #      'department',
+  #      'keyword',
+  #      'subject',
+  #      'language',
+  #      'license',
+  #      'based_near_label',
+  #      'file_format',
+  #      'member_of_collections',
+  #      'generic_type',
+  #      'rights_statement']
+  #   end
+  #
+  #   it 'has exactly expected facets' do
+  #     expect(facets).to contain_exactly(*expected_facets)
+  #   end
+  # end
+
+  describe 'index fields' do
+    let(:index_fields) do
+      controller
+        .blacklight_config
+        .index_fields.keys
+        .map { |field| field.gsub(/\_s+im$/, '') }
+    end
+
+    let(:expected_index_fields) do
+      ['description_tesim',
+       'date_created_tesim',
+       'resource_type_tesim']
+    end
+    it { expect(index_fields).to contain_exactly(*expected_index_fields) }
+  end
+
+  describe 'search fields' do
+    let(:search_fields) { controller.blacklight_config.search_fields.keys }
+
+    let(:expected_search_fields) do
+      ['all_fields']
+    end
+
+    it { expect(search_fields).to contain_exactly(*expected_search_fields) }
+  end
+end


### PR DESCRIPTION
Connects #16

- Add a catalog_controller_spec to verify only the expected fields are
returned by the catalog_controller
- Revise catalog_controller to only return the fields specified in #16