### PR TITLE
Better tablet layout

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -1,5 +1,4 @@
 @import 'ursus/variables';
-@import 'bootstrap';
 @import 'blacklight/blacklight';
 @import 'ursus/card';
 @import 'ursus/facets';

--- a/app/assets/stylesheets/ursus.scss
+++ b/app/assets/stylesheets/ursus.scss
@@ -1,4 +1,5 @@
 @import 'ursus/banner';
+@import 'ursus/breakpoints';
 @import 'ursus/buttons';
 @import 'ursus/citation';
 @import 'ursus/colors';

--- a/app/assets/stylesheets/ursus/_variables.scss
+++ b/app/assets/stylesheets/ursus/_variables.scss
@@ -1,4 +1,29 @@
 @import 'colors';
+@import 'bootstrap';
+@import 'bootstrap/variables';
+
+$grid-columns:      12;
+$grid-gutter-width: 30px;
+
+$grid-breakpoints: (
+  // Extra small screen / phone
+  xs: 0,
+  // Small screen / phone
+  sm: 767px,
+  // Medium screen / tablet
+  md: 991px,
+  // Large screen / desktop
+  lg: 992px,
+  // Extra large screen / wide desktop
+  xl: 1200px
+);
+
+$container-max-widths: (
+  sm: 540px,
+  md: 720px,
+  lg: 960px,
+  xl: 1140px
+);
 
 //== Typography
 $font-family-sans-serif: 'Helvetica', 'Arial', sans-serif;

--- a/config/initializers/layout_helper_behavior.rb
+++ b/config/initializers/layout_helper_behavior.rb
@@ -22,14 +22,14 @@ module Blacklight
     # Classes used for sizing the main content of a Blacklight page
     # @return [String]
     def main_content_classes
-      'col-md-9'
+      'col-md-12 col-sm-12 col-lg-9 col-xs-12 col-xl-9'
     end
 
     ##
     # Classes used for sizing the sidebar content of a Blacklight page
     # @return [String]
     def sidebar_classes
-      'page-sidebar col-md-3'
+      'page-sidebar col-md-12 col-sm-12 col-lg-3 col-xs-12 col-xl-3'
     end
 
     ##


### PR DESCRIPTION
This changes the breakpoints so that the tablet
view uses the phone style layout. That way the
facets display correctly on smaller resolution
screens.

The layout now show up on screens 0-991px wide.

Connected to URS-312