### PR TITLE
Hide the title in the UV display

### DIFF
--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -22,6 +22,9 @@
           display: inline !important;
          }
 
+         .title > span {
+            display: none;
+         }
 
     </style>
     <script type="text/javascript">


### PR DESCRIPTION
This changes the uv.html template that was created to ensure that
buttons remained visible after the
upgrade to also hide the title with
css

Connected to URS-354