### PR TITLE
Add remote byebug

### DIFF
--- a/config/initializers/byebug.rb
+++ b/config/initializers/byebug.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+if Rails.env.development?
+  require 'byebug/core'
+  Byebug.wait_connection = true
+  Byebug.start_server 'localhost', '8989'
+end


### PR DESCRIPTION
This will add a remote byebug server that
will allow you to connect by using this command:

`bundle exec byebug -R localhost:1048`

When you are running ursus in docker, you can have this running 
in a terminal and then add `byebug` in the page to debug. 

See https://www.honeybadger.io/blog/remote-debugging-with-byebug-rails-and-pow/