### PR TITLE
move feedback link

### DIFF
--- a/app/assets/stylesheets/ursus/_feedback_link.scss
+++ b/app/assets/stylesheets/ursus/_feedback_link.scss
@@ -1,7 +1,6 @@
 @import 'colors';
 
 .feedback-link {
-  text-transform: uppercase;
   background-color: #dddddd;
   border-radius: 2rem 2rem 0rem 0rem;
 
@@ -11,7 +10,7 @@
   padding: 2rem 1.25rem 5rem 1.25rem;
   position: fixed;
   bottom: 0;
-  left: 3rem;
+  right: 3rem;
 
   a {
     color: $ucla-blue;
@@ -21,7 +20,6 @@
 
 @media screen and (max-device-width: 480px) {
   .feedback-link {
-    text-transform: uppercase;
     background-color: #dddddd;
     border-radius: 2rem 2rem 0rem 0rem;
     font-size: .75em;


### PR DESCRIPTION
<img width="1114" alt="screen shot 2018-11-15 at 1 20 45 pm" src="https://user-images.githubusercontent.com/73365/48582478-7f888200-e8d9-11e8-9c37-3cbf9761c86b.png">

This still sometimes blocks content on the homepage and search results page:
<img width="1126" alt="screen shot 2018-11-15 at 1 21 00 pm" src="https://user-images.githubusercontent.com/73365/48582480-7f888200-e8d9-11e8-8a52-4e5987e87091.png">

But we can always scroll past it:
<img width="1127" alt="screen shot 2018-11-15 at 1 21 15 pm" src="https://user-images.githubusercontent.com/73365/48582481-7f888200-e8d9-11e8-8f1a-2709ac409cbb.png">

I think the best solution to that would be a "dismiss" button which moves the link down to the footer (instead of floating at the bottom of the window). I'll write a ticket for that and let mgmt prioritize – for now, it's better on the right than on the left.

Connected to 122