### PR TITLE
Add blacklight-gallery from GitHub master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem 'blacklight-gallery', github: 'projectblacklight/blacklight-gallery'
 gem 'dotenv-rails'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/projectblacklight/blacklight-gallery.git
+  revision: f885a5a57db751b4cdf57ebdff47d86a2fcad426
+  specs:
+    blacklight-gallery (1.0.0.alpha)
+      blacklight (~> 7.0)
+      bootstrap (~> 4.0)
+      openseadragon (>= 0.2.0)
+      rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -180,6 +190,8 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
+    openseadragon (0.5.0)
+      rails (> 3.2.0)
     orm_adapter (0.5.0)
     pkg-config (1.3.7)
     popper_js (1.14.5)
@@ -352,6 +364,7 @@ PLATFORMS
 
 DEPENDENCIES
   blacklight (~> 7.0.1)
+  blacklight-gallery!
   blacklight_range_limit (~> 7.0.0)
   bootstrap (~> 4.0)
   byebug

--- a/app/assets/javascripts/blacklight_gallery.js
+++ b/app/assets/javascripts/blacklight_gallery.js
@@ -1,0 +1,1 @@
+//= require blacklight_gallery/default

--- a/app/assets/javascripts/openseadragon.js
+++ b/app/assets/javascripts/openseadragon.js
@@ -1,0 +1,2 @@
+//= require openseadragon/openseadragon
+//= require openseadragon/rails

--- a/app/assets/stylesheets/blacklight_gallery.css.scss
+++ b/app/assets/stylesheets/blacklight_gallery.css.scss
@@ -1,0 +1,3 @@
+/*
+ *= require blacklight_gallery/default
+ */

--- a/app/assets/stylesheets/openseadragon.css
+++ b/app/assets/stylesheets/openseadragon.css
@@ -1,0 +1,3 @@
+/*
+ *= require openseadragon/openseadragon
+ */

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  helper Openseadragon::OpenseadragonHelper
   # Adds a few additional behaviors into the application controller
   include Blacklight::Controller
   layout 'blacklight'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -14,6 +14,13 @@ class CatalogController < ApplicationController
   }
 
   configure_blacklight do |config|
+    config.view.gallery.partials = [:index_header, :index]
+    config.view.masonry.partials = [:index]
+    config.view.slideshow.partials = [:index]
+
+
+    config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
+    config.show.partials.insert(1, :openseadragon)
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository
     #

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -1,5 +1,7 @@
 class SolrDocument
   include Blacklight::Solr::Document
+  include Blacklight::Gallery::OpenseadragonSolrDocument
+
   # self.unique_key = 'id'
 
   # Email uses the semantic field mappings below to generate the body of an email.

--- a/spec/features/search_collection_results.rb
+++ b/spec/features/search_collection_results.rb
@@ -25,4 +25,14 @@ RSpec.feature "Search collection results page" do
     expect(page).to have_content 'Title'
     expect(page).to have_content 'Description: Description 1'
   end
+
+  scenario 'has a gallery view button' do
+    visit '/catalog?f%5Blocation_tesim%5D%5B%5D=search_collection_results_spec'
+    expect(page).to have_selector '.view-type-gallery'
+  end
+
+  scenario 'has a list view button' do
+    visit '/catalog?f%5Blocation_tesim%5D%5B%5D=search_collection_results_spec'
+    expect(page).to have_selector '.view-type-list'
+  end
 end


### PR DESCRIPTION
This installs `blacklight-gallery` from the
current master branch, which has been updated
to work with Blacklight 7.

Connected to UCLALibrary/ursus#275