### PR TITLE
Add feedback and about links to the header

### DIFF
--- a/app/assets/stylesheets/ursus/_colors.scss
+++ b/app/assets/stylesheets/ursus/_colors.scss
@@ -1,9 +1,7 @@
 $ucla-blue: #2774ae;
 $ucla-gold: #ffd100;
-$ucla-blue: #2774ae;
-$ucla-gold: #ffd100;
 $ucla-darkest-blue: #003b5c;
-$ucla-darker-blue: #003b5c;
+$ucla-darker-blue: #005587;
 $ucla-lighter-blue: #8bb8e8;
 $ucla-lightest-blue: #c3d7ee;
 $black: #000000;

--- a/app/assets/stylesheets/ursus/_feedback_link.scss
+++ b/app/assets/stylesheets/ursus/_feedback_link.scss
@@ -1,51 +1,24 @@
 @import 'colors';
 
-.feedback-link {
-  text-transform: uppercase;
-  background-color: #dddddd;
-  border-radius: 2rem 2rem 0rem 0rem;
-  font-size: 1.2em;
-  font-weight: 500;
-  margin: 0px;
-  padding: 2rem 2.5rem 5rem 1rem;
-  position: fixed;
-  bottom: 0;
-  left: 3rem;
+.nav-item > .feedback-link {
+  background-color: $ucla-darker-blue;
+  padding: 30px 0px 21px 0px;
   a {
-    color: $ucla-blue;
+    display: inline-block;
+  }
+  .feedback-email {
+    color: $ucla-lighter-blue;
   }
 }
 
-@media screen and (max-device-width: 480px) {
-  .feedback-link {
-    text-transform: uppercase;
-    background-color: #dddddd;
-    border-radius: 2rem 2rem 0rem 0rem;
-    font-size: .75em;
-    /* font-weight: 500; */
-    margin: 0px;
-    padding: 1rem 2rem 1.2rem 1rem;
-    position: fixed;
-    bottom: 0;
-    /* left: 3rem; */
-  }
+.nav-item > .feedback-link:hover {
+  background-color: $ucla-darkest-blue;
+  color: #fff !important;
 }
 
-.alert-close {
-  color: #FFFFFF;
-  cursor: pointer;
-  font-size: 25px;
-  font-weight: normal;
-  height: 30px;
-  width: 30px;
-  line-height: 30px;
-  position: absolute;
-  right: 0px;
-  top: 10px;
-  text-align: center;
-  -webkit-transition: color 0.2s ease-in-out;
-  -moz-transition: color 0.2s ease-in-out;
-  -o-transition: color 0.2s ease-in-out;
-  transition: color 0.2s ease-in-out;
-  color: $gray;
+@media screen and (max-width: 768px) {
+  .nav-item > .feedback-link {
+    border-top: 1px solid #c3d7ee;
+    padding: 10px;
+  }
 }

--- a/app/assets/stylesheets/ursus/_navbar.scss
+++ b/app/assets/stylesheets/ursus/_navbar.scss
@@ -1,14 +1,33 @@
 @import 'colors';
 
+.navbar.navbar-expand-md.navbar-dark.bg-dark.topbar {
+  background-color: $ucla-blue !important;
+}
+
 .navbar-logo-block {
-  height: 65px !important;
+  height: 44px !important;
+  display: flex !important;
+  justify-content: center !important;
+  align-items: center !important;
+}
+
+.navbar-brand {
+  display: block;
+  margin-left: 2px !important;
+  background: transparent image_url('logo2.svg') no-repeat center !important;
+  height: inherit !important;
+  margin-right: 0 !important;
+  margin-top: 0 !important;
+  flex: unset !important;
+  overflow: unset !important;
+  width: 118px !important;
 }
 
 .navbar-text-logo {
   font-weight: 300;
   position: relative;
-  top: -0.185em;
-  left: -1.25em;
+  top: 0.25em;
+  left: 0.5em;
   color: #fff;
   font-size: 0.9em;
   letter-spacing: 0.05em;
@@ -22,34 +41,99 @@
 .navbar-pipe::after {
   content: '|';
   position: relative;
-  left: -1.25em;
-  top: -0.275em;
+  left: 0.175em;
+  top: 0.12em;
   font-weight: 300;
   color: $ucla-lighter-blue;
 }
 
-.navbar-brand {
-  margin-left: 2px !important;
-  background: transparent image_url('logo2.svg') no-repeat top left !important;
-  height: 22px !important;
-  margin-top: 25px !important;
-  flex: 0 0 250px !important;
-  overflow: unset !important;
-  width: 118px !important;
+.nav-item a {
+  color: #fff;
+  font-weight: 300;
+  font-size: 0.9em;
+  letter-spacing: 0.05em;
+  margin-right: 1em;
+}
+
+.nav-item a:hover {
+  color: $ucla-gold;
+  text-decoration: none;
+}
+
+.nav-link {
+  color: #fff !important;
+  padding-left: 1rem !important;
+  padding-right: 1rem !important;
+}
+
+.nav-link:hover {
+  color: $ucla-gold !important;
 }
 
 .navbar > .container {
   flex-wrap: nowrap;
 }
 
-.nav-link:hover {
-  color: $ucla-tertiary-yellow !important;
+.navbar-nav.nav {
+  align-items: center;
+  position: absolute;
 }
 
-.navbar-right {
-  margin-top: 10px;
-}
+@media screen and (max-width: 767px) {
+  .navbar {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
 
-.navbar-nav {
-  display: none !important;
+  .navbar > .container {
+    max-width: 100%;
+    padding-left: 15px !important;
+    padding-right: 15px !important;
+  }
+
+  .navbar-nav.nav {
+    background-color: $ucla-darker-blue;
+    display: inline-block;
+    width: 100%;
+    align-items: normal;
+    position: static;
+    margin-top: 20px;
+  }
+
+  .navbar-collapse {
+    margin-bottom: -8px;
+    min-width: 768px;
+    position: relative;
+    left: -15px;
+  }
+
+  .nav-item a {
+    margin-right: 0;
+  }
+
+  .nav-item:nth-child(1) {
+    padding: 10px 0;
+  }
+
+  .nav-item:nth-child(1):hover {
+    background-color: $ucla-darkest-blue;
+    a {
+      color: #fff !important;
+      text-decoration: none;
+    }
+  }
+
+  .navbar-toggler {
+    border-color: transparent !important;
+    outline: none !important;
+  }
+
+  .navbar-toggler.custom-toggler {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .custom-toggler .navbar-toggler-icon:hover {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='rgba(255,209,0, 1.0)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E") !important;
+  }
 }

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,11 +1,6 @@
 <footer class="footer">
   <div class="container">
 
-    <div class="feedback-link">
-      <div class="alert-close">×</div>
-      <a href="mailto:dlp@library.ucla.edu">Give Us Feedback</a>
-    </div>
-
     <div class="footer-links">
       <a href="http://digital2.library.ucla.edu/copyright.html">Copyright and Collections</a>
       <a href="http://www.library.ucla.edu/use/access-privileges/privacy-policy">Privacy Policy</a>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,18 +1,26 @@
 <nav class="navbar navbar-expand-md navbar-dark bg-dark topbar" role="navigation">
   <div class="<%= container_classes %>">
+
     <div class="navbar-logo-block">
-      <a href="https://library.ucla.edu"><div class="navbar-brand"></div></a>
+      <a href="https://library.ucla.edu" class="navbar-brand"></a>
       <span class="navbar-pipe"></span>
       <%= link_to 'Digital Collections', root_path, class: 'navbar-text-logo' %>
     </div>
-    <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
+
+    <button class="navbar-toggler custom-toggler" type="button" data-toggle="collapse" data-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
-    
+
     <div class="collapse navbar-collapse justify-content-md-end" id="user-util-collapse">
-      <%= render 'shared/user_util_links' %>
-    </div>
+    <ul class="navbar-nav nav ml-auto">
+      <li class="nav-item"><a href="/about" class="nav-link">About</a></li>
+      <li class="nav-item"><a href="mailto:dlp@library.ucla.edu" class="nav-link feedback-link">Give us feedback<br><span class="feedback-email">at dlp@library.ucla.edu</span></a></li>
+    </ul>
   </div>
+
+  </div>
+
+
 </nav>
 
 <div class="navbar-search navbar navbar-light bg-faded" role="navigation">


### PR DESCRIPTION
Added About page link and Feedback "button" to the site header.
Removed duplicate color variables in _colors.scss.

Connected to #245 

Desktop: 
<img width="1233" alt="header-links-btns-desktop" src="https://user-images.githubusercontent.com/24995224/55187055-46003700-5155-11e9-877f-ae07bf47104b.png">

Note: The mobile, and by default, the tablet implementations vary slightly from the C5 comp. The initial proposal showed a narrow (or element-wide) dropdown banner. In the actual implementation of this, the composition of the header elements looked out of balance. 

See:
<img width="399" alt="right-aligned-half-bground" src="https://user-images.githubusercontent.com/24995224/55186729-7d221880-5154-11e9-951e-ad0fccb8c336.png">

I made the design decision to instead model the default bootstrap appearance, which is to have a full-width dropdown menu.

Tablet:
<img width="733" alt="left-aligned-line-wrap-tab" src="https://user-images.githubusercontent.com/24995224/55186921-f1f55280-5154-11e9-9e75-e6c8e88c3d63.png">

Mobile:
<img width="400" alt="left-aligned-line-wrap-mob" src="https://user-images.githubusercontent.com/24995224/55186955-03d6f580-5155-11e9-9d8c-30c9e6fe46db.png">

State change on hover:
<img width="411" alt="header-links-btn-hover" src="https://user-images.githubusercontent.com/24995224/55187034-3e409280-5155-11e9-8ab5-720f6d8cb2c8.png">
