### PR TITLE
docker: fix thumbnails and images

### DIFF
--- a/docker-compose-with-californica.yml
+++ b/docker-compose-with-californica.yml
@@ -10,6 +10,7 @@ services:
       DATABASE_USERNAME: californica
       DATABASE_PASSWORD: californica
       IIIF_URL: http://localhost:3000/concern/works
+      THUMBNAIL_BASE_URL: http://localhost:3000
       SOLR_URL: http://solr:8983/solr/californica
       SOLR_TEST_URL: http://solr_test:8983/solr/californica
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       - ./dotenv.sample
     environment:
       DATABASE_HOST: db
-      IIIF_URL: http://t-u-cantaloupe01.library.ucla.edu/images
+      IIIF_URL: https://californica-test.library.ucla.edu/concern/works
+      THUMBNAIL_BASE_URL: http://californica-test.library.ucla.edu
       SOLR_URL: http://solr:8983/solr/calursus
       SOLR_TEST_URL: http://solr_test:8983/solr/calursus
     ports:


### PR DESCRIPTION
- Fixes thumbnails in both standalone and 'with-californica' environments.
- Fixes Universal Viewer images in the standalone environment.
<img width="901" alt="Screen Shot 2019-03-08 at 12 23 03 PM" src="https://user-images.githubusercontent.com/73365/54053725-1042e080-419d-11e9-95e5-cf152ed5f3f4.png">
<img width="1172" alt="Screen Shot 2019-03-08 at 12 23 46 PM" src="https://user-images.githubusercontent.com/73365/54053726-1042e080-419d-11e9-9126-a68cf9515d1b.png">

closes #239 
