### PR TITLE
Add a static about page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,6 @@ end
 gem 'dotenv-rails'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.6'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
 # Use SCSS for stylesheets
@@ -25,12 +23,9 @@ gem 'sidekiq'
 # Error reporting tool
 gem 'rollbar'
 
-# Use CoffeeScript for .coffee assets and views
-gem 'coffee-rails', '~> 4.2'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.5'
+
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,13 +92,6 @@ GEM
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
-    coffee-rails (4.2.2)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
     coveralls (0.8.22)
@@ -314,7 +307,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.0)
     sshkit (1.18.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -370,14 +362,12 @@ DEPENDENCIES
   capistrano-rails
   capistrano-sidekiq (~> 0.20.0)
   capybara (~> 2.13)
-  coffee-rails (~> 4.2)
   coveralls
   devise
   devise-guests (~> 0.6)
   dotenv-rails
   equivalent-xml
   httparty
-  jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
   loofah (>= 2.2.3)
@@ -397,7 +387,6 @@ DEPENDENCIES
   solrizer
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -1,3 +1,4 @@
 @import 'ursus/variables';
 @import 'bootstrap';
 @import 'blacklight/blacklight';
+@import 'ursus/card';

--- a/app/assets/stylesheets/ursus/_card.scss
+++ b/app/assets/stylesheets/ursus/_card.scss
@@ -1,0 +1,44 @@
+.about-page {
+  #headingOne {
+    border-top: 1px solid rgba(0, 0, 0, 0.125);
+  }
+  .card {
+    border-radius: 0;
+    border: 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+    .card-header {
+      border-radius: 0;
+      background-color: inherit;
+      border-bottom: 0;
+    }
+    button.collapsed::after {
+      content: "⌃";
+      font-weight: 800;
+      position: absolute;
+      right: 1em;
+      top: 25px;
+    }
+    button::after {
+      content: "⌄";
+      font-weight: 800;
+      position: absolute;
+      right: 1em;
+      top: 20px;
+    }
+    .card-body {
+      border-radius: 0;
+    }
+    .card-footer {
+      border-radius: 0;
+    }
+
+    .btn {
+      font-size: 1em;
+    }
+
+    .btn[aria-expanded="true"] {
+      font-weight: bold;
+      text-decoration: none;
+    }
+  }
+}

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,0 +1,4 @@
+class StaticController < ApplicationController
+  def about
+  end
+end

