### PR TITLE
Change feedback link styles to have a tad less pop

### DIFF
--- a/app/assets/stylesheets/ursus/_feedback_link.scss
+++ b/app/assets/stylesheets/ursus/_feedback_link.scss
@@ -2,11 +2,11 @@
 
 .feedback-link {
   text-transform: uppercase;
-  background-color: #343A40;
+  background-color: #dddddd;
   border-radius: 2rem 2rem 0rem 0rem;
-  a { 
-  	color: $ucla-gold;
-  	border-bottom: 1px solid $ucla-gold;
+  a {
+  	color: $ucla-blue;
+  	border-bottom: 1px solid $ucla-blue;
   }
   font-size: 1.25em;
   font-weight: 500;
@@ -24,7 +24,7 @@
 @media screen and (max-device-width: 480px) {
   .feedback-link {
       text-transform: uppercase;
-      background-color: #343A40;
+      background-color: #dddddd;
       border-radius: 2rem 2rem 0rem 0rem;
       font-size: .75em;
       /* font-weight: 500; */

--- a/app/assets/stylesheets/ursus/_feedback_link.scss
+++ b/app/assets/stylesheets/ursus/_feedback_link.scss
@@ -4,10 +4,7 @@
   text-transform: uppercase;
   background-color: #dddddd;
   border-radius: 2rem 2rem 0rem 0rem;
-  a {
-  	color: $ucla-blue;
-  	border-bottom: 1px solid $ucla-blue;
-  }
+
   font-size: 1.25em;
   font-weight: 500;
   margin: 0px;
@@ -15,23 +12,24 @@
   position: fixed;
   bottom: 0;
   left: 3rem;
-  a:hover {
-  	color: $ucla-tertiary-yellow;
-  	border-bottom: 1px solid $ucla-tertiary-yellow;
+
+  a {
+    color: $ucla-blue;
   }
+
 }
 
 @media screen and (max-device-width: 480px) {
   .feedback-link {
-      text-transform: uppercase;
-      background-color: #dddddd;
-      border-radius: 2rem 2rem 0rem 0rem;
-      font-size: .75em;
-      /* font-weight: 500; */
-      margin: 0px;
-      padding: 1rem 1rem 1.2rem 1.2rem;
-      position: fixed;
-      bottom: 0;
-      /* left: 3rem; */
+    text-transform: uppercase;
+    background-color: #dddddd;
+    border-radius: 2rem 2rem 0rem 0rem;
+    font-size: .75em;
+    /* font-weight: 500; */
+    margin: 0px;
+    padding: 1rem 1rem 1.2rem 1.2rem;
+    position: fixed;
+    bottom: 0;
+    /* left: 3rem; */
   }
 }

--- a/app/assets/stylesheets/ursus/_footer.scss
+++ b/app/assets/stylesheets/ursus/_footer.scss
@@ -9,11 +9,6 @@
     color: snow;
   }
 
-  a:hover {
-    color: $ucla-tertiary-yellow;
-    text-decoration: none;
-  }
-
   .footer-links {
     padding-top: 15px;
     text-align: center;


### PR DESCRIPTION
- Use the same gray background from the facet links
- Use the standard ucla blue for the link color

Connected to #123