### PR TITLE
FIX: Update item and facet terms font-color to UCLA-Blue

### DIFF
--- a/app/assets/stylesheets/ursus/_facets.scss
+++ b/app/assets/stylesheets/ursus/_facets.scss
@@ -9,7 +9,7 @@
 
   .text-success,
   .facet-values li .selected {
-    color: #2774ae !important;
+    color: $ucla-blue !important;
   }
 
   .border-success,
@@ -19,7 +19,7 @@
   }
 
   .facet-limit-active .card-header {
-    background-color: #2774ae !important;
+    background-color: $ucla-blue !important;
     color: #ffff !important;
   }
 
@@ -30,12 +30,17 @@
   }
 
   span.facet-label > span.selected {
-    color: #2774ae !important;
+    color: $ucla-blue !important;
+  }
+
+  .facet-label a,
+  .more_facets a {
+    color: $ucla-darker-blue;
   }
 
   .card-header.collapse-toggle[aria-expanded='true'] {
     background-color: #c3d7ee;
-    color: #003b5c;
+    color: $ucla-darkest-blue;
     border: 1px solid #c1c1c1;
   }
 
@@ -91,7 +96,7 @@
 
     .btn {
       font-size: 1em;
-      background-color: #2774ae;
+      background-color: $ucla-blue;
       margin-left: 5px;
     }
 

--- a/app/assets/stylesheets/ursus/_home.scss
+++ b/app/assets/stylesheets/ursus/_home.scss
@@ -7,3 +7,12 @@
 p {
   padding: 10px 0px;
 }
+
+.caption {
+  a {
+    color: $ucla-blue;
+  }
+  a:hover {
+    color: $ucla-darker-blue;
+  }
+}

--- a/app/assets/stylesheets/ursus/_navbar.scss
+++ b/app/assets/stylesheets/ursus/_navbar.scss
@@ -36,7 +36,7 @@
 }
 
 .navbar-text-logo:hover {
-  color: $ucla-gold;
+  color: $ucla-gold !important;
   text-decoration: none;
 }
 
@@ -80,8 +80,6 @@
   align-items: center;
   position: absolute;
 }
-
-
 
 @media screen and (max-width: 767px) {
   .navbar {

--- a/app/assets/stylesheets/ursus/_show.scss
+++ b/app/assets/stylesheets/ursus/_show.scss
@@ -4,13 +4,17 @@
   margin-bottom: 2px;
 }
 
-.item-value{
+.item-value {
   margin-bottom: 25px;
 }
 
 dd a {
   color: $ucla-blue;
   text-decoration: none;
+}
+
+dd a:hover {
+  color: $ucla-darker-blue;
 }
 
 .item-heading {

--- a/app/assets/stylesheets/ursus/_sort-pagination.scss
+++ b/app/assets/stylesheets/ursus/_sort-pagination.scss
@@ -26,7 +26,7 @@ a.page-link {
   padding: 0.5rem 0.75rem;
   margin-left: -1px;
   line-height: 1.25;
-  color: #1e4b87;
+  color: $ucla-darker-blue;
   background-color: #ffffff;
   border: 1px solid #dee2e6;
 }

--- a/app/assets/stylesheets/ursus/_title.scss
+++ b/app/assets/stylesheets/ursus/_title.scss
@@ -5,6 +5,12 @@
     font-weight: 400;
     font-size: 1rem;
     color: $ucla-blue;
+    a {
+      color: $ucla-blue;
+    }
+    a:hover {
+      color: $ucla-darker-blue;
+    }
   }
   dl.document-metadata {
     margin-left: 1em;

--- a/app/assets/stylesheets/ursus/_variables.scss
+++ b/app/assets/stylesheets/ursus/_variables.scss
@@ -2,20 +2,20 @@
 @import 'bootstrap';
 @import 'bootstrap/variables';
 
-$grid-columns:      12;
+$grid-columns: 12;
 $grid-gutter-width: 30px;
 
 $grid-breakpoints: (
   // Extra small screen / phone
-  xs: 0,
+    xs: 0,
   // Small screen / phone
-  sm: 767px,
+    sm: 767px,
   // Medium screen / tablet
-  md: 991px,
+    md: 991px,
   // Large screen / desktop
-  lg: 992px,
+    lg: 992px,
   // Extra large screen / wide desktop
-  xl: 1200px
+    xl: 1200px
 );
 
 $container-max-widths: (
@@ -27,9 +27,5 @@ $container-max-widths: (
 
 //== Typography
 $font-family-sans-serif: 'Helvetica', 'Arial', sans-serif;
-
-//== Links
-$link-color: $ucla-blue;
-$link-hover-color: $ucla-darker-blue;
 
 $container-padding: 90%;


### PR DESCRIPTION
Earlier commit broke the color scheme: items and facet terms on the home page and the search result page were being rendered in old brand color. Updated to current ucla-blue and to the darker-blue on hover.

<img width="513" alt="previous state" src="https://user-images.githubusercontent.com/24995224/56618842-95ad1380-65d8-11e9-9961-398e2e2e69e3.png">

<img width="542" alt="updated state" src="https://user-images.githubusercontent.com/24995224/56618864-a78eb680-65d8-11e9-9e4d-7c59130bfd78.png">
