### PR TITLE
Add feature spec to test search results page.

### DIFF
--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -69,161 +69,54 @@
          will be overridden by parameters in the request
       -->
      <lst name="defaults">
-       <str name="defType">dismax</str>
+       <str name="defType">edismax</str>
        <str name="echoParams">explicit</str>
-       <int name="rows">10</int>
-
        <str name="q.alt">*:*</str>
        <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
-
+       <int name="qs">1</int>
+       <int name="ps">2</int>
+       <float name="tie">0.01</float>
        <!-- this qf and pf are used by default, if not otherwise specified by
             client. The default blacklight_config will use these for the
-            "keywords" search. See the author_qf/author_pf, title_qf, etc 
+            "keywords" search. See the author_qf/author_pf, title_qf, etc
             below, which the default blacklight_config will specify for
             those searches. You may also be interested in:
             http://wiki.apache.org/solr/LocalParams
        -->
+        <str name="qf">
+          id
+          title_tesim
+          author_tesim
+          subject_tesim
+        </str>
+        <str name="pf">
+          all_text_timv^10
+        </str>
 
-       <str name="qf">
-         title_unstem_search^100000
-         subtitle_unstem_search^50000
-         title_t^25000
-         subtitle_t^10000
-         title_addl_unstem_search^5000
-         title_addl_t^2500
-         title_added_entry_unstem_search^1500
-         title_added_entry_t^1250
-         subject_topic_unstem_search^1000
-         subject_unstem_search^750
-         subject_topic_facet^625
-         subject_t^500
-         author_unstem_search^250
-         author_addl_unstem_search^250
-         author_t^100
-         author_addl_t^50
-         subject_addl_unstem_search^250
-         subject_addl_t^50
-         title_series_unstem_search^25
-         title_series_t^10
-         isbn_t
-         text
-       </str>
-       <str name="pf">
-         title_unstem_search^1000000
-         subtitle_unstem_search^500000
-         title_t^250000
-         subtitle_t^100000
-         title_addl_unstem_search^50000
-         title_addl_t^25000
-         title_added_entry_unstem_search^15000
-         title_added_entry_t^12500
-         subject_topic_unstem_search^10000
-         subject_unstem_search^7500
-         subject_topic_facet^6250
-         subject_t^5000
-         author_unstem_search^2500
-         author_addl_unstem_search^2500
-         author_t^1000
-         author_addl_t^500
-         subject_addl_unstem_search^2500
-         subject_addl_t^500
-         title_series_unstem_search^250
-         title_series_t^100
-         text^10
-       </str>
        <str name="author_qf">
-         author_unstem_search^200
-         author_addl_unstem_search^50
-         author_t^20
-         author_addl_t
+          author_tesim
        </str>
        <str name="author_pf">
-         author_unstem_search^2000
-         author_addl_unstem_search^500
-         author_t^200
-         author_addl_t^10
        </str>
        <str name="title_qf">
-         title_unstem_search^50000
-         subtitle_unstem_search^25000
-         title_addl_unstem_search^10000
-         title_t^5000
-         subtitle_t^2500
-         title_addl_t^100
-         title_added_entry_unstem_search^50
-         title_added_entry_t^10
-         title_series_unstem_search^5
-         title_series_t
+          title_tesim
        </str>
        <str name="title_pf">
-         title_unstem_search^500000
-         subtitle_unstem_search^250000
-         title_addl_unstem_search^100000
-         title_t^50000
-         subtitle_t^25000
-         title_addl_t^1000
-         title_added_entry_unstem_search^500
-         title_added_entry_t^100
-         title_series_t^50
-         title_series_unstem_search^10
        </str>
        <str name="subject_qf">
-         subject_topic_unstem_search^200
-         subject_unstem_search^125
-         subject_topic_facet^100
-         subject_t^50
-         subject_addl_unstem_search^10
-         subject_addl_t
+          subject_tesim
        </str>
        <str name="subject_pf">
-         subject_topic_unstem_search^2000
-         subject_unstem_search^1250
-         subject_t^1000
-         subject_topic_facet^500
-         subject_addl_unstem_search^100
-         subject_addl_t^10
        </str>
-       
-       <int name="ps">3</int>
-       <float name="tie">0.01</float>
 
-       <!-- NOT using marc_display because it is large and will slow things down for search results -->
        <str name="fl">
-         id, 
-         score,
-         author_display,
-         author_vern_display, 
-         format, 
-         isbn_t, 
-         language_facet, 
-         lc_callnum_display,
-         material_type_display, 
-         published_display,
-         published_vern_display,
-         pub_date,
-         title_display,
-         title_vern_display,
-         subject_topic_facet,
-         subject_geo_facet,
-         subject_era_facet,
-         subtitle_display,
-         subtitle_vern_display,
-         url_fulltext_display,
-         url_suppl_display,
+         *,
+         score
        </str>
 
        <str name="facet">true</str>
        <str name="facet.mincount">1</str>