--- a/app/views/static/about.html.erb
+++ b/app/views/static/about.html.erb
@@ -1,0 +1,131 @@
+<div class="about-page">
+  <h1 class="mt-3 mb-3">About UCLA Digital Collections</h1>
+  <hr></hr>
+  <div class="row">
+    <div class="col-md-12 mt-4 mb-4">
+      Give us feedback at <a href="mailto:dlp@library.ucla.edu">dlp@library.ucla.edu</a>.
+    </div>
+  </div>
+  <div id="accordion">
+    <div class="card">
+      <div class="card-header" id="headingOne">
+        <h5 class="mb-0">
+          <button class="btn btn-link" data-toggle="collapse" data-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
+            The UCLA Digital Collection's Mission
+          </button>
+        </h5>
+      </div>
+
+      <div id="collapseOne" class="collapse" aria-labelledby="headingOne" data-parent="#accordion">
+        <div class="card-body">
+          The UCLA Digital Library Program (DLP) serves as the catalyst for the creation, management, and delivery of digital content in support of the UCLA Library mission and goals. The Program provides for the storage and dissemination of digital objects, including text, images, audio, and video in their various digital manifestations and combinations. The UCLA Library provides a web presence for digital collections, and provides storage, backup and digital preservation support for all digital content accepted into, or developed by, the Library.
+        </div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-header" id="headingTwo">
+        <h5 class="mb-0">
+          <button class="btn btn-link collapsed" data-toggle="collapse" data-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+            Our Services
+          </button>
+        </h5>
+      </div>
+      <div id="collapseTwo" class="collapse" aria-labelledby="headingTwo" data-parent="#accordion">
+        <div class="card-body">
+          <h3 class="mb-5">Project Planning</h3>
+          <p>
+            Digital Library Program staff can provide assistance in the planning and management of digital projects. We work with faculty and various campus organizations to create digital collections to support both teaching and research. DLP staff can provide advice during the development of grant applications. Areas of expertise include: digitization standards, digitization costs, digitization methods, metadata standards, rights management, and usability issues.</p>
+            <h3 class="mt-5 mb-5">Project Management</h3>
+            <p>One of the keys to a successful project is strong project management. Once a digital project has been approved and funded, the Digital Library Program staff can work with the project team to assure proper management. DLP staff is experienced with the hiring and training of staff, establishing workflow and procedures, quality control, and budget management.</p>
+
+            <h3 class="mt-5 mb-5">Production Partner</h3>
+            <p><a href="#">Southern Regional Library Facility</a></p>
+            <p>Digital Library Program staff can provide assistance in the planning and management of digital projects. We work with faculty and various campus organizations to create digital collections to support both teaching and research. DLP staff can provide advice during the development of grant applications. Areas of expertise include: digitization standards, digitization costs, digitization methods, metadata standards, rights management, and usability issues.
+            </p>
+            <h3 class="mt-5 mb-5">Digital Preservation and Access</h3>
+            <p>The Digital Library provides backup and digital preservation support for all its collections. Digital master files are stored in their original, uncompressed format and can be made web accessible. Backup services are provided by Library Information Technology. In addition, the Library is working with the CDL Digital Preservation Program to provide for long-term preservation of the UCLA Library's digital assets.</p>
+        </div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-header" id="headingThree">
+        <h5 class="mb-0">
+          <button class="btn btn-link collapsed" data-toggle="collapse" data-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+            UCLA Library Criteria for Digital Projects
+          </button>
+        </h5>
+      </div>
+      <div id="collapseThree" class="collapse" aria-labelledby="headingThree" data-parent="#accordion">
+        <div class="card-body">
+          <p>These criteria have been adopted by the UCLA Library as an aid in evaluating whether projects will be a good return on investment, and to help in establishing a strong rationale when requesting support from internal or external sources.</p>
+          <p>The criteria are designed to assess strengths and weaknesses and promote an analytical approach, but they do not have equal weight, and not all may be relevant to any given project.</p>
+          <ul>
+			      <li>The project provides significant support for UCLA research and instruction.
+
+			      </li><li>There are faculty and library advocates for the project.
+			      </li><li>The project's intrinsic value will ensure long-term use by a significant audience within and/or beyond the UCLA community.
+			      </li><li>The project can be completed with available funding, or has the potential to generate funding through grants, donors, or other external fund sources.
+			      </li><li>The project will strengthen or enhance an existing CDL or UCLA resource, become part of an important virtual collection, or support a national initiative such as those sponsored by Association of Research Libraries and Digital Library Federation.
+			      </li><li>UCLA has intellectual property rights to the content and can manage any required restrictions to access, or can realistically solve any rights issues.
+			      </li><li>The project falls within traditional areas of library service or moves our services in a direction consonant with the Library's strategic directions.
+			      </li><li>The project advances sustainable models for scholarly publishing.
+			      </li><li>The project brings credit to UCLA library in a manner likely to generate further digital library projects and funding.
+			      </li><li>The project has local or regional importance, and represents an effort only UCLA can initiate.
+			      </li><li>The project is reasonable, practical, and achievable.
+			      </li><li>The project saves money in the long term by eliminating the need to acquire resources, or by freeing up staff time.
+			      </li><li>The project creates or sustains a partnership that the library will find valuable for future development.
+			      </li><li>There is a compelling argument for digitizing material that is deteriorating.
+			      </li><li>The project will expand our technical infrastructure or contribute to the development of national digital library standards. </li></ul>
+        </div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-header" id="headingFour">
+        <h5 class="mb-0">
+          <button class="btn btn-link collapsed" data-toggle="collapse" data-target="#collapseFour" aria-expanded="false" aria-controls="collapseThree">
+            Copyright and Collections
+          </button>
+        </h5>
+      </div>
+      <div id="collapseFour" class="collapse" aria-labelledby="headingFour" data-parent="#accordion">
+        <div class="card-body">
+          <h3 class="mb-5">Requesting Reproductions or Permissions to Publish</h3>
+          The UCLA Digital Library does not handle requests for reproductions or permissions to publish. All requests for reproductions or permissions to publish should be directed to the item's holding repository. The name of the home repository can be found in either the item-level metadata (see an example) or in the collection record (example). In most cases, this will be the the UCLA Library Special Collections unit. Users can find information on requesting reproductions, as well as the "Request to Publish Form" on their "Special Collections Reproductions" page, or you can email spec-coll@library.ucla.edu.
+
+          <h3 class="mt-5 mb-5">Copyright</h3>
+          Materials in this collection may be protected by domestic and/or international copyright and property laws. Distribution or reproduction of copyrighted materials beyond that allowed by fair use requires the written permission of the copyright owners. To the extent that restrictions other than copyright apply, permission for distribution or reproduction from the applicable rights holder is also required. Responsibility for obtaining permission, and for any use, rests exclusively with the user.
+
+          <h3 class="mt-5 mb-5">Opt-Out Procedure</h3>
+          Your content helps us fulfill the UCLA Library mission of preserving and providing access to important cultural, political, and public health records. We urge you to let us preserve and make it available and accessible.
+
+          If your material has been included in our digital collections, you can request that we limit its public access. We ask that you consider this option very carefully. Should you decide that your content should be removed from our pages, we will continue to preserve it. For more information, contact: copyright@library.ucla.edu.
+        </div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-header" id="headingFive">
+        <h5 class="mb-0">
+          <button class="btn btn-link collapsed" data-toggle="collapse" data-target="#collapseFive" aria-expanded="false" aria-controls="collapseFive">
+            Contact
+          </button>
+        </h5>
+      </div>
+      <div id="collapseFive" class="collapse" aria-labelledby="headingFive" data-parent="#accordion">
+        <div class="card-body">
+          <h3 class="mb-5">Collection inquiries, requesting reproductions, and permissions to publish</h3>
+          <p>For inquiries related to digital collections content or to request reproductions or permissions to publish, please contact the item's holding repository.</p>
+
+          <h3 class="mt-5 mb-5">Contact information</h3>
+          <b>UCLA Library Special Collections</b>:
+          <p>Users can find information on requesting reproductions, as well as the "Request to Publish Form" on their <a href="http://www.library.ucla.edu/use/access-privileges/print-copy-scan/special-collections-reproductions">Special Collections Reproductions</a> page, or you can email <a href="mailto:spec-coll@library.ucla.edu">spec-coll@library.ucla.edu</a>.</p>
+
+          <b>Chicano Studies Research Center</b>:
+          <p>Visit the <a href="http://www.chicano.ucla.edu/library">CSRC website</a> or send an email to <a href="mailto:librarian@chicano.ucla.edu">librarian@chicano.ucla.edu</a>.</p>
+
+          <h3 class="mt-5 mb-5">Something not working?</h3>
+          <p>If you experience any technical issues, please let us know <a href="mailto:dlp@library.ucla.edu">here</a></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
+
 Rails.application.routes.draw do
+  get '/about', to: 'static#about'
+
   concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
   concern :searchable, Blacklight::Routes::Searchable.new
 

--- a/spec/controllers/static_controller_spec.rb
+++ b/spec/controllers/static_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe StaticController, type: :controller do
+
+  describe "GET #about" do
+    it "returns http success" do
+      get :about
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/features/about_spec.rb
+++ b/spec/features/about_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.feature "viewing the about page" do
+  it 'has the right header' do
+    visit('/about')
+    expect(page.html).to match(/About UCLA Digital Collections/)
+  end
+
+  it 'has an accordion element' do
+    visit('/about')
+    expect(page.html).to match(/accordion/)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,5 +63,6 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
 
+
   WebMock.allow_net_connect!
 end


### PR DESCRIPTION
This introduces an about page that
you can view at `/about` based on the
c5 design.

Connected to UCLALibrary/ursus#269