### PR TITLE
Presenters for secondary metadata terms

### DIFF
--- a/app/presenters/ursus/primary_metadata_presenter.rb
+++ b/app/presenters/ursus/primary_metadata_presenter.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module Ursus
+  class PrimaryMetadataPresenter
+    attr_reader :document, :config
+
+    def initialize(document:, config:)
+      @document = document
+      @config = config
+    end
+
+    def terms
+      keys = @config.keys.map(&:to_sym)
+      @document.reject { |doc| keys.include?(doc) }
+    end
+  end
+end

--- a/app/presenters/ursus/secondary_metadata_presenter.rb
+++ b/app/presenters/ursus/secondary_metadata_presenter.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module Ursus
+  class SecondaryMetadataPresenter
+    attr_reader :document, :config
+
+    def initialize(document:, config:)
+      @document = document
+      @config = config
+    end
+
+    def terms
+      keys = @config.keys.map(&:to_sym)
+      keys.map { |key| @document.slice(key) }
+    end
+  end
+end

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -1,0 +1,20 @@
+<% content_for(:content) do %>
+  <% if content_for? :sidebar %>
+    <section id="content" class="<%= main_content_classes %> order-last">
+      <%= yield %>
+    </section>
+
+    <section id="sidebar" class="<%= sidebar_classes %> order-first">
+      <%= content_for(:sidebar) %>
+    </section>
+  <% else %>
+    <section class="col-md-8">
+      <%= yield %>
+    </section>
+    <section class="col-md-4">
+      hey
+    </section>
+  <% end %>
+<% end %>
+
+<%= render template: "layouts/blacklight/base" %>

--- a/config/secondary_metadata.yml
+++ b/config/secondary_metadata.yml
@@ -1,0 +1,7 @@
+repository_tesim: 'Repository'
+funding_note_tesim: 'Funding Note'
+rights_country_tesim: 'Rights Country'
+rights_holder_tesim: 'Rights Holder'
+license_tesim: 'License'
+identifier_tesim: 'Identifier'
+local_identifier_tesim: 'Local Identifier'

--- a/spec/presenters/ursus/primary_metadata_presenter_spec.rb
+++ b/spec/presenters/ursus/primary_metadata_presenter_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Ursus::PrimaryMetadataPresenter do
+  let(:id) { '123' }
+  let(:pres) { described_class.new(document: doc, config: config) }
+  let(:config) { YAML.safe_load(File.open(Rails.root.join('config', 'secondary_metadata.yml'))) }
+  let(:doc) do
+    {
+      id: id,
+      has_model_ssim: ['Work'],
+      title_tesim: ['The Title of my Work'],
+      description_tesim: ['Description 1', 'Description 2'],
+      identifier_tesim: ['ark 123'],
+      subject_tesim: ['Subj 1', 'Subj 2'],
+      resource_type_tesim: ['still image'],
+      human_readable_rights_statement_tesim: ['copyrighted'],
+      genre_tesim: ['Genre 1', 'Genre 2', 'Genre 3'],
+      named_subject_tesim: ["Named Subject 1", "Named Subject 2", "Named Subject 3", "Named Subject 4"],
+      repository_tesim: ['University of California, Los Angeles. Library. Department of Special Collections'],
+      location_tesim: ['Los Angeles'],
+      publisher_tesim: ['Los Angeles Daily News'],
+      rights_country_tesim: ['US'],
+      rights_holder_tesim: ['Charles E. Young'],
+      normalized_date_tesim: ['1934-56-78'], # unique value so we can test it doesn't display
+      local_identifier_tesim: ['local id 123'],
+      date_created_tesim: ["September 17, 1947"],
+      medium_tesim: ['1 photograph'],
+      extent_tesim: ['1 photograph'],
+      dimensions_tesim: ['10 x 12.5 cm.'],
+      funding_note_tesim: ['Info about funding'],
+      geographic_coordinates_ssim: ['34.0, -118.2'],
+      caption_tesim: ['the caption'],
+      language_tesim: ['No linguistic content'],
+      photographer_tesim: ['Poalillo, Charles'],
+      member_of_collections_ssim: ['Photographic Collection'],
+      license_tesim: ['https://creativecommons.org/licenses/by/4.0/']
+    }
+  end
+
+  let(:primary) do
+    {
+      id: id,
+      has_model_ssim: ['Work'],
+      title_tesim: ['The Title of my Work'],
+      description_tesim: ['Description 1', 'Description 2'],
+      subject_tesim: ['Subj 1', 'Subj 2'],
+      resource_type_tesim: ['still image'],
+      human_readable_rights_statement_tesim: ['copyrighted'],
+      genre_tesim: ['Genre 1', 'Genre 2', 'Genre 3'],
+      named_subject_tesim: ["Named Subject 1", "Named Subject 2", "Named Subject 3", "Named Subject 4"],
+      location_tesim: ['Los Angeles'],
+      publisher_tesim: ['Los Angeles Daily News'],
+      normalized_date_tesim: ['1934-56-78'], # unique value so we can test it doesn't display
+      date_created_tesim: ["September 17, 1947"],
+      medium_tesim: ['1 photograph'],
+      extent_tesim: ['1 photograph'],
+      dimensions_tesim: ['10 x 12.5 cm.'],
+      geographic_coordinates_ssim: ['34.0, -118.2'],
+      caption_tesim: ['the caption'],
+      language_tesim: ['No linguistic content'],
+      photographer_tesim: ['Poalillo, Charles'],
+      member_of_collections_ssim: ['Photographic Collection']
+    }
+  end
+
+  context 'with a solr document containing secondary metadata' do
+    describe '#terms' do
+      it 'returns a hash that only has the primary metadata' do
+        expect(pres.terms).to eq(primary)
+      end
+    end
+  end
+end

