### PR TITLE
Facet link fix

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -80,7 +80,7 @@ class CatalogController < ApplicationController
     config.add_facet_field ::Solrizer.solr_name('location', :facetable), limit: 5
     config.add_facet_field 'year_isim', limit: 5, range: true
     config.add_facet_field ::Solrizer.solr_name('language', :facetable), limit: 5
-    config.add_facet_field ::Solrizer.solr_name('member_of_collections', :symbol), limit: 5, label: 'Collection'
+    config.add_facet_field 'member_of_collections_ssim', limit: 5, label: 'Collection'
 
     # config.add_facet_field ::Solrizer.solr_name('human_readable_type', :facetable), label: 'Type', limit: 5
     # config.add_facet_field ::Solrizer.solr_name('creator', :facetable), limit: 5

--- a/spec/features/view_work_spec.rb
+++ b/spec/features/view_work_spec.rb
@@ -98,6 +98,7 @@ RSpec.feature "View a Work", js: true do
     expect(page.find('dd.blacklight-photographer_tesim')).to have_link 'Poalillo, Charles'
     expect(page.find('dd.blacklight-language_tesim')).to have_link 'No linguistic content'
     expect(page).to have_link 'Photographic Collection'
+    expect(page.html).to match(/member_of_collections_ssim/)
   end
 
   scenario 'only displays the tools we want to support' do


### PR DESCRIPTION
This link for the facet was pointing to `member_of_collections_sim`
and not `member_of_collections_ssim`.

Connected to UCLALibrary/ursus#277