### PR TITLE
Fix accessibility issues on homepage - part 1

### DIFF
--- a/app/assets/stylesheets/ursus/_logo.scss
+++ b/app/assets/stylesheets/ursus/_logo.scss
@@ -3,7 +3,7 @@
     height: 85px;
   }
 
-  .seperator {
+  .separator {
     display:none;
   }
 }
@@ -36,7 +36,7 @@ object[type*="svg"] {
   pointer-events: none;
 }
 
-.seperator {
+.separator {
   vertical-align: middle;
   color: snow;
   margin: 0;

--- a/app/views/catalog/_image_grid.html.erb
+++ b/app/views/catalog/_image_grid.html.erb
@@ -34,7 +34,7 @@
   <div class="col-md-6">
     <div class="thumbnail no-border">
       <a href="/catalog?f%5Bsubject_sim%5D%5B%5D=Disaster">
-        <img src="<%= image_url('tombstone.jpg') %>" alt="Lights" style="border: 1px solid #ddd; width:100%"/>
+        <img src="<%= image_url('tombstone.jpg') %>" alt="A slab of the St. Francis Dam visible after its disastrous 1928 collapse" style="border: 1px solid #ddd; width:100%"/>
       </a>
       <div class="caption">
         <%= link_to_featured_work('Side view "The Tombstone", a slab of the St. Francis Dam visible after its disastrous 1928 collapse.', '21198/zz00253zhs') %>
@@ -48,7 +48,7 @@
   <div class="col-md-6">
     <div class="thumbnail no-border">
       <a href="/catalog?f%5Bsubject_sim%5D%5B%5D=Government">
-        <img src="<%= image_url('primary.jpg') %>" alt="Lights" style="border: 1px solid #ddd; width:100%"/>
+        <img src="<%= image_url('primary.jpg') %>" alt="Corridor filled with men and women tabulating ballots for California primary election in Los Angeles, Calif., 1954" style="border: 1px solid #ddd; width:100%"/>
       </a>
       <div class="caption">
         <%= link_to_featured_work('Corridor filled with men and women tabulating ballots for California primary election in Los Angeles, Calif., 1954', '21198/zz0002pzjx') %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -10,11 +10,11 @@
       <ul class="logo-links">
         <li>
           <a href="http://www.library.ucla.edu" style="display: block; z-index: 1;">
-            <object data="<%= image_url('logo2.svg') %>" type="image/svg+xml">UCLA Library</object>
+            <object data="<%= image_url('logo2.svg', alt: "UCLA Library Logo") %>" type="image/svg+xml">UCLA Library</object>
           </a>
         </li>
         <li class="logo-digital-collections">
-          <span class="seperator"> | </span>
+          <span class="separator"> | </span>
           <a href="/" style="display: block; z-index: 1;"><%= t('blacklight.short_application_name') %> </a>
         </li>
       </ul>


### PR DESCRIPTION
Connected to [206](https://github.com/UCLALibrary/amalgamated-samvera/issues/206) 

---

1. Provide the correct alt text for the images on the home page
2. Change the CSS class from: `seperator` to: `separator`
3. Add an `alt tag` to the UCLA Library Logo image
    + `<%= image_url('logo2.svg', alt: "UCLA Library Logo") %>`

---

Changes to be committed:
+ modified:   app/assets/stylesheets/ursus/_logo.scss
+ modified:   app/views/catalog/_image_grid.html.erb
+ modified:   app/views/shared/_header_navbar.html.erb