### PR TITLE
Add a spec for checking that UV is loaded

### DIFF
--- a/spec/features/view_work_spec.rb
+++ b/spec/features/view_work_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "View a Work" do
     solr = Blacklight.default_index.connection
     solr.add(work_attributes)
     solr.commit
+    allow(Rails.application.config).to receive(:iiif_url).and_return('https://example.com')
   end
 
   let(:id) { '123' }
@@ -74,7 +75,10 @@ RSpec.feature "View a Work" do
 
     # we DO NOT want the SMS This link
     expect(page).to_not have_content 'SMS This'
-    
   end
 
+  scenario 'loads UV on the page with correct IIIF URI' do
+    visit solr_document_path(id)
+    expect(page.html).to match(/iiifResourceUri: \'https:\/\/example.com\/123\/manifest/)
+  end
 end


### PR DESCRIPTION
This adds a spec that ensures that UV is on
the page and that there is code that will
be able to generate the correct IIIF url
path when it is set in the config.

Connected to UCLALibrary/ursus#63