### PR TITLE
Replace sass-rails with sassc-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'rails', '~> 5.1.6'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
+gem 'sassc-rails'
 # Use Uglifier as compressor for JavaScript assets
 gem 'mysql2', '~> 0.5'
 gem 'pkg-config', '~> 1.1'
@@ -43,6 +43,7 @@ group :development, :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
   gem 'equivalent-xml'
+  gem 'factory_bot_rails'
   gem 'rspec-collection_matchers'
   gem 'rspec-its'
   gem 'rspec-rails', '~> 3.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,11 @@ GEM
       nokogiri (>= 1.4.3)
     erubi (1.8.0)
     execjs (2.7.0)
+    factory_bot (5.0.2)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.0.2)
+      factory_bot (~> 5.0.2)
+      railties (>= 4.2.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
@@ -283,17 +288,6 @@ GEM
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
     safe_yaml (1.0.5)
-    sass (3.7.3)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
     sassc (2.0.1)
       ffi (~> 1.9)
       rake
@@ -400,6 +394,7 @@ DEPENDENCIES
   devise-guests (~> 0.6)
   dotenv-rails
   equivalent-xml
+  factory_bot_rails
   httparty
   jquery-rails
   listen (>= 3.0.5, < 3.2)
@@ -414,7 +409,7 @@ DEPENDENCIES
   rspec-its
   rspec-rails (~> 3.8)
   rubocop
-  sass-rails (~> 5.0)
+  sassc-rails
   selenium-webdriver
   sidekiq
   solr_wrapper (>= 2.1.0)
@@ -430,4 +425,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
This removes the `sass-rails` gem and
replaces it with `sassc-rails`.

Connected to URS-48