### PR TITLE
Display secondary metadata in sidebar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development, :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
   gem 'equivalent-xml'
+  gem 'factory_bot_rails'
   gem 'rspec-collection_matchers'
   gem 'rspec-its'
   gem 'rspec-rails', '~> 3.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,11 @@ GEM
       nokogiri (>= 1.4.3)
     erubi (1.8.0)
     execjs (2.7.0)
+    factory_bot (5.0.2)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.0.2)
+      factory_bot (~> 5.0.2)
+      railties (>= 4.2.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
@@ -400,6 +405,7 @@ DEPENDENCIES
   devise-guests (~> 0.6)
   dotenv-rails
   equivalent-xml
+  factory_bot_rails
   httparty
   jquery-rails
   listen (>= 3.0.5, < 3.2)
@@ -430,4 +436,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/app/assets/stylesheets/ursus.scss
+++ b/app/assets/stylesheets/ursus.scss
@@ -17,3 +17,4 @@
 @import 'ursus/sort-pagination';
 @import 'ursus/title';
 @import 'ursus/description';
+@import 'ursus/secondary_metadata';

--- a/app/assets/stylesheets/ursus/_home.scss
+++ b/app/assets/stylesheets/ursus/_home.scss
@@ -1,3 +1,9 @@
+@import 'variables';
+
+#main-container {
+  width: $container-padding;
+}
+
 p {
   padding: 10px 0px;
 }

--- a/app/assets/stylesheets/ursus/_navbar.scss
+++ b/app/assets/stylesheets/ursus/_navbar.scss
@@ -2,6 +2,8 @@
 
 .navbar.navbar-expand-md.navbar-dark.bg-dark.topbar {
   background-color: $ucla-blue !important;
+  padding-left: 0.75em !important;
+  padding-right: 0.75em !important;
 }
 
 .navbar-logo-block {
@@ -78,6 +80,8 @@
   align-items: center;
   position: absolute;
 }
