### PR TITLE
Add "Sort by" options on search results page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -179,11 +179,10 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     # label is key, solr field is value
-    # config.add_sort_field "score desc, #{uploaded_field} desc", label: 'relevance'
-    # config.add_sort_field "#{uploaded_field} desc", label: "date uploaded \u25BC"
-    # config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
-    # config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
-    # config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
+
+    config.add_sort_field 'sort_title_isi desc, system_create_dtsi desc', label: 'Title'
+    config.add_sort_field 'sort_year_isi desc, system_create_dtsi desc', label: 'Year (earliest)'
+    config.add_sort_field 'score desc, system_create_dtsi desc', label: 'Relevance'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.


### PR DESCRIPTION
Connected to URS-145

- [x] Add a “sort by” button to allow sort by
- [x] Relevance (default)
- [x] Year (earliest)
- [x] Title
- [x] Grid and List views should both be sortable
- [x] Title sort is the default

---

+ modified:   app/controllers/catalog_controller.rb