### PR TITLE
Format the citation modal window

### DIFF
--- a/app/assets/stylesheets/ursus.scss
+++ b/app/assets/stylesheets/ursus.scss
@@ -7,3 +7,4 @@
 @import 'ursus/logo';
 @import 'ursus/navbar';
 @import 'ursus/feedback_link';
+@import 'ursus/citation';

--- a/app/assets/stylesheets/ursus/_citation.scss
+++ b/app/assets/stylesheets/ursus/_citation.scss
@@ -1,0 +1,3 @@
+.modal-content {
+  padding: 20px;
+}

--- a/app/views/catalog/_citation.html.erb
+++ b/app/views/catalog/_citation.html.erb
@@ -1,10 +1,8 @@
 <% @documents.each do |document| %>
-  <h1 class="modal-title"><%= document_heading(document) %> - Citation</h1>
+  <h2 class="modal-title">Recommended Citation</h2>
   <hr>
   <% if document.respond_to?(:export_as_ucla_citation_txt) %>
-    <h2><%= t('blacklight.citation.ucla') %></h2>
-    <h4><%= document.send(:export_as_ucla_citation_txt).html_safe %></h4>
-    <h4>web accessed: <%= Time.now.strftime('%A %B %d, %Y -- %l:%M %p') %></h4>
+    <h4><%= document.send(:export_as_ucla_citation_txt).html_safe %> Web accessed: <%= Time.now.strftime('%A %B %d, %Y -- %l:%M %p') %></h4>
   <% end %> 
   <hr>
   <h4><a href= "<%= solr_document_path %>">BACK</a></h4>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -85,4 +85,3 @@ en:
           title_tesim: 'Title'
     tools:
       citation: 'Cite This Item'
-    citation: 'UCLA'


### PR DESCRIPTION
+ The modal window has some padding / a margin around the content.
+ Remove the "Ucla" subheading.

If we add other formats we can think what to call it, but for now it's best without.

<img width="865" alt="screen shot 2018-12-17 at 10 41 29 am" src="https://user-images.githubusercontent.com/751697/50107748-5add3e00-01e8-11e9-8064-8269a7ae414f.png">

---

Changes to be committed:
+ modified:   app/assets/stylesheets/ursus.scss
+ new file:   app/assets/stylesheets/ursus/_citation.scss
+ modified:   app/views/catalog/_citation.html.erb
+ modified:   config/locales/blacklight.en.yml