### PR TITLE
Display the human-readable copyright status instead of the URL. Story #57 

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -102,7 +102,7 @@ class CatalogController < ApplicationController
     config.add_show_field ::Solrizer.solr_name('date_uploaded', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('date_modified', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('date_created', :stored_searchable)
-    config.add_show_field ::Solrizer.solr_name('rights_statement', :stored_searchable)
+    config.add_show_field ::Solrizer.solr_name('human_readable_rights_statement', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('license', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('resource_type', :stored_searchable), label: 'Resource Type'
     config.add_show_field ::Solrizer.solr_name('format', :stored_searchable)

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -39,7 +39,7 @@ en:
           repository_tesim: 'Repository'
           rights_country_tesim: 'Rights (country of creation)'
           rights_holder_tesim: 'Rights Holder'
-          rights_statement_tesim: 'Copyright Status'
+          human_readable_rights_statement_tesim: 'Copyright Status'
           subject_tesim: 'Subjects'
           title_tesim: 'Title'
         show:
@@ -67,6 +67,6 @@ en:
           repository_tesim: 'Repository'
           rights_country_tesim: 'Rights (country of creation)'
           rights_holder_tesim: 'Rights Holder'
-          rights_statement_tesim: 'Copyright Status'
+          human_readable_rights_statement_tesim: 'Copyright Status'
           subject_tesim: 'Subjects'
           title_tesim: 'Title'

--- a/spec/features/view_work_spec.rb
+++ b/spec/features/view_work_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "View a Work" do
       identifier_tesim: ['ark 123'],
       subject_tesim: ['Subj 1', 'Subj 2'],
       resource_type_tesim: ['still image'],
-      rights_statement_tesim: ['http://rightsstatements.org/vocab/InC/1.0/'],
+      human_readable_rights_statement_tesim: ['copyrighted'],
       genre_tesim: ['news photographs'],
       named_subject_tesim: ["Los Angeles County (Calif.). $b Board of Supervisors"],
       repository_tesim: ['University of California, Los Angeles. Library. Department of Special Collections'],
@@ -47,7 +47,7 @@ RSpec.feature "View a Work" do
     expect(page).to have_content 'Subjects: Subj 1'
     expect(page).to have_content 'Subj 2'
     expect(page).to have_content 'Resource Type: still image'
-    expect(page).to have_content 'Copyright Status: http://rightsstatements.org/vocab/InC/1.0/'
+    expect(page).to have_content 'Copyright Status: copyrighted'
     expect(page).to have_content 'Genre: news photographs'
     expect(page).to have_content 'Name (subject): Los Angeles County (Calif.). $b Board of Supervisors'
     expect(page).to have_content 'Repository: University of California, Los Angeles. Library. Department of Special Collections'


### PR DESCRIPTION
This depends on the corresponding PR in californica:
https://github.com/UCLALibrary/californica/pull/299

Connected to https://github.com/UCLALibrary/ursus/issues/57