### PR TITLE
fix: citation bugs

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -16,11 +16,11 @@ class SolrDocument
   use_extension(Blacklight::Document::DublinCore)
 
   def export_as_ucla_citation_txt
-    image = self 
-    title = image[:title_tesim].first
-    collection = image[:publisher_tesim].first
-    resource_type = image[:resource_type_tesim].first
+    image = self
+    title = (image[:title_tesim].to_a.first or 'Untitled')
+    collection = (image[:dlcs_collection_name_ssm].to_a.first or 'No collection')
+    resource_type = (image[:resource_type_tesim].to_a.first or 'unknown type')
     imageid = image[:id]
-    "#{title}. [ #{resource_type} ]. UCLA Library Digital Collections. #{collection}. https://ursus-test.library.ucla.edu/catalog/#{imageid}"
+    "#{title}. [#{resource_type}]. UCLA Library Digital Collections. #{collection}. https://#{ENV['RAILS_HOST']}/catalog/#{imageid}"
   end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+ENV['RAILS_HOST'] ||= 'ursus-test'
+
+RSpec.describe SolrDocument do
+  let(:solr_document) do
+    described_class.new(id: 'abc123',
+                        title_tesim: ['Test record'],
+                        dlcs_collection_name_ssm: ['Collection 1'],
+                        resource_type_tesim: ['still image'])
+  end
+
+  it 'formats a citation' do
+    expect(solr_document.export_as_ucla_citation_txt).to eq("Test record. [still image]. UCLA Library Digital Collections. Collection 1. https://#{ENV['RAILS_HOST']}/catalog/abc123")
+  end
+
+  context 'when fields are missing' do
+    let(:solr_document) do
+      described_class.new(id: 'abc123',
+                          title_tesim: [],
+                          dlcs_collection_name_ssm: [],
+                          resource_type_tesim: [])
+    end
+
+    it 'uses placeholder values' do
+      expect(solr_document.export_as_ucla_citation_txt).to eq("Untitled. [unknown type]. UCLA Library Digital Collections. No collection. https://#{ENV['RAILS_HOST']}/catalog/abc123")
+    end
+  end
+end


### PR DESCRIPTION
- use placeholder text when a field is missing
- build URL off ENV['RAILS_HOST'] instead of always 'ursus-test'
- use dlcs_collection_name_ssm instead of publisher_tesim

connected to #249 
connected to #260 