### PR TITLE
wip: facet links

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -95,7 +95,11 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The   config.add_index_field ::Solrizer.solr_name('title', :stored_searchable), label: 'Title', itemprop: 'name', if: false
 
-    config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description', separator_options: BREAKS
+<<<<<<< HEAD
+    config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description', helper_method: :values_with_line_breaks
+    config.add_index_field ::Solrizer.solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
+=======
+    config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description'
     config.add_index_field ::Solrizer.solr_name('date_created', :stored_searchable), itemprop: 'dateCreated', link_to_search: ::Solrizer.solr_name('date_created', :facetable)
     # config.add_index_field ::Solrizer.solr_name('normalized_date', :stored_searchable), itemprop: 'dateCreated'
 >>>>>>> wip: facet links

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -95,11 +95,7 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The   config.add_index_field ::Solrizer.solr_name('title', :stored_searchable), label: 'Title', itemprop: 'name', if: false
 
-<<<<<<< HEAD
-    config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description', helper_method: :values_with_line_breaks
-    config.add_index_field ::Solrizer.solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
-=======
-    config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description'
+    config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description', separator_options: BREAKS
     config.add_index_field ::Solrizer.solr_name('date_created', :stored_searchable), itemprop: 'dateCreated', link_to_search: ::Solrizer.solr_name('date_created', :facetable)
     # config.add_index_field ::Solrizer.solr_name('normalized_date', :stored_searchable), itemprop: 'dateCreated'
 >>>>>>> wip: facet links

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -95,14 +95,9 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The   config.add_index_field ::Solrizer.solr_name('title', :stored_searchable), label: 'Title', itemprop: 'name', if: false
 
-<<<<<<< HEAD
-    config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description', helper_method: :values_with_line_breaks
-    config.add_index_field ::Solrizer.solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
-=======
-    config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description'
+    config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description', separator_options: BREAKS
     config.add_index_field ::Solrizer.solr_name('date_created', :stored_searchable), itemprop: 'dateCreated', link_to_search: ::Solrizer.solr_name('date_created', :facetable)
     # config.add_index_field ::Solrizer.solr_name('normalized_date', :stored_searchable), itemprop: 'dateCreated'
->>>>>>> wip: facet links
     config.add_index_field ::Solrizer.solr_name('resource_type', :stored_searchable), label: 'Resource Type', link_to_search: ::Solrizer.solr_name('resource_type', :facetable)
     config.add_index_field ::Solrizer.solr_name('photographer', :stored_searchable), label: 'Photographer', link_to_search: ::Solrizer.solr_name('photographer', :facetable)
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -5,6 +5,12 @@ require 'solrizer'
 class CatalogController < ApplicationController
   include Blacklight::Catalog
 
+  BREAKS = {
+    words_connector: '<br/>',
+    two_words_connector: '<br/>',
+    last_word_connector: '<br/>'
+  }
+
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository
@@ -89,8 +95,14 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The   config.add_index_field ::Solrizer.solr_name('title', :stored_searchable), label: 'Title', itemprop: 'name', if: false
 
+<<<<<<< HEAD
     config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description', helper_method: :values_with_line_breaks
     config.add_index_field ::Solrizer.solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
+=======
+    config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description'
+    config.add_index_field ::Solrizer.solr_name('date_created', :stored_searchable), itemprop: 'dateCreated', link_to_search: ::Solrizer.solr_name('date_created', :facetable)
+    # config.add_index_field ::Solrizer.solr_name('normalized_date', :stored_searchable), itemprop: 'dateCreated'
+>>>>>>> wip: facet links
     config.add_index_field ::Solrizer.solr_name('resource_type', :stored_searchable), label: 'Resource Type', link_to_search: ::Solrizer.solr_name('resource_type', :facetable)
     config.add_index_field ::Solrizer.solr_name('photographer', :stored_searchable), label: 'Photographer', link_to_search: ::Solrizer.solr_name('photographer', :facetable)
 
