### PR TITLE
Change default search operator to AND

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -35,6 +35,7 @@ class CatalogController < ApplicationController
     ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
     config.default_solr_params = {
       qt: 'search',
+      mm: '100%',
       rows: 10,
       qf: 'title_tesim description_tesim creator_tesim keyword_tesim',
       fq: '{!terms f=has_model_ssim v=Work,Collection}'
@@ -168,7 +169,8 @@ class CatalogController < ApplicationController
       title_name = ::Solrizer.solr_name('title', :stored_searchable)
       field.solr_parameters = {
         qf: search_field_service.search_fields,
-        pf: title_name.to_s
+        pf: title_name.to_s,
+        mm: '100%'
       }
     end
 

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 require 'rails_helper'
 
@@ -6,6 +7,7 @@ RSpec.feature "Search results page" do
     solr = Blacklight.default_index.connection
     solr.add(work_1_attributes)
     solr.add(work_2_attributes)
+    solr.add(work_3_attributes)
     solr.commit
     allow(Rails.application.config).to receive(:iiif_url).and_return('https://example.com')
   end
@@ -33,6 +35,20 @@ RSpec.feature "Search results page" do
       title_tesim: ['Title Two'],
       identifier_tesim: ['ark 456'],
       description_tesim: ['Description 3', 'Description 4'],
+      date_created_tesim: ["Date 1"],
+      resource_type_tesim: ['still image'],
+      photographer_tesim: ['Person 1'],
+      location_tesim: ['search_results_spec'] # to control what displays
+    }
+  end
+
+  let(:work_3_attributes) do
+    {
+      id: 'id456',
+      has_model_ssim: ['Work'],
+      title_tesim: ['Title Three'],
+      identifier_tesim: ['ark 456'],
+      description_tesim: ['Description 3', 'Description 4', 'another desc'],
       date_created_tesim: ["Date 1"],
       resource_type_tesim: ['still image'],
       photographer_tesim: ['Person 1'],
@@ -71,5 +87,11 @@ RSpec.feature "Search results page" do
   scenario 'displays line breaks between the values of certain fields' do
     visit '/catalog?f%5Blocation_tesim%5D%5B%5D=search_results_spec'
     expect(page.all('br').length).to eq 1
+  end
+
+  scenario 'uses AND not OR for search results by default' do
+    visit '/catalog?search_field=all_fields&q=Description+desc'
+    expect(page).to have_content 'Title Three'
+    expect(page).not_to have_content 'Title One'
   end
 end


### PR DESCRIPTION
This changes the default solr queries to
include `mm=100%`, (minimum match). This
means they will use AND and not OR.

See this discussion here for more details
(the discussion is about VuFind, but is
relevant because both VuFind and Blacklight use
solr):
https://vufind.org/jira/browse/VUFIND-935

Connected to URS-221