### PR TITLE
Prevent searches from being saved to the database

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -23,6 +23,9 @@ class CatalogController < ApplicationController
     ## Model that maps search index responses to the blacklight response model
     # config.response_model = Blacklight::Solr::Response
 
+    # Do not store searches for anyone since they are not displayed and will fill up the database
+    config.crawler_detector = ->(req) { true }
+
     ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
     config.default_solr_params = {
       qt: 'search',

--- a/spec/features/search_crawler_spec.rb
+++ b/spec/features/search_crawler_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "Search History Page" do
+  describe "crawler search" do
+    it "doesn't remember human searches" do
+      visit root_path
+      fill_in "q", with: 'cat'
+      expect { click_button 'Search' }.not_to change { Search.count }
+    end
+
+    it "doesn't remember bot searches" do
+      page.driver.header('User-Agent', 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)')
+      visit root_path
+      fill_in "q", with: 'cat'
+      expect { click_button 'Search' }.not_to change { Search.count }
+    end
+  end
+end


### PR DESCRIPTION
Currently we run a rake task everyday that deletes the searches

**`config/schedule.rb:25`**
```
rake "blacklight:delete_old_searches[1]"
```

This PR will replace the need for this scheduled rake task.

---

branch do-not-save-searches_287
Changes to be committed:
+ modified:   app/controllers/catalog_controller.rb
+ new file:   spec/features/search_crawler_spec.rb