### PR TITLE
Include collection-level records in search results

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -28,7 +28,7 @@ class CatalogController < ApplicationController
       qt: 'search',
       rows: 10,
       qf: 'title_tesim description_tesim creator_tesim keyword_tesim',
-      fq: '{!term f=has_model_ssim v=Work}'
+      fq: '{!terms f=has_model_ssim v=Work,Collection}'
     }
 
     config.show.partials.insert(1, :uv)

--- a/config/solr_wrapper_test.yml
+++ b/config/solr_wrapper_test.yml
@@ -1,3 +1,4 @@
+version: 7.7.1
 port: 8985
 instance_dir: tmp/solr-test
 download_dir: tmp/solr_downloads

--- a/spec/features/search_collection_results.rb
+++ b/spec/features/search_collection_results.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature "Search collection results page" do
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add(collection_attributes)
+    solr.commit
+    allow(Rails.application.config).to receive(:iiif_url).and_return('https://example.com')
+  end
+
+  let(:collection_attributes) do
+    {
+      id:'id123',
+      has_model_ssim: ['Collection'],
+      title_tesim: ['Title'],
+      description_tesim: ['Description 1'],
+      thumbnail_path_ss:'/assets/collection-a38b932554788aa578debf2319e8c4ba8a7db06b3ba57ecda1391a548a4b6e0a.png',
+      location_tesim: ['search_collection_results_spec'] # to control what displays
+    }
+  end
+
+  scenario 'displays collection: title, description,' do
+    visit '/catalog?f%5Blocation_tesim%5D%5B%5D=search_collection_results_spec'
+    expect(page).to have_content 'Title'
+    expect(page).to have_content 'Description: Description 1'
+  end
+end


### PR DESCRIPTION
Connected to #255 

Collections were not viewable when the User searched for them even though they existed.

Now they are viewable.

<img width="1221" alt="Screen Shot 2019-03-14 at 9 17 55 AM" src="https://user-images.githubusercontent.com/751697/54373905-4bc92900-463b-11e9-9625-63d4b1b1083b.png">

---

+ modified:   app/controllers/catalog_controller.rb
+ new file:   spec/features/search_collection_results.rb