### PR TITLE
Remove Link from the "Date created" result in the search results view

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -99,7 +99,7 @@ class CatalogController < ApplicationController
     #   The   config.add_index_field ::Solrizer.solr_name('title', :stored_searchable), label: 'Title', itemprop: 'name', if: false
 
     config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description', separator_options: BREAKS
-    config.add_index_field ::Solrizer.solr_name('date_created', :stored_searchable), itemprop: 'dateCreated', link_to_search: ::Solrizer.solr_name('date_created', :facetable)
+    config.add_index_field ::Solrizer.solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
     # config.add_index_field ::Solrizer.solr_name('normalized_date', :stored_searchable), itemprop: 'dateCreated'
     config.add_index_field ::Solrizer.solr_name('resource_type', :stored_searchable), label: 'Resource Type', link_to_search: ::Solrizer.solr_name('resource_type', :facetable)
     config.add_index_field ::Solrizer.solr_name('photographer', :stored_searchable), label: 'Photographer', link_to_search: ::Solrizer.solr_name('photographer', :facetable)

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature "Search results page" do
     visit '/catalog?f%5Blocation_tesim%5D%5B%5D=search_results_spec'
     expect(page).to have_link 'Title One'
     expect(page).to have_link 'still image'
-    expect(page).to have_link 'Date 1'
+    expect(page).not_to have_link 'Date 1'
     expect(page).to have_link 'Person 1'
   end
 


### PR DESCRIPTION
Connected to #179 

### The link is broken on the value of "Date created"
Date created: [December 1941]()

---

#### When you click on the Date Created Link
<img width="745" alt="screen shot 2018-12-06 at 3 17 13 pm" src="https://user-images.githubusercontent.com/751697/49618734-7afe3900-f96e-11e8-8e26-b979f96b720a.png">

---

#### Then you get this error
<img width="553" alt="screen shot 2018-12-06 at 3 17 01 pm" src="https://user-images.githubusercontent.com/751697/49618737-7e91c000-f96e-11e8-86d9-0fafd6c9c9b7.png">


---

On branch remove-date-created-link

Changes to be committed:
modified:   app/controllers/catalog_controller.rb
modified:   spec/features/search_results_spec.rb