+
+
 
 @media screen and (max-width: 767px) {
   .navbar {

--- a/app/assets/stylesheets/ursus/_searchbar.scss
+++ b/app/assets/stylesheets/ursus/_searchbar.scss
@@ -1,3 +1,15 @@
-.input-group { 
-  border: 10px solid #003B5C; 
+@import 'variables';
+
+.input-group {
+  border: 10px solid #003B5C;
+}
+
+.blacklight-catalog {
+  .navbar-search {
+    padding-left: 0;
+  }
+
+  .navbar-search > .container-fluid {
+    width: $container-padding;
+  }
 }

--- a/app/assets/stylesheets/ursus/_secondary_metadata.scss
+++ b/app/assets/stylesheets/ursus/_secondary_metadata.scss
@@ -1,0 +1,8 @@
+@import 'colors';
+
+.secondary-metadata {
+  background: $ucla-lightest-blue;
+  max-width: 375px;
+  padding-left: 2.5em;
+  padding-right: 2.5em;
+}

--- a/app/assets/stylesheets/ursus/_variables.scss
+++ b/app/assets/stylesheets/ursus/_variables.scss
@@ -10,3 +10,5 @@ $link-hover-color: $ucla-link-hover;
 $navbar-inverse-link-color: snow;
 
 $dark: $ucla-secondary-blue-dark;
+
+$container-padding: 90%;

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -42,7 +42,6 @@ class CatalogController < ApplicationController
 
     config.show.partials.insert(1, :collection_banner)
     config.show.partials.insert(2, :uv)
-    config.show.partials.insert(3, :license)
 
     # solr field configuration for document/show views
     config.index.title_field = ::Solrizer.solr_name('title', :stored_searchable)

--- a/app/presenters/ursus/primary_metadata_presenter.rb
+++ b/app/presenters/ursus/primary_metadata_presenter.rb
@@ -3,14 +3,13 @@ module Ursus
   class PrimaryMetadataPresenter
     attr_reader :document, :config
 
-    def initialize(document:, config:)
+    def initialize(document:)
       @document = document
-      @config = config
+      @config = YAML.safe_load(File.open(Rails.root.join('config', 'secondary_metadata.yml')))
     end
 
     def terms
-      keys = @config.keys.map(&:to_sym)
-      @document.reject { |doc| keys.include?(doc) }
+      @document.reject { |doc| @config.keys.include?(doc) }
     end
   end
 end

--- a/app/presenters/ursus/secondary_metadata_presenter.rb
+++ b/app/presenters/ursus/secondary_metadata_presenter.rb
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 module Ursus
   class SecondaryMetadataPresenter
-    attr_reader :document, :config
+    attr_reader :document
 
-    def initialize(document:, config:)
+    def initialize(document:)
       @document = document
-      @config = config
+      @config = YAML.safe_load(File.open(Rails.root.join('config', 'secondary_metadata.yml')))
     end
 
     def terms
-      keys = @config.keys.map(&:to_sym)
-      keys.map { |key| @document.slice(key) }
+      @document.select { |doc| @config.keys.include?(doc) }.sort_by { |_d| @config.keys }
     end
   end
 end

--- a/app/views/catalog/_license.html.erb
+++ b/app/views/catalog/_license.html.erb
@@ -1,2 +1,2 @@
-<dt class="blacklight-license item-label">License:</dt>
-<dd class="blacklight-license item-value"><%= render_license %></dd>
+<dt class="blacklight-license item-label col-md-6">License:</dt>
+<dd class="blacklight-license item-value col-md-9"><%= render_license %></dd>

--- a/app/views/catalog/_primary_metadata.html.erb
+++ b/app/views/catalog/_primary_metadata.html.erb
@@ -1,0 +1,10 @@
+<% doc_presenter = show_presenter(document) %>
+<% fields_to_render = Ursus::PrimaryMetadataPresenter.new(document: doc_presenter.fields_to_render).terms %>
+<div class="primary-metadata">
+  <h3 class='item-heading'>About This Item</h3>
+  <dl class='row document-metadata'>
+    <% fields_to_render.each do |field_name, field| -%>
+      <dt class="blacklight-<%= field_name.parameterize %> col-md-6 item-label"><%= render_document_show_field_label document, field: field_name %><dd class="blacklight-<%= field_name.parameterize %> col-md-9 item-value"><%= doc_presenter.field_value field %></dd></dt>
+    <% end %>
+  </dl>
+</div>

--- a/app/views/catalog/_secondary_metadata.html.erb
+++ b/app/views/catalog/_secondary_metadata.html.erb
@@ -1,0 +1,13 @@
+<% doc_presenter = show_presenter(document) %>
+<% secondary_fields = Ursus::SecondaryMetadataPresenter.new(document: doc_presenter.fields_to_render).terms %>
+<div class="secondary-metadata">
+  <h3 class='item-heading'>
+    At the Library
+  </h3>
+  <dl class='row document-metadata'>
+    <% secondary_fields.each do |field_name, field| -%>
+      <dt class="blacklight-<%= field_name.parameterize %> col-md-6 item-label"><%= render_document_show_field_label document, field: field_name %><dd class="blacklight-<%= field_name.parameterize %> col-md-9 item-value"><%= doc_presenter.field_value field %></dd></dt>
+    <% end %>
+    <%= render 'license' %>
+  </dl>
+</div>

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -1,8 +1,10 @@
-<% doc_presenter = show_presenter(document) %>
-<%# default partial to display solr document fields in catalog show view -%>
-<h3 class='item-heading'>About This Item</h3>
-<dl class='row document-metadata'>
-  <% doc_presenter.fields_to_render.each do |field_name, field| -%>
-    <dt class="blacklight-<%= field_name.parameterize %> col-md-6 item-label"><%= render_document_show_field_label document, field: field_name %><dd class="blacklight-<%= field_name.parameterize %> col-md-9 item-value"><%= doc_presenter.field_value field %></dd></dt>
-  <% end -%>
-</dl>
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-md-7">
+      <%= render 'primary_metadata', { document: document }  %>
+    </div>
+    <div class="col-md-5">
+      <%= render 'secondary_metadata', { document: document } %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,5 @@
 <footer class="footer">
-  <div class="container">
+  <div class="<%= container_classes %>">
 
     <div class="footer-links">
       <a href="http://digital2.library.ucla.edu/copyright.html">Copyright and Collections</a>

--- a/config/initializers/layout_helper_behavior.rb
+++ b/config/initializers/layout_helper_behavior.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+# Methods added to this helper will be available to all templates in the hosting
+# application
+module Blacklight
+  # A module for useful methods used in layout configuration
+  module UrsusLayoutHelperBehavior
+    ##
+    # Classes added to a document's show content div
+    # @return [String]
+    def show_content_classes
+      "#{main_content_classes} show-document"
+    end
+
+    ##
+    # Classes added to a document's sidebar div
+    # @return [String]
+    def show_sidebar_classes
+      sidebar_classes
+    end
+
+    ##
+    # Classes used for sizing the main content of a Blacklight page
+    # @return [String]
+    def main_content_classes
+      'col-md-9'
+    end
+
+    ##
+    # Classes used for sizing the sidebar content of a Blacklight page
+    # @return [String]
+    def sidebar_classes
+      'page-sidebar col-md-3'
+    end
+
+    ##
+    # Class used for specifying main layout container classes. Can be
+    # overwritten to return 'container-fluid' for Bootstrap full-width layout
+    # @return [String]
+    def container_classes
+      'container-fluid'
+    end
+  end
+end

--- a/config/initializers/prepends.rb
+++ b/config/initializers/prepends.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 CatalogHelper.send(:prepend, Blacklight::FacetLabelButtonBehavior)
 Blacklight::ThumbnailPresenter.send(:prepend, Ursus::ThumbnailPresenter)
+Blacklight::BlacklightHelperBehavior.send(:prepend, Blacklight::UrsusLayoutHelperBehavior)

--- a/spec/features/view_work_spec.rb
+++ b/spec/features/view_work_spec.rb
@@ -49,6 +49,9 @@ RSpec.feature "View a Work", js: true do
   scenario 'displays the metadata' do
     visit solr_document_path(id)
 
+    expect(page).to have_selector('.primary-metadata')
+    expect(page).to have_selector('.secondary-metadata')
+
     expect(page).to have_content 'The Title of my Work'
     expect(page).to have_content 'Identifier: ark 123'
     expect(page).to have_content 'Description: Description 1'

--- a/spec/presenters/ursus/primary_metadata_presenter_spec.rb
+++ b/spec/presenters/ursus/primary_metadata_presenter_spec.rb
@@ -3,71 +3,45 @@ require 'rails_helper'
 
 RSpec.describe Ursus::PrimaryMetadataPresenter do
   let(:id) { '123' }
-  let(:pres) { described_class.new(document: doc, config: config) }
+  let(:pres) { described_class.new(document: doc) }
   let(:config) { YAML.safe_load(File.open(Rails.root.join('config', 'secondary_metadata.yml'))) }
   let(:doc) do
     {
-      id: id,
-      has_model_ssim: ['Work'],
-      title_tesim: ['The Title of my Work'],
-      description_tesim: ['Description 1', 'Description 2'],
-      identifier_tesim: ['ark 123'],
-      subject_tesim: ['Subj 1', 'Subj 2'],
-      resource_type_tesim: ['still image'],
-      human_readable_rights_statement_tesim: ['copyrighted'],
-      genre_tesim: ['Genre 1', 'Genre 2', 'Genre 3'],
-      named_subject_tesim: ["Named Subject 1", "Named Subject 2", "Named Subject 3", "Named Subject 4"],
-      repository_tesim: ['University of California, Los Angeles. Library. Department of Special Collections'],
-      location_tesim: ['Los Angeles'],
-      publisher_tesim: ['Los Angeles Daily News'],
-      rights_country_tesim: ['US'],
-      rights_holder_tesim: ['Charles E. Young'],
-      normalized_date_tesim: ['1934-56-78'], # unique value so we can test it doesn't display
-      local_identifier_tesim: ['local id 123'],
-      date_created_tesim: ["September 17, 1947"],
-      medium_tesim: ['1 photograph'],
-      extent_tesim: ['1 photograph'],
-      dimensions_tesim: ['10 x 12.5 cm.'],
-      funding_note_tesim: ['Info about funding'],
-      geographic_coordinates_ssim: ['34.0, -118.2'],
-      caption_tesim: ['the caption'],
-      language_tesim: ['No linguistic content'],
-      photographer_tesim: ['Poalillo, Charles'],
-      member_of_collections_ssim: ['Photographic Collection'],
-      license_tesim: ['https://creativecommons.org/licenses/by/4.0/']
-    }
-  end
-
-  let(:primary) do
-    {
-      id: id,
-      has_model_ssim: ['Work'],
-      title_tesim: ['The Title of my Work'],
-      description_tesim: ['Description 1', 'Description 2'],
-      subject_tesim: ['Subj 1', 'Subj 2'],
-      resource_type_tesim: ['still image'],
-      human_readable_rights_statement_tesim: ['copyrighted'],
-      genre_tesim: ['Genre 1', 'Genre 2', 'Genre 3'],
-      named_subject_tesim: ["Named Subject 1", "Named Subject 2", "Named Subject 3", "Named Subject 4"],
-      location_tesim: ['Los Angeles'],
-      publisher_tesim: ['Los Angeles Daily News'],
-      normalized_date_tesim: ['1934-56-78'], # unique value so we can test it doesn't display
-      date_created_tesim: ["September 17, 1947"],
-      medium_tesim: ['1 photograph'],
-      extent_tesim: ['1 photograph'],
-      dimensions_tesim: ['10 x 12.5 cm.'],
-      geographic_coordinates_ssim: ['34.0, -118.2'],
-      caption_tesim: ['the caption'],
-      language_tesim: ['No linguistic content'],
-      photographer_tesim: ['Poalillo, Charles'],
-      member_of_collections_ssim: ['Photographic Collection']
+      'id': id,
+      'has_model_ssim': ['Work'],
+      'title_tesim': ['The Title of my Work'],
+      'description_tesim': ['Description 1', 'Description 2'],
+      'identifier_tesim': ['ark 123'],
+      'subject_tesim': ['Subj 1', 'Subj 2'],
+      'resource_type_tesim': ['still image'],
+      'human_readable_rights_statement_tesim': ['copyrighted'],
+      'genre_tesim': ['Genre 1', 'Genre 2', 'Genre 3'],
+      'named_subject_tesim': ["Named Subject 1", "Named Subject 2", "Named Subject 3", "Named Subject 4"],
+      'repository_tesim': ['University of California, Los Angeles. Library. Department of Special Collections'],
+      'location_tesim': ['Los Angeles'],
+      'publisher_tesim': ['Los Angeles Daily News'],
+      'rights_country_tesim': ['US'],
+      'rights_holder_tesim': ['Charles E. Young'],
+      'normalized_date_tesim': ['1934-56-78'], # unique value so we can test it doesn't display
+      'local_identifier_tesim': ['local id 123'],
+      'date_created_tesim': ["September 17, 1947"],
+      'medium_tesim': ['1 photograph'],
+      'extent_tesim': ['1 photograph'],
+      'dimensions_tesim': ['10 x 12.5 cm.'],
+      'funding_note_tesim': ['Info about funding'],
+      'geographic_coordinates_ssim': ['34.0, -118.2'],
+      'caption_tesim': ['the caption'],
+      'language_tesim': ['No linguistic content'],
+      'photographer_tesim': ['Poalillo, Charles'],
+      'member_of_collections_ssim': ['Photographic Collection'],
+      'license_tesim': ['https://creativecommons.org/licenses/by/4.0/']
     }
   end
 
   context 'with a solr document containing secondary metadata' do
     describe '#terms' do
       it 'returns a hash that only has the primary metadata' do
-        expect(pres.terms).to eq(primary)
+        expect(pres.terms).not_to include('https://creativecommons.org/licenses/by/4.0/')
       end
     end
   end

--- a/spec/presenters/ursus/secondary_metadata_presenter_spec.rb
+++ b/spec/presenters/ursus/secondary_metadata_presenter_spec.rb
@@ -3,54 +3,16 @@ require 'rails_helper'
 
 RSpec.describe Ursus::SecondaryMetadataPresenter do
   let(:id) { '123' }
-  let(:pres) { described_class.new(document: doc, config: config) }
+  let(:pres) { described_class.new(document: doc) }
   let(:config) { YAML.safe_load(File.open(Rails.root.join('config', 'secondary_metadata.yml'))) }
   let(:doc) do
-    {
-      id: id,
-      has_model_ssim: ['Work'],
-      title_tesim: ['The Title of my Work'],
-      description_tesim: ['Description 1', 'Description 2'],
-      identifier_tesim: ['ark 123'],
-      subject_tesim: ['Subj 1', 'Subj 2'],
-      resource_type_tesim: ['still image'],
-      human_readable_rights_statement_tesim: ['copyrighted'],
-      genre_tesim: ['Genre 1', 'Genre 2', 'Genre 3'],
-      named_subject_tesim: ["Named Subject 1", "Named Subject 2", "Named Subject 3", "Named Subject 4"],
-      repository_tesim: ['University of California, Los Angeles. Library. Department of Special Collections'],
-      location_tesim: ['Los Angeles'],
-      publisher_tesim: ['Los Angeles Daily News'],
-      rights_country_tesim: ['US'],
-      rights_holder_tesim: ['Charles E. Young'],
-      normalized_date_tesim: ['1934-56-78'], # unique value so we can test it doesn't display
-      local_identifier_tesim: ['local id 123'],
-      date_created_tesim: ["September 17, 1947"],
-      medium_tesim: ['1 photograph'],
-      extent_tesim: ['1 photograph'],
-      dimensions_tesim: ['10 x 12.5 cm.'],
-      funding_note_tesim: ['Info about funding'],
-      geographic_coordinates_ssim: ['34.0, -118.2'],
-      caption_tesim: ['the caption'],
-      language_tesim: ['No linguistic content'],
-      photographer_tesim: ['Poalillo, Charles'],
-      member_of_collections_ssim: ['Photographic Collection'],
-      license_tesim: ['https://creativecommons.org/licenses/by/4.0/']
-    }
+    { "title_tesim" => { "key" => "title_tesim", "field" => "title_tesim", "label" => "Title Tesim", "if" => true, "unless" => false }, "description_tesim" => { "separator_options" => { "words_connector" => "<br/>", "two_words_connector" => "<br/>", "last_word_connector" => "<br/>" }, "key" => "description_tesim", "field" => "description_tesim", "label" => "Description Tesim", "if" => true, "unless" => false }, "subject_tesim" => { "link_to_facet" => "subject_sim", "separator_options" => { "words_connector" => "<br/>", "two_words_connector" => "<br/>", "last_word_connector" => "<br/>" }, "key" => "subject_tesim", "field" => "subject_tesim", "label" => "Subject Tesim", "if" => true, "unless" => false }, "publisher_tesim" => { "key" => "publisher_tesim", "field" => "publisher_tesim", "label" => "Publisher Tesim", "if" => true, "unless" => false }, "language_tesim" => { "link_to_facet" => "language_sim", "key" => "language_tesim", "field" => "language_tesim", "label" => "Language Tesim", "if" => true, "unless" => false }, "date_created_tesim" => { "key" => "date_created_tesim", "field" => "date_created_tesim", "label" => "Date Created Tesim", "if" => true, "unless" => false }, "human_readable_rights_statement_tesim" => { "key" => "human_readable_rights_statement_tesim", "field" => "human_readable_rights_statement_tesim", "label" => "Human Readable Rights Statement Tesim", "if" => true, "unless" => false }, "resource_type_tesim" => { "label" => "Resource Type", "link_to_facet" => "resource_type_sim", "key" => "resource_type_tesim", "field" => "resource_type_tesim", "if" => true, "unless" => false }, "identifier_tesim" => { "key" => "identifier_tesim", "field" => "identifier_tesim", "label" => "Identifier Tesim", "if" => true, "unless" => false }, "extent_tesim" => { "key" => "extent_tesim", "field" => "extent_tesim", "label" => "Extent Tesim", "if" => true, "unless" => false }, "genre_tesim" => { "link_to_facet" => "genre_sim", "separator_options" => { "words_connector" => "<br/>", "two_words_connector" => "<br/>", "last_word_connector" => "<br/>" }, "key" => "genre_tesim", "field" => "genre_tesim", "label" => "Genre Tesim", "if" => true, "unless" => false }, "location_tesim" => { "link_to_facet" => "location_sim", "key" => "location_tesim", "field" => "location_tesim", "label" => "Location Tesim", "if" => true, "unless" => false }, "local_identifier_tesim" => { "key" => "local_identifier_tesim", "field" => "local_identifier_tesim", "label" => "Local Identifier Tesim", "if" => true, "unless" => false }, "named_subject_tesim" => { "link_to_facet" => "named_subject_sim", "separator_options" => { "words_connector" => "<br/>", "two_words_connector" => "<br/>", "last_word_connector" => "<br/>" }, "key" => "named_subject_tesim", "field" => "named_subject_tesim", "label" => "Named Subject Tesim", "if" => true, "unless" => false }, "repository_tesim" => { "key" => "repository_tesim", "field" => "repository_tesim", "label" => "Repository Tesim", "if" => true, "unless" => false }, "rights_country_tesim" => { "key" => "rights_country_tesim", "field" => "rights_country_tesim", "label" => "Rights Country Tesim", "if" => true, "unless" => false }, "rights_holder_tesim" => { "key" => "rights_holder_tesim", "field" => "rights_holder_tesim", "label" => "Rights Holder Tesim", "if" => true, "unless" => false } } # rubocop:disable Metrics/LineLength
   end
 
-  let(:secondary) do
-    [{ repository_tesim: ["University of California, Los Angeles. Library. Department of Special Collections"] },
-     { funding_note_tesim: ["Info about funding"] },
-     { rights_country_tesim: ["US"] },
-     { rights_holder_tesim: ["Charles E. Young"] },
-     { license_tesim: ['https://creativecommons.org/licenses/by/4.0/'] },
-     { identifier_tesim: ["ark 123"] },
-     { local_identifier_tesim: ["local id 123"] }]
-  end
   context 'with a solr document containing secondary metadata' do
     describe '#terms' do
       it 'returns a hash that only has the secondary metadata' do
-        expect(pres.terms).to eq(secondary)
+        expect(pres.terms).not_to include('title_tesim')
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,8 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
This moves the secondary metadata into
a sidebar. It also changes the
containers to fluid width so there is enough
room on the show page to display the sidebar.

Connected to UCLALibrary/ursus#331