### PR TITLE
Use the californica db and solr instance in docker env

### DIFF
--- a/docker-compose-with-californica.yml
+++ b/docker-compose-with-californica.yml
@@ -1,0 +1,27 @@
+version: "3.6"
+
+services:
+  web:
+    image: uclalibrary/ursus
+    env_file:
+      - ./dotenv.sample
+    environment:
+      DATABASE_HOST: db
+      DATABASE_USERNAME: californica
+      DATABASE_PASSWORD: californica
+      IIIF_URL: http://t-u-cantaloupe01.library.ucla.edu/images
+      SOLR_URL: http://solr:8983/solr/californica
+      SOLR_TEST_URL: http://solr_test:8983/solr/californica
+    ports:
+      - "3003:3000"
+    volumes:
+      - .:/ursus
+      - bundle_dir:/usr/local/bundle
+    working_dir: /ursus
+    networks:
+      - californica_default
+volumes:
+  bundle_dir:
+networks:
+  californica_default:
+    external: true


### PR DESCRIPTION
This changes the `docker-compose.yml` to use the same
network as californica. After this is merged, you will
need to have californica running with `docker-compose`
up and then start ursus. This is so that they can
share the same solr instance and be running at the same
time.

The previous setup is left commented out in case you wanted
to run this by itself.