### PR TITLE
STYLE: Global override of Bootstrap button colors

### DIFF
--- a/app/assets/stylesheets/ursus/_buttons.scss
+++ b/app/assets/stylesheets/ursus/_buttons.scss
@@ -1,16 +1,42 @@
 @import 'colors';
 
 .btn-primary {
-  background-color: $ucla-secondary-blue-light !important;
-  border-color: $ucla-secondary-blue-light !important;
+  background-color: $ucla-blue !important;
+  border-color: $ucla-blue !important;
 }
 
 .btn-primary:hover {
-  background-color: $ucla-tertiary-yellow !important;
-  color: $ucla-secondary-blue-dark !important;
-  border-color: $ucla-tertiary-yellow !important;
+  background-color: $ucla-darker-blue !important;
+  color: $white !important;
+  border-color: $ucla-darker-blue !important;
+}
+
+.btn-secondary {
+  background-color: $light-gray !important;
+  border-color: $light-gray !important;
+}
+
+.btn-outline-secondary {
+  border-color: $light-gray !important;
+  color: $ucla-darker-blue !important;
+}
+
+.btn-outline-secondary:hover {
+  background-color: $light-gray !important;
+  border-color: $light-gray !important;
+}
+
+.btn-outline-secondary:not(:disabled):not(.disabled).active {
+  background-color: $light-gray !important;
+  border-color: $light-gray !important;
+}
+
+.applied-filter .remove:hover {
+  background-color: #dc3545 !important;
+  border-color: #dc3545 !important;
+  color: $white !important;
 }
 
 .facet-limit {
-  margin-bottom: .2rem !important;
+  margin-bottom: 0.2rem !important;
 }

--- a/app/assets/stylesheets/ursus/_colors.scss
+++ b/app/assets/stylesheets/ursus/_colors.scss
@@ -19,3 +19,4 @@ $ucla-tertiary-orange: #ffb300;
 $ucla-link: #8237ff;
 $ucla-link-hover: #1e4b87;
 $gray: #525252;
+$light-gray: #dddddd;


### PR DESCRIPTION
Update Bootstrap button primary blue to UCLA Blue
Update Bootstrap button secondary gray to a lighter gray (#ddd)

<img width="304" alt="adjusted-btn-primary-normal" src="https://user-images.githubusercontent.com/24995224/56439050-b5bb9a80-6299-11e9-991f-176a279fed29.png">
<br>

<img width="311" alt="adjusted-btn-primary-hover" src="https://user-images.githubusercontent.com/24995224/56439067-b9e7b800-6299-11e9-8a3a-42c578950dea.png">
<br>

<img width="427" alt="adjusted-btn-secondary" src="https://user-images.githubusercontent.com/24995224/56439082-c23ff300-6299-11e9-933f-a5a29759a047.png">
