### PR TITLE
Add old collection link to search results

### DIFF
--- a/app/assets/stylesheets/ursus.scss
+++ b/app/assets/stylesheets/ursus.scss
@@ -8,3 +8,4 @@
 @import 'ursus/navbar';
 @import 'ursus/feedback_link';
 @import 'ursus/citation';
+@import 'ursus/old_collections_link';

--- a/app/assets/stylesheets/ursus/_old_collections_link.scss
+++ b/app/assets/stylesheets/ursus/_old_collections_link.scss
@@ -1,0 +1,3 @@
+.old-collections-link {
+  margin-top: 1em;
+}

--- a/app/views/catalog/_old_collections.html.erb
+++ b/app/views/catalog/_old_collections.html.erb
@@ -1,0 +1,5 @@
+<div class="row">
+  <div class="col-md-12 old-collections-link">
+    Not finding what you're looking for? More items may be available on our <a href="http://digital2.library.ucla.edu/">original digital collections site</a>.
+  </div>
+</div>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -1,0 +1,28 @@
+<% @page_title = t('blacklight.search.page_title.title', :constraints => render_search_to_page_title(params), :application_name => application_name) %>
+
+<% content_for(:head) do -%>
+  <%= render_opensearch_response_metadata %>
+  <%= rss_feed_link_tag %>
+  <%= atom_feed_link_tag %>
+  <%= json_api_link_tag %>
+<% end %>
+
+<% content_for(:container_header) do -%>
+  <h1 class="sr-only top-content-title"><%= t('blacklight.search.header') %></h1>
+
+  <%= render 'constraints' %>
+<% end %>
+
+<%= render 'search_header' %>
+
+<h2 class="sr-only"><%= t('blacklight.search.search_results') %></h2>
+
+<%- if @response.empty? %>
+  <%= render "zero_results" %>
+<%- elsif render_grouped_response? %>
+  <%= render_grouped_document_index %>
+<%- else %>
+  <%= render_document_index %>
+<%- end %>
+
+<%= render 'results_pagination' %>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -26,3 +26,4 @@
 <%- end %>
 
 <%= render 'results_pagination' %>
+<%= render 'old_collections' %>

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -58,6 +58,16 @@ RSpec.feature "Search results page" do
     expect(page).to have_link 'Person 1'
   end
 
+  scenario 'displays the old site link with page results' do
+    visit '/catalog?f%5Blocation_tesim%5D%5B%5D=search_results_spec'
+    expect(page).to have_link 'original digital collections site'
+  end
+
+  scenario 'displays the old site link on page with no results' do
+    visit '/catalog?f%5Blocation_tesim%5D%5B%5D=zebra'
+    expect(page).to have_link 'original digital collections site'
+  end
+
   scenario 'displays line breaks between the values of certain fields' do
     visit '/catalog?f%5Blocation_tesim%5D%5B%5D=search_results_spec'
     expect(page.all('dd.blacklight-description_tesim')[1].all(:css, 'br').length).to eq 1


### PR DESCRIPTION
This commit renders a partial with a link
to the old collection site. It also includes
a SASS partial that adds some margin.

Connected to #273