### PR TITLE
Change search placeholder text

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -2,6 +2,9 @@ en:
   blacklight:
     application_name: 'UCLA Library Digital Collections'
     search:
+      form:
+        search:
+          placeholder: 'Search Los Angeles Daily News Negatives'
       fields:
         facet:
           date_created_tesim: 'Date Created'


### PR DESCRIPTION
This changes the search placeholder text
to 'Search Los Angeles Daily News Negatives' to indicate
the collection that you are searching.

Connected to UCLALibrary/amalgamated-samvera#184