-       <str name="facet.field">format</str>
-       <str name="facet.field">lc_1letter_facet</str>
-       <str name="facet.field">lc_alpha_facet</str>
-       <str name="facet.field">lc_b4cutter_facet</str>
-       <str name="facet.field">language_facet</str>
-       <str name="facet.field">pub_date</str>
-       <str name="facet.field">subject_era_facet</str>
-       <str name="facet.field">subject_geo_facet</str>
-       <str name="facet.field">subject_topic_facet</str>
-       
+
        <str name="spellcheck">true</str>
        <str name="spellcheck.dictionary">default</str>
        <str name="spellcheck.onlyMorePopular">true</str>
@@ -232,62 +125,9 @@
        <str name="spellcheck.count">5</str>
 
      </lst>
-    <!-- In addition to defaults, "appends" params can be specified
-         to identify values which should be appended to the list of
-         multi-val params from the query (or the existing "defaults").
-      -->
-    <!-- In this example, the param "fq=instock:true" would be appended to
-         any query time fq params the user may specify, as a mechanism for
-         partitioning the index, independent of any user selected filtering
-         that may also be desired (perhaps as a result of faceted searching).
-
-         NOTE: there is *absolutely* nothing a client can do to prevent these
-         "appends" values from being used, so don't use this mechanism
-         unless you are sure you always want it.
-      -->
-    <!--
-       <lst name="appends">
-         <str name="fq">inStock:true</str>
-       </lst>
-      -->
-    <!-- "invariants" are a way of letting the Solr maintainer lock down
-         the options available to Solr clients.  Any params values
-         specified here are used regardless of what values may be specified
-         in either the query, the "defaults", or the "appends" params.
-
-         In this example, the facet.field and facet.query params would
-         be fixed, limiting the facets clients can use.  Faceting is
-         not turned on by default - but if the client does specify
-         facet=true in the request, these are the only facets they
-         will be able to see counts for; regardless of what other
-         facet.field or facet.query params they may specify.
-
-         NOTE: there is *absolutely* nothing a client can do to prevent these
-         "invariants" values from being used, so don't use this mechanism
-         unless you are sure you always want it.
-      -->
-    <!--
-       <lst name="invariants">
-         <str name="facet.field">cat</str>
-         <str name="facet.field">manu_exact</str>
-         <str name="facet.query">price:[* TO 500]</str>
-         <str name="facet.query">price:[500 TO *]</str>
-       </lst>
-      -->
-    <!-- If the default list of SearchComponents is not desired, that
-         list can either be overridden completely, or components can be
-         prepended or appended to the default list.  (see below)
-      -->
-    <!--
-       <arr name="components">
-         <str>nameOfCustomComponent1</str>
-         <str>nameOfCustomComponent2</str>
-       </arr>
-      -->
     <arr name="last-components">
       <str>spellcheck</str>
     </arr>
-      
   </requestHandler>
 
   <!-- for requests to get a single document; use id=666 instead of q=id:666 -->

--- a/spec/features/search_catalog_spec.rb
+++ b/spec/features/search_catalog_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Search the catalog' do
+  before do
+    delete_all_documents_from_solr
+    solr = Blacklight.default_index.connection
+    solr.add([orange, banana])
+    solr.commit
+  end
+
+  let(:orange) do
+    {
+      id: '111',
+      has_model_ssim: ['Work'],
+      title_tesim: ['Orange Carrot']
+    }
+  end
+
+  let(:banana) do
+    {
+      id: '222',
+      has_model_ssim: ['Work'],
+      title_tesim: ['Yellow Banana']
+    }
+  end
+
+  scenario 'get correct search results' do
+    visit root_path
+
+    within '#documents' do
+      expect(page).to have_link('Orange Carrot')
+      expect(page).to have_link('Yellow Banana')
+    end 
+
+    # Search for something
+    fill_in 'q', with: 'carrot'
+    click_on 'search'
+
+    within '#documents' do
+      expect(page).to     have_link('Orange Carrot')
+      expect(page).to_not have_link('Yellow Banana')
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,5 @@ RSpec.configure do |config|
 
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
+  config.include SolrHelpers, type: :feature
 end

--- a/spec/support/solr_helpers.rb
+++ b/spec/support/solr_helpers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SolrHelpers
+  def delete_all_documents_from_solr
+    solr = Blacklight.default_index.connection
+    solr.delete_by_query('*:*')
+    solr.commit
+  end
+end


### PR DESCRIPTION
* Add a spec helper method to delete all documents from solr.

* Change the 'search' requestHandler config to exactly match the config
in californica.  With the old config, the spec failed because blacklight
used the ID instead of the title to construct the document link.  That
happened because only a partial solr doc was returned with the old
config, so the title wasn't available to create the link.