@@ -99,12 +111,12 @@ class CatalogController < ApplicationController
     config.add_show_field ::Solrizer.solr_name('title', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('description', :stored_searchable), helper_method: :values_with_line_breaks
     config.add_show_field ::Solrizer.solr_name('keyword', :stored_searchable)
-    config.add_show_field ::Solrizer.solr_name('subject', :stored_searchable), helper_method: :values_with_line_breaks
+    config.add_show_field ::Solrizer.solr_name('subject', :stored_searchable), link_to_search: ::Solrizer.solr_name('subject', :facetable), separator_options: BREAKS
     config.add_show_field ::Solrizer.solr_name('creator', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('contributor', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('publisher', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('based_near_label', :stored_searchable)
-    config.add_show_field ::Solrizer.solr_name('language', :stored_searchable)
+    config.add_show_field ::Solrizer.solr_name('language', :stored_searchable), link_to_search: ::Solrizer.solr_name('language', :facetable)
     config.add_show_field ::Solrizer.solr_name('date_uploaded', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('date_modified', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('date_created', :stored_searchable)
@@ -115,16 +127,16 @@ class CatalogController < ApplicationController
     config.add_show_field ::Solrizer.solr_name('identifier', :stored_searchable)
 
     config.add_show_field ::Solrizer.solr_name('caption', :stored_searchable)
-    config.add_show_field ::Solrizer.solr_name('dimensions', :stored_searchable)
+    config.add_show_field ::Solrizer.solr_name('dimensions', :stored_searchable), link_to_search: ::Solrizer.solr_name('dimensions', :facetable)
     config.add_show_field ::Solrizer.solr_name('extent', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('funding_note', :stored_searchable)
-    config.add_show_field ::Solrizer.solr_name('genre', :stored_searchable), helper_method: :values_with_line_breaks_and_facet_links
+    config.add_show_field ::Solrizer.solr_name('genre', :stored_searchable), link_to_search: ::Solrizer.solr_name('genre', :facetable), separator_options: BREAKS
     config.add_show_field ::Solrizer.solr_name("geographic_coordinates", :symbol)
-    config.add_show_field ::Solrizer.solr_name('location', :stored_searchable)
+    config.add_show_field ::Solrizer.solr_name('location', :stored_searchable), link_to_search: ::Solrizer.solr_name('location', :facetable)
     config.add_show_field ::Solrizer.solr_name('local_identifier', :stored_searchable)
-    config.add_show_field ::Solrizer.solr_name('medium', :stored_searchable)
-    config.add_show_field ::Solrizer.solr_name('named_subject', :stored_searchable)
-    config.add_show_field ::Solrizer.solr_name('normalized_date', :stored_searchable)
+    config.add_show_field ::Solrizer.solr_name('medium', :stored_searchable), link_to_search: ::Solrizer.solr_name('medium', :facetable)
+    config.add_show_field ::Solrizer.solr_name('named_subject', :stored_searchable), link_to_search: ::Solrizer.solr_name('named_subject', :facetable), separator_options: BREAKS
+    config.add_show_field ::Solrizer.solr_name('normalized_date', :stored_searchable), link_to_search: ::Solrizer.solr_name('normalized_date', :facetable)
     config.add_show_field ::Solrizer.solr_name('repository', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('rights_country', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('rights_holder', :stored_searchable)

--- a/spec/features/view_work_spec.rb
+++ b/spec/features/view_work_spec.rb
@@ -20,9 +20,10 @@ RSpec.feature "View a Work" do
       subject_tesim: ['Subj 1', 'Subj 2'],
       resource_type_tesim: ['still image'],
       human_readable_rights_statement_tesim: ['copyrighted'],
-      genre_tesim: ['news photographs'],
-      named_subject_tesim: ["Los Angeles County (Calif.). $b Board of Supervisors"],
+      genre_tesim: ['Genre 1', 'Genre 2'],
+      named_subject_tesim: ["Named Subject 1", "Named Subject 2"],
       repository_tesim: ['University of California, Los Angeles. Library. Department of Special Collections'],
+      location_tesim: ['Los Angeles'],
       publisher_tesim: ['Los Angeles Daily News'],
       rights_country_tesim: ['US'],
       rights_holder_tesim: ['Charles E. Young'],
@@ -46,12 +47,11 @@ RSpec.feature "View a Work" do
     expect(page).to have_content 'The Title of my Work'
     expect(page).to have_content 'Identifier: ark 123'
     expect(page).to have_content 'Subjects: Subj 1'
-    expect(page).to have_content 'Subj 2'
     expect(page).to have_content 'Resource Type: still image'
-    expect(page).to have_link    'still image'
     expect(page).to have_content 'Copyright Status: copyrighted'
-    expect(page).to have_content 'Genre: news photographs'
-    expect(page).to have_content 'Name (subject): Los Angeles County (Calif.). $b Board of Supervisors'
+    expect(page).to have_content 'Genre: Genre 1'
+    expect(page).to have_content 'Name (subject): Named Subject 1'
+    expect(page).to have_content 'Location: Los Angeles'
     expect(page).to have_content 'Repository: University of California, Los Angeles. Library. Department of Special Collections'
     expect(page).to have_content 'Publisher: Los Angeles Daily News'
     expect(page).to have_content 'Rights (country of creation): US'
@@ -67,8 +67,31 @@ RSpec.feature "View a Work" do
     expect(page).to have_content 'Caption: the caption'
     expect(page).to have_content 'Language: No linguistic content'
     expect(page).to have_content 'Photographer: Poalillo, Charles'
-    expect(page).to have_link    'Poalillo, Charles'
   end
+  
+  scenario 'displays facetable fields as links' do
+    visit solr_document_path(id)
+    expect(page.find('dd.blacklight-subject_tesim')).to have_link    'Subj 1'
+    expect(page.find('dd.blacklight-subject_tesim')).to have_link    'Subj 2'
+    expect(page.find('dd.blacklight-resource_type_tesim')).to have_link    'still image'
+    expect(page.find('dd.blacklight-genre_tesim')).to have_link    'Genre 1'
+    expect(page.find('dd.blacklight-genre_tesim')).to have_link    'Genre 2'
+    expect(page.find('dd.blacklight-named_subject_tesim')).to have_link    'Named Subject 1'
+    expect(page.find('dd.blacklight-location_tesim')).to have_link    'Los Angeles'
+    expect(page.find('dd.blacklight-photographer_tesim')).to have_link 'Poalillo, Charles'
+    expect(page.find('dd.blacklight-normalized_date_tesim')).to have_link '1947-09-17'
+    expect(page.find('dd.blacklight-medium_tesim')).to have_link '1 photograph'
+    expect(page.find('dd.blacklight-dimensions_tesim')).to have_link '10 x 12.5 cm.'
+    expect(page.find('dd.blacklight-language_tesim')).to have_link 'No linguistic content'
+  end
+
+  scenario 'displays line breaks between the values of certain fields' do
+    visit solr_document_path(id)
+    expect(page.find('dd.blacklight-subject_tesim').all(:css, 'br').length).to eq 1
+    expect(page.find('dd.blacklight-genre_tesim').all(:css, 'br').length).to eq 1
+    expect(page.find('dd.blacklight-named_subject_tesim').all(:css, 'br').length).to eq 1
+  end
+
   scenario 'only displays the tools we want to support' do
     visit solr_document_path(id)
 


### PR DESCRIPTION
In this Pull Request:
- [*] Displays every facetable field value as a link in both search results and single-item pages.
- [*] Separates "Named subject" values with a line break in single-item page.
- [*] Refactors all item separators and facet links to use catalog_controller.rb options instead of helper methods.
- [*] Tests written for all changes to single-item page

Still to do:
- [ ] Write tests for search results page
- [ ] New waffle ticket to document that we are combining issues and seek lazy consent from mgmt

Connected to https://github.com/UCLALibrary/ursus/issues/65
Connected to https://github.com/UCLALibrary/ursus/issues/67