### PR TITLE
Prevent searches from being saved to the database by bots only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,3 +81,4 @@ gem 'jquery-rails'
 gem 'loofah', '>= 2.2.3'
 gem 'rsolr', '>= 1.0'
 gem 'solrizer'
+gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       xpath (>= 2.0, < 4.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    chronic (0.10.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -331,6 +332,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    whenever (0.10.0)
+      chronic (>= 0.6.3)
     xml-simple (1.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -383,7 +386,8 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  whenever
   xray-rails
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -23,6 +23,9 @@ class CatalogController < ApplicationController
     ## Model that maps search index responses to the blacklight response model
     # config.response_model = Blacklight::Solr::Response
 
+    # Do not store searches for anyone since they are not displayed and will fill up the database
+    config.crawler_detector = ->(req) { req.env['HTTP_USER_AGENT'] =~ /bot/ }
+
     ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
     config.default_solr_params = {
       qt: 'search',

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+# Delete blacklight saved searches
+every :day, at: '11:55pm' do
+  rake "blacklight:delete_old_searches[1]"
+end
+
+# Remove files in /tmp owned by the deploy user that are older than 7 days
+every :day, at: '3:00am' do
+  command "/usr/bin/find /tmp -type f -mtime +7 -user deploy -execdir /bin/rm -- {} \\;"
+end
+
+# Remove files in /opt/uploads owned by the deploy user that are older than 7 days
+every :day, at: '3:00am' do
+  command "/usr/bin/find /opt/uploads -type f -mtime +7 -user deploy -execdir /bin/rm -- {} \\;"
+end

--- a/spec/features/search_crawler_spec.rb
+++ b/spec/features/search_crawler_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "Search History Page" do
+  describe "crawler search" do
+    it "does remember human searches" do
+      visit root_path
+      fill_in "q", with: 'cat'
+      expect { click_button 'Search' }.to change { Search.count == 1 }
+    end
+
+    it "does not remember bot searches" do
+      page.driver.header('User-Agent', 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)')
+      visit root_path
+      fill_in "q", with: 'cat'
+      expect { click_button 'Search' }.not_to change { Search.count }
+    end
+  end
+end

--- a/spec/features/search_crawler_spec.rb
+++ b/spec/features/search_crawler_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Search History Page" do
     it "does remember human searches" do
       visit root_path
       fill_in "q", with: 'cat'
-      expect { click_button 'Search' }.to change { Search.count == 1 }
+      expect { click_button 'Search' }.to change { Search.count }.by(1)
     end
 
     it "does not remember bot searches" do


### PR DESCRIPTION
Connected to https://github.com/UCLALibrary/amalgamated-samvera/issues/287

### Only delete searches by bots.

### Adds a rake task will run everyday that deletes searches

**`config/schedule.rb:25`**
```
rake "blacklight:delete_old_searches[1]"
```

---

branch do-not-save-searches_287
Changes to be committed:
+ modified:   app/controllers/catalog_controller.rb
+ new file:   spec/features/search_crawler_spec.rb
+ new file:   config/schedule.rb