### PR TITLE
Exclude facet for "Medium" and "Dimensions"

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -70,8 +70,6 @@ class CatalogController < ApplicationController
     config.add_facet_field ::Solrizer.solr_name('named_subject', :facetable), limit: 5
     config.add_facet_field ::Solrizer.solr_name('location', :facetable), limit: 5
     config.add_facet_field 'year_isim', limit: 5, range: true
-    config.add_facet_field ::Solrizer.solr_name('medium', :facetable), limit: 5
-    config.add_facet_field ::Solrizer.solr_name('dimensions', :facetable), limit: 5
     config.add_facet_field ::Solrizer.solr_name('language', :facetable), limit: 5
 
     # config.add_facet_field ::Solrizer.solr_name('human_readable_type', :facetable), label: 'Type', limit: 5
@@ -124,14 +122,14 @@ class CatalogController < ApplicationController
     config.add_show_field ::Solrizer.solr_name('identifier', :stored_searchable)
 
     config.add_show_field ::Solrizer.solr_name('caption', :stored_searchable)
-    config.add_show_field ::Solrizer.solr_name('dimensions', :stored_searchable), link_to_search: ::Solrizer.solr_name('dimensions', :facetable)
+    config.add_show_field ::Solrizer.solr_name('dimensions', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('extent', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('funding_note', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('genre', :stored_searchable), link_to_search: ::Solrizer.solr_name('genre', :facetable), separator_options: BREAKS
     config.add_show_field ::Solrizer.solr_name("geographic_coordinates", :symbol)
     config.add_show_field ::Solrizer.solr_name('location', :stored_searchable), link_to_search: ::Solrizer.solr_name('location', :facetable)
     config.add_show_field ::Solrizer.solr_name('local_identifier', :stored_searchable)
-    config.add_show_field ::Solrizer.solr_name('medium', :stored_searchable), link_to_search: ::Solrizer.solr_name('medium', :facetable)
+    config.add_show_field ::Solrizer.solr_name('medium', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('named_subject', :stored_searchable), link_to_search: ::Solrizer.solr_name('named_subject', :facetable), separator_options: BREAKS
     config.add_show_field ::Solrizer.solr_name('repository', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('rights_country', :stored_searchable)

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe CatalogController, type: :controller do
        'named_subject',
        'location',
        'year_isim',
-       'medium',
        'language',
-       'dimensions',
        'generic_type']
     end
 

--- a/spec/features/facet_labels_spec.rb
+++ b/spec/features/facet_labels_spec.rb
@@ -18,8 +18,6 @@ RSpec.feature 'The facet sidebar', :clean, js: false do
       genre_sim: ['news photographs'],
       named_subject_sim: ['Los Angeles County (Calif.). Board of Supervisors'],
       year_isim: [1947],
-      medium_sim: ['1 photograph'],
-      dimensions_sim: ['10 x 12.5 cm.'],
       language_sim: ['No linguistic content'],
       location_sim: ['LA']
     }
@@ -35,8 +33,6 @@ RSpec.feature 'The facet sidebar', :clean, js: false do
       'Names',
       'Location',
       'Date',
-      'Medium',
-      'Dimensions',
       'Language'
     )
   end

--- a/spec/features/view_work_spec.rb
+++ b/spec/features/view_work_spec.rb
@@ -93,8 +93,6 @@ RSpec.feature "View a Work" do
     expect(page.find('dd.blacklight-named_subject_tesim')).to have_link    'Named Subject 1'
     expect(page.find('dd.blacklight-location_tesim')).to have_link    'Los Angeles'
     expect(page.find('dd.blacklight-photographer_tesim')).to have_link 'Poalillo, Charles'
-    expect(page.find('dd.blacklight-medium_tesim')).to have_link '1 photograph'
-    expect(page.find('dd.blacklight-dimensions_tesim')).to have_link '10 x 12.5 cm.'
     expect(page.find('dd.blacklight-language_tesim')).to have_link 'No linguistic content'
   end
 


### PR DESCRIPTION
Connected to #217

As a user, I expect a selected facet to work across all collections in a controlled manner.

The facets for "Medium" and "Dimensions" are not working against controlled fields and I do not want them offered as controlled facets.

<img width="988" alt="screen shot 2018-12-12 at 12 57 46 pm" src="https://user-images.githubusercontent.com/751697/49898430-e2eccd80-fe0d-11e8-9426-41456ffb0a35.png">

___

Changes to be committed:
+ modified:   `app/controllers/catalog_controller.rb`
+ modified:   `spec/features/view_work_spec.rb`