### PR TITLE
Restore UV config

### DIFF
--- a/app/views/catalog/_uv.html.erb
+++ b/app/views/catalog/_uv.html.erb
@@ -1,6 +1,6 @@
 <iframe
     class="universal-viewer-iframe"
-    src="<%= request&.base_url %>/uv/uv.html#?manifest=<%= Rails.application.config.iiif_url %>/<%= document.id %>/manifest&config=uv-config.json"
+    src="<%= request&.base_url %>/uv/uv.html#?manifest=<%= Rails.application.config.iiif_url %>/<%= document.id %>/manifest"
     width="640"
     height="480"
     allowfullscreen

--- a/config/uv/uv-config.json
+++ b/config/uv/uv-config.json
@@ -1,0 +1,14 @@
+{
+    "options": {
+        "rightPanelEnabled": false
+    },
+    "modules": {
+        "footerPanel": {
+            "options": {
+                "downloadEnabled": false,
+                "fullscreenEnabled": true,
+                "shareEnabled": false
+            }
+        }
+    }
+}

--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -1,0 +1,82 @@
+<!--
+    This is what the embed iframe src links to. It doesn't need to communicate with the parent page, only fill the available space and look for #? parameters
+-->
+
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <link rel="icon" href="favicon.ico">
+    <link rel="stylesheet" type="text/css" href="uv.css">
+    <script type="text/javascript" src="lib/offline.js"></script>
+    <script type="text/javascript" src="helpers.js"></script>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            overflow: hidden;
+        }
+    </style>
+    <script type="text/javascript">
+    window.addEventListener('uvLoaded', function(e) {
+            urlDataProvider = new UV.URLDataProvider(true);
+            var formattedLocales;
+            var locales = urlDataProvider.get('locales', '');
+            if (locales) {
+                var names = locales.split(',');
+                formattedLocales = [];
+                for (var i in names) {
+                    var nameparts = String(names[i]).split(':');
+                    formattedLocales[i] = {name: nameparts[0], label: nameparts[1]};
+                }
+
+            } else {
+                formattedLocales = [
+                    {
+                        name: 'en-GB'
+                    }
+                ]
+            }
+            uv = createUV('#uv', {
+                root: '.',
+                iiifResourceUri: urlDataProvider.get('manifest'),
+                configUri: 'uv-config.json',
+                collectionIndex: Number(urlDataProvider.get('c', 0)),
+                manifestIndex: Number(urlDataProvider.get('m', 0)),
+                sequenceIndex: Number(urlDataProvider.get('s', 0)),
+                canvasIndex: Number(urlDataProvider.get('cv', 0)),
+                rangeId: urlDataProvider.get('rid', 0),
+                rotation: Number(urlDataProvider.get('r', 0)),
+                xywh: urlDataProvider.get('xywh', ''),
+                embedded: true,
+                locales: formattedLocales
+            }, urlDataProvider);
+        }, false);
+    </script>
+</head>
+<body>
+
+<div id="uv" class="uv"></div>
+
+<script>
+    $(function() {
+        var $UV = $('#uv');
+        function resize() {
+            var windowWidth = window.innerWidth;
+            var windowHeight = window.innerHeight;
+            $UV.width(windowWidth);
+            $UV.height(windowHeight);
+        }
+        $(window).on('resize' ,function() {
+            resize();
+        });
+
+        resize();
+    });
+
+</script>
+
+<script type="text/javascript" src="uv.js"></script>
+
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   },
   "scripts": {
     "preinstall": "rm -rf ./public/uv",
-    "postinstall": "shx cp -r ./node_modules/universalviewer/uv ./public/"
+    "postinstall": "yarn run uv-install && yarn run uv-config",
+    "uv-install": "shx cp -r ./node_modules/universalviewer/uv ./public/",
+    "uv-config": "shx cp ./config/uv/uv.html ./public/uv/uv.html & shx cp ./config/uv/uv-config.json ./public/uv/"
   },
   "devDependencies": {
     "shx": "^0.3.2"


### PR DESCRIPTION
This restores the UV config that was UV
before we switched to using the UV `iframe`.

The configuration for the view is in `config/uv`.

If you want to make changes to those files, they will
be used after running `yarn install`.

Connected to UCLALibrary/amalgamated-samvera#286
Connected to UCLALibrary/ursus#278