### PR TITLE
Allow usage of byebug with docker-compose

### DIFF
--- a/docker-compose-with-californica.yml
+++ b/docker-compose-with-californica.yml
@@ -3,6 +3,8 @@ version: "3.6"
 services:
   web:
     image: uclalibrary/ursus
+    stdin_open: true
+    tty: true
     env_file:
       - ./dotenv.sample
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
       - .:/ursus
       - bundle_dir:/usr/local/bundle
     working_dir: /ursus
-
+    stdin_open: true
+    tty: true
   db:
     image: mysql:5.6
     volumes:


### PR DESCRIPTION
This allows you to use `byebug` as you normally would
with docker-compose. To access the prompt after putting
it in code:

run `docker ps` and get the ID of the ursus/web container.

Then run `docker attach <ID>` and press enter. You'll be
in the byebug prompt.