### PR TITLE
Test if TRAVIS_TAG is not empty for stage deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,6 @@ after_success:
   if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
     curl "$JENKINS_DEPLOY_URL"
   fi
-  if [[ $TRAVIS_TAG =~ ^sprint[0-9]*\.rc[0-9]* ]]; then
+  if [[ $TRAVIS_TAG != "" ]]; then
     curl "$JENKINS_TAG_DEPLOY_URL"
   fi


### PR DESCRIPTION
This allows us to perform continuous deployment to the staging server for **any** tagged release - this includes our proposals of:

- `sprintX.Y`
- `X.Y.ZrcN`
- `X.Y.Z`

When a tag is created for any of the above, the release will be deployed to the stage environment. 