### PR TITLE
Remove normalized date field on showpage

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -133,7 +133,6 @@ class CatalogController < ApplicationController
     config.add_show_field ::Solrizer.solr_name('local_identifier', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('medium', :stored_searchable), link_to_search: ::Solrizer.solr_name('medium', :facetable)
     config.add_show_field ::Solrizer.solr_name('named_subject', :stored_searchable), link_to_search: ::Solrizer.solr_name('named_subject', :facetable), separator_options: BREAKS
-    config.add_show_field ::Solrizer.solr_name('normalized_date', :stored_searchable), link_to_search: ::Solrizer.solr_name('normalized_date', :facetable)
     config.add_show_field ::Solrizer.solr_name('repository', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('rights_country', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('rights_holder', :stored_searchable)

--- a/spec/features/view_work_spec.rb
+++ b/spec/features/view_work_spec.rb
@@ -28,7 +28,6 @@ RSpec.feature "View a Work" do
       publisher_tesim: ['Los Angeles Daily News'],
       rights_country_tesim: ['US'],
       rights_holder_tesim: ['Charles E. Young'],
-      normalized_date_tesim: ['1947-09-17'],
       local_identifier_tesim: ['local id 123'],
       date_created_tesim: ["September 17, 1947"],
       medium_tesim: ['1 photograph'],
@@ -60,7 +59,6 @@ RSpec.feature "View a Work" do
     expect(page).to have_content 'Publisher: Los Angeles Daily News'
     expect(page).to have_content 'Rights (country of creation): US'
     expect(page).to have_content 'Rights Holder: Charles E. Young'
-    expect(page).to have_content 'Normalized Date: 1947-09-17'
     expect(page).to have_content 'Local Identifier: local id 123'
     expect(page).to have_content 'Date Created: September 17, 1947'
     expect(page).to have_content 'Medium: 1 photograph'
@@ -91,7 +89,6 @@ RSpec.feature "View a Work" do
     expect(page.find('dd.blacklight-named_subject_tesim')).to have_link    'Named Subject 1'
     expect(page.find('dd.blacklight-location_tesim')).to have_link    'Los Angeles'
     expect(page.find('dd.blacklight-photographer_tesim')).to have_link 'Poalillo, Charles'
-    expect(page.find('dd.blacklight-normalized_date_tesim')).to have_link '1947-09-17'
     expect(page.find('dd.blacklight-medium_tesim')).to have_link '1 photograph'
     expect(page.find('dd.blacklight-dimensions_tesim')).to have_link '10 x 12.5 cm.'
     expect(page.find('dd.blacklight-language_tesim')).to have_link 'No linguistic content'


### PR DESCRIPTION
Connected to #150

As a Digital Library Professional, I don't want to show my machine readable dates to end users.

---

On branch remove-normalized-date

Changes to be committed:
  modified:   app/controllers/catalog_controller.rb