### PR TITLE
Display collection membership

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -131,7 +131,7 @@ class CatalogController < ApplicationController
     config.add_show_field ::Solrizer.solr_name('resource_type', :stored_searchable), label: 'Resource Type', link_to_facet: ::Solrizer.solr_name('resource_type', :facetable)
     config.add_show_field ::Solrizer.solr_name('format', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('identifier', :stored_searchable)
-
+    config.add_show_field ::Solrizer.solr_name('member_of_collections', :symbol), label: 'Collection', link_to_facet: ::Solrizer.solr_name('member_of_collections', :facetable)
     config.add_show_field ::Solrizer.solr_name('caption', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('dimensions', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('extent', :stored_searchable)

--- a/spec/features/view_work_spec.rb
+++ b/spec/features/view_work_spec.rb
@@ -41,6 +41,7 @@ RSpec.feature "View a Work", js: true do
       caption_tesim: ['the caption'],
       language_tesim: ['No linguistic content'],
       photographer_tesim: ['Poalillo, Charles'],
+      member_of_collections_ssim: ['Photographic Collection'],
       license_tesim: ['https://creativecommons.org/licenses/by/4.0/']
     }
   end
@@ -96,6 +97,7 @@ RSpec.feature "View a Work", js: true do
     expect(page.find('dd.blacklight-location_tesim')).to have_link 'Los Angeles'
     expect(page.find('dd.blacklight-photographer_tesim')).to have_link 'Poalillo, Charles'
     expect(page.find('dd.blacklight-language_tesim')).to have_link 'No linguistic content'
+    expect(page).to have_link 'Photographic Collection'
   end
 
   scenario 'only displays the tools we want to support' do


### PR DESCRIPTION
This adds the display for the `member_of_collections`
field to the ursus show page.

Connected to UCLALibrary/ursus#277