### PR TITLE
Add yarn to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,18 @@ FROM ruby:2.5
 RUN gem install bundler
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
-RUN apt-get update -qq && apt-get install -y mysql-client build-essential libpq-dev nodejs
+
+RUN apt-get update -qq
+
+# Add https support to apt to download yarn & newer node
+RUN apt-get install -y  apt-transport-https
+
+# Add node and yarn repos and install them along
+# along with other rails deps
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get install mysql-client build-essential libpq-dev yarn nodejs -y
 
 # Install Ruby Gems
 RUN gem install bundler
@@ -12,7 +23,6 @@ WORKDIR /californica
 COPY Gemfile /californica/Gemfile
 COPY Gemfile.lock /californica/Gemfile.lock
 RUN bundle install
-
 
 # Add californica
 COPY / /ursus

--- a/start-ursus.sh
+++ b/start-ursus.sh
@@ -3,4 +3,5 @@
 bundle check || bundle install
 
 find . -name *.pid -delete
+yarn install
 bundle exec rails s


### PR DESCRIPTION
This adds the nodesource and yarn repos to apt
in the Dockerfile and installs them.

`npm` is the default node package manager, but rails
5.1+ is designed to work with `yarn`:

https://edgeguides.rubyonrails.org/5_1_release_notes.html#yarn-support

`yarn` is faster, and DCE has experience running it in production.

We'll need to have an ansible role that installs yarn on the ursus
production machines before deploying any commits that use
`yarn` to install dependencies.

Connected to #236