### PR TITLE
FIX: Accordion text alignment and toggle arrows

### DIFF
--- a/app/assets/stylesheets/ursus/_card.scss
+++ b/app/assets/stylesheets/ursus/_card.scss
@@ -6,28 +6,42 @@
     border-radius: 0;
     border: 0;
     border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+    .btn {
+      text-align: left;
+    }
     .card-header {
       border-radius: 0;
       background-color: inherit;
       border-bottom: 0;
     }
     button.collapsed::after {
-      content: "⌃";
+      content: '❯';
       font-weight: 800;
       position: absolute;
       right: 1em;
       top: 25px;
+      font-size: 16px;
+      -webkit-transform: rotate(270deg);
+      transform: rotate(270deg);
     }
     button::after {
-      content: "⌄";
+      content: '❯';
       font-weight: 800;
       position: absolute;
       right: 1em;
       top: 20px;
+      font-size: 16px;
+      -webkit-transform: rotate(90deg);
+      transform: rotate(90deg);
     }
     .card-body {
       border-radius: 0;
+      padding: 1.25rem 2rem;
     }
+    .card-body .mb-5 {
+      margin-bottom: 1rem !important;
+    }
+
     .card-footer {
       border-radius: 0;
     }
@@ -36,7 +50,7 @@
       font-size: 1em;
     }
 
-    .btn[aria-expanded="true"] {
+    .btn[aria-expanded='true'] {
       font-weight: bold;
       text-decoration: none;
     }

--- a/app/assets/stylesheets/ursus/_facets.scss
+++ b/app/assets/stylesheets/ursus/_facets.scss
@@ -1,45 +1,43 @@
 #facets {
-
   #facet-year_isim > div > div > ul {
     display: none;
   }
 
   .slider_js .slider-selection {
-    background: #C3D7EE;
+    background: #c3d7ee;
   }
 
-  .text-success, .facet-values li .selected {
-    color: #2774AE !important;
+  .text-success,
+  .facet-values li .selected {
+    color: #2774ae !important;
   }
 
-  .border-success, .facet-limit-active {
+  .border-success,
+  .facet-limit-active {
     border-color: initial !important;
-        color: #FFFF !important;
+    color: #ffff !important;
   }
 
   .facet-limit-active .card-header {
-    background-color: #2774AE !important;
-    color: #FFFF !important;
+    background-color: #2774ae !important;
+    color: #ffff !important;
   }
 
   .facet-content {
-    border-left: 1px solid #C1C1C1;
-    border-right: 1px solid #C1C1C1;
-    border-bottom: 1px solid #C1C1C1;
+    border-left: 1px solid #c1c1c1;
+    border-right: 1px solid #c1c1c1;
+    border-bottom: 1px solid #c1c1c1;
   }
 
   span.facet-label > span.selected {
-    color: #2774AE !important;
+    color: #2774ae !important;
   }
 
-
-
-  .card-header.collapse-toggle[aria-expanded="true"] {
-    background-color: #C3D7EE;
-    color: #003B5C;
-    border: 1px solid #C1C1C1;
+  .card-header.collapse-toggle[aria-expanded='true'] {
+    background-color: #c3d7ee;
+    color: #003b5c;
+    border: 1px solid #c1c1c1;
   }
-
 
   .card-header.collapse-toggle.collapsed::after {
     -webkit-transform: rotate(90deg);
@@ -68,14 +66,14 @@
       border-bottom: 1px solid rgba(0, 0, 0, 0.125);
     }
     button.collapsed::after {
-      content: "⌃";
+      content: '⌃';
       font-weight: 800;
       position: absolute;
       right: 1em;
       top: 25px;
     }
     button::after {
-      content: "⌄";
+      content: '⌄';
       font-weight: 800;
       position: absolute;
       right: 1em;
@@ -84,17 +82,20 @@
     .card-body {
       border-radius: 0;
     }
+    .card-body .mb-5 {
+      margin-bottom: 1rem !important;
+    }
     .card-footer {
       border-radius: 0;
     }
 
     .btn {
       font-size: 1em;
-      background-color: #2774AE;
+      background-color: #2774ae;
       margin-left: 5px;
     }
 
-    .btn[aria-expanded="true"] {
+    .btn[aria-expanded='true'] {
       font-weight: bold;
       text-decoration: none;
     }

--- a/app/views/static/about.html.erb
+++ b/app/views/static/about.html.erb
@@ -10,7 +10,7 @@
     <div class="card">
       <div class="card-header" id="headingOne">
         <h5 class="mb-0">
-          <button class="btn btn-link" data-toggle="collapse" data-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
+          <button class="btn btn-link collapsed" data-toggle="collapse" data-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
             The UCLA Digital Collection's Mission
           </button>
         </h5>


### PR DESCRIPTION
Aligned paragraph text with its corresponding headline.
Fixed issue of toggle arrow shrinking in size on toggle.
Fixed open toggle arrow on first accordion item.
Left aligned accordion headline texts on mobile.

<img width="1001" alt="about-page-fixes" src="https://user-images.githubusercontent.com/24995224/56395572-fb238d80-61ef-11e9-8ec5-39c4dda569ae.png">

<img width="385" alt="about-page-fixes-mobile" src="https://user-images.githubusercontent.com/24995224/56395576-fe1e7e00-61ef-11e9-85a4-5d192d02316b.png">