--- a/spec/presenters/ursus/secondary_metadata_presenter_spec.rb
+++ b/spec/presenters/ursus/secondary_metadata_presenter_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Ursus::SecondaryMetadataPresenter do
+  let(:id) { '123' }
+  let(:pres) { described_class.new(document: doc, config: config) }
+  let(:config) { YAML.safe_load(File.open(Rails.root.join('config', 'secondary_metadata.yml'))) }
+  let(:doc) do
+    {
+      id: id,
+      has_model_ssim: ['Work'],
+      title_tesim: ['The Title of my Work'],
+      description_tesim: ['Description 1', 'Description 2'],
+      identifier_tesim: ['ark 123'],
+      subject_tesim: ['Subj 1', 'Subj 2'],
+      resource_type_tesim: ['still image'],
+      human_readable_rights_statement_tesim: ['copyrighted'],
+      genre_tesim: ['Genre 1', 'Genre 2', 'Genre 3'],
+      named_subject_tesim: ["Named Subject 1", "Named Subject 2", "Named Subject 3", "Named Subject 4"],
+      repository_tesim: ['University of California, Los Angeles. Library. Department of Special Collections'],
+      location_tesim: ['Los Angeles'],
+      publisher_tesim: ['Los Angeles Daily News'],
+      rights_country_tesim: ['US'],
+      rights_holder_tesim: ['Charles E. Young'],
+      normalized_date_tesim: ['1934-56-78'], # unique value so we can test it doesn't display
+      local_identifier_tesim: ['local id 123'],
+      date_created_tesim: ["September 17, 1947"],
+      medium_tesim: ['1 photograph'],
+      extent_tesim: ['1 photograph'],
+      dimensions_tesim: ['10 x 12.5 cm.'],
+      funding_note_tesim: ['Info about funding'],
+      geographic_coordinates_ssim: ['34.0, -118.2'],
+      caption_tesim: ['the caption'],
+      language_tesim: ['No linguistic content'],
+      photographer_tesim: ['Poalillo, Charles'],
+      member_of_collections_ssim: ['Photographic Collection'],
+      license_tesim: ['https://creativecommons.org/licenses/by/4.0/']
+    }
+  end
+
+  let(:secondary) do
+    [{ repository_tesim: ["University of California, Los Angeles. Library. Department of Special Collections"] },
+     { funding_note_tesim: ["Info about funding"] },
+     { rights_country_tesim: ["US"] },
+     { rights_holder_tesim: ["Charles E. Young"] },
+     { license_tesim: ['https://creativecommons.org/licenses/by/4.0/'] },
+     { identifier_tesim: ["ark 123"] },
+     { local_identifier_tesim: ["local id 123"] }]
+  end
+  context 'with a solr document containing secondary metadata' do
+    describe '#terms' do
+      it 'returns a hash that only has the secondary metadata' do
+        expect(pres.terms).to eq(secondary)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a presenter that creates a new
document hash that contains only the secondary
metadata terms.

This is controlled with a yml file in the `config`
directory. This is so that if the terms that
show up on the side need to change they can
be configured easily.

There is also a presenter that does the reverse --
it removes the secondary terms from the document
so that you can get a hash of only the primary
terms.

Connected to UCLALibrary/ursus#331