### PR TITLE
Implement Read More / Read Less buttons

### DIFF
--- a/app/assets/javascripts/truncate_description.js
+++ b/app/assets/javascripts/truncate_description.js
@@ -1,0 +1,21 @@
+document.addEventListener("DOMContentLoaded", function() {
+  var viewMoreButtons = document.querySelectorAll('.view-more')
+  viewMoreButtons.forEach(function(el) {
+    el.addEventListener('click', function() {
+      var description = this.previousElementSibling
+
+      if (description.style.textOverflow == 'ellipsis') {
+        el.innerHTML = 'Read Less <div class="up-arrow">&raquo;</div>'
+        description.style.overflow = 'initial'
+        description.style.whiteSpace = 'initial'
+        description.style.textOverflow = 'initial'
+      } else {
+        console.log(description.style.textOverflow)
+        el.innerHTML = 'Read More <div class="down-arrow">&raquo;</div>'
+        description.style.textOverflow = 'ellipsis'
+        description.style.overflow = 'hidden'
+        description.style.whiteSpace = 'nowrap'
+      }
+    })
+  })
+})

--- a/app/assets/stylesheets/ursus.scss
+++ b/app/assets/stylesheets/ursus.scss
@@ -15,3 +15,4 @@
 @import 'ursus/selected_facet';
 @import 'ursus/sort-pagination';
 @import 'ursus/title';
+@import 'ursus/description';

--- a/app/assets/stylesheets/ursus/_description.scss
+++ b/app/assets/stylesheets/ursus/_description.scss
@@ -1,0 +1,15 @@
+@import "../blacklight.scss";
+
+.view-more {
+  @extend a;
+}
+
+.down-arrow{
+  transform:rotate(-270deg);
+  display: inline-block;
+}
+
+.up-arrow{
+  transform:rotate(-90deg);
+  display: inline-block;
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -106,7 +106,7 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The   config.add_index_field ::Solrizer.solr_name('title', :stored_searchable), label: 'Title', itemprop: 'name', if: false
 
-    config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description', separator_options: BREAKS
+    config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description', helper_method: :render_truncated_description
     config.add_index_field ::Solrizer.solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
     # config.add_index_field ::Solrizer.solr_name('normalized_date', :stored_searchable), itemprop: 'dateCreated'
     config.add_index_field ::Solrizer.solr_name('resource_type', :stored_searchable), label: 'Resource Type', link_to_facet: ::Solrizer.solr_name('resource_type', :facetable)

--- a/app/helpers/ursus/catalog_helper.rb
+++ b/app/helpers/ursus/catalog_helper.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 module Ursus
   module CatalogHelper
@@ -15,5 +16,18 @@ module Ursus
       index_presenter(document).thumbnail.thumbnail_tag(image_options, url_options)
     end
     deprecation_deprecate render_thumbnail_tag: "Use IndexPresenter#thumbnail.thumbnail_tag"
+
+    # Render value for a document's field as a truncate description
+    # div. Arguments come from Blacklight::DocumentPresenter's
+    # get_field_values method
+    # @param [Hash] args from get_field_values
+    def render_truncated_description(args)
+      content_tag :div, class: 'truncate-description' do
+        description = args[:value][0]
+        style = 'text-overflow: ellipsis; overflow: hidden; white-space: nowrap;'
+        button = '<span class="view-more" href>Read More <div class="down-arrow">&raquo;</div></span>'
+        return "<div class='description' style='#{style}'>#{description}</div>#{button}".html_safe # rubocop:disable Rails/OutputSafety
+      end
+    end
   end
 end

--- a/spec/features/search_catalog_spec.rb
+++ b/spec/features/search_catalog_spec.rb
@@ -16,7 +16,8 @@ RSpec.feature 'Search the catalog' do
       id: '111',
       has_model_ssim: ['Work'],
       title_tesim: ['Orange Carrot'],
-      photographer_tesim: ['Bittersweet Tangerine']
+      photographer_tesim: ['Bittersweet Tangerine'],
+      description_tesim: ['Long description Long description Long description Long description Long description Long description']
     }
   end
 
@@ -122,5 +123,13 @@ RSpec.feature 'Search the catalog' do
       expect(page).to have_link('Bittersweet Tangerine')
       expect(page).to_not have_link('Buff Saffron')
     end
+  end
+
+  scenario 'verify view more links are present' do
+    visit root_path
+    # Search for something
+    fill_in 'q', with: 'carrot'
+    click_on 'search'
+    expect(page).to have_content('Read More')
   end
 end


### PR DESCRIPTION
This adds read more / read less buttons
to the description in search results.

It uses JS and the CSS ellipsis property
to do it.

Connected to UCLALibrary/ursus#328