### PR TITLE
Use human_readable_resource_type instead of resource_type

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,7 @@ Metrics/LineLength:
     - 'app/importers/rights_statement_validator.rb'
     - 'spec/features/import_and_show_work_spec.rb'
     - app/importers/actor_record_importer.rb
+    - 'app/controllers/catalog_controller.rb'
 
 Metrics/MethodLength:
   Enabled: true

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -74,7 +74,8 @@ class CatalogController < ApplicationController
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
     config.add_facet_field ::Solrizer.solr_name('subject', :facetable), limit: 5, label: 'Subjects'
-    config.add_facet_field ::Solrizer.solr_name('resource_type', :facetable), limit: 5
+    # config.add_facet_field ::Solrizer.solr_name('resource_type', :facetable), limit: 5
+    config.add_facet_field ::Solrizer.solr_name('human_readable_resource_type', :facetable), limit: 5, label: 'Resource Type'
     config.add_facet_field ::Solrizer.solr_name('genre', :facetable), limit: 5
     config.add_facet_field ::Solrizer.solr_name('named_subject', :facetable), limit: 5
     config.add_facet_field ::Solrizer.solr_name('location', :facetable), limit: 5
@@ -108,7 +109,7 @@ class CatalogController < ApplicationController
     config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description', helper_method: :render_truncated_description
     config.add_index_field ::Solrizer.solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
     # config.add_index_field ::Solrizer.solr_name('normalized_date', :stored_searchable), itemprop: 'dateCreated'
-    config.add_index_field ::Solrizer.solr_name('resource_type', :stored_searchable), label: 'Resource Type', link_to_facet: ::Solrizer.solr_name('resource_type', :facetable)
+    config.add_index_field ::Solrizer.solr_name('human_readable_resource_type', :stored_searchable), label: 'Resource Type', link_to_facet: ::Solrizer.solr_name('human_readable_resource_type', :facetable)
     config.add_index_field ::Solrizer.solr_name('photographer', :stored_searchable), label: 'Photographer', link_to_facet: ::Solrizer.solr_name('photographer', :facetable)
 
     # solr fields to be displayed in the show (single result) view
@@ -127,7 +128,7 @@ class CatalogController < ApplicationController
     config.add_show_field ::Solrizer.solr_name('date_modified', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('date_created', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('human_readable_rights_statement', :stored_searchable)
-    config.add_show_field ::Solrizer.solr_name('resource_type', :stored_searchable), label: 'Resource Type', link_to_facet: ::Solrizer.solr_name('resource_type', :facetable)
+    config.add_show_field ::Solrizer.solr_name('human_readable_resource_type', :stored_searchable), label: 'Resource Type', link_to_facet: ::Solrizer.solr_name('human_readable_resource_type', :facetable)
     config.add_show_field ::Solrizer.solr_name('format', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('identifier', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('member_of_collections', :symbol), label: 'Collection', link_to_facet: ::Solrizer.solr_name('member_of_collections', :facetable)

--- a/config/materials_metadata.yml
+++ b/config/materials_metadata.yml
@@ -1,4 +1,4 @@
-resource_type_tesim: 'Resource Type'
+human_readable_resource_type_tesim: 'Resource Type'
 format_tesim: 'Format'
 medium_tesim: 'Medium'
 genre_tesim: 'Genre'

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CatalogController, type: :controller do
 
     let(:expected_facets) do
       ['subject',
-       'resource_type',
+       'human_readable_resource_type',
        'genre',
        'named_subject',
        'location',
@@ -38,7 +38,7 @@ RSpec.describe CatalogController, type: :controller do
     let(:expected_index_fields) do
       ['description_tesim',
        'date_created_tesim',
-       'resource_type_tesim',
+       'human_readable_resource_type_tesim',
        'photographer_tesim']
     end
     it { expect(index_fields).to contain_exactly(*expected_index_fields) }

--- a/spec/features/facet_labels_spec.rb
+++ b/spec/features/facet_labels_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'The facet sidebar', :clean, js: false do
       has_model_ssim: ['Work'],
       has_model_sim: ['Work'],
       subject_sim: ['People', 'Crime'],
-      resource_type_sim: ['Photograph'],
+      human_readable_resource_type_sim: ['Photograph'],
       genre_sim: ['news photographs'],
       named_subject_sim: ['Aimee McPherson Semple'],
       year_isim: [1947],

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -12,7 +12,6 @@ RSpec.feature "Search results page" do
     allow(Rails.application.config).to receive(:iiif_url).and_return('https://example.com')
   end
 
-  # Probably smarter to use an array of objects, but I'm not familiar enough w/ rail / blacklight [AW]
   let(:work_1_attributes) do
     {
       id: 'id123',
@@ -21,7 +20,7 @@ RSpec.feature "Search results page" do
       identifier_tesim: ['ark 123'],
       description_tesim: ['Description 1', 'Description 2'],
       date_created_tesim: ["Date 1"],
-      resource_type_tesim: ['still image'],
+      human_readable_resource_type_tesim: ['still image'],
       photographer_tesim: ['Person 1', 'Person 2'],
       location_tesim: ['search_results_spec'], # to control what displays,
       thumbnail_path_ss: ["/assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png"]
@@ -36,7 +35,7 @@ RSpec.feature "Search results page" do
       identifier_tesim: ['ark 456'],
       description_tesim: ['Description 3', 'Description 4'],
       date_created_tesim: ["Date 1"],
-      resource_type_tesim: ['still image'],
+      human_readable_resource_type_tesim: ['still image'],
       photographer_tesim: ['Person 1'],
       location_tesim: ['search_results_spec'] # to control what displays
     }
@@ -50,7 +49,7 @@ RSpec.feature "Search results page" do
       identifier_tesim: ['ark 456'],
       description_tesim: ['Description 3', 'Description 4', 'another desc'],
       date_created_tesim: ["Date 1"],
-      resource_type_tesim: ['still image'],
+      human_readable_resource_type_tesim: ['still image'],
       photographer_tesim: ['Person 1'],
       location_tesim: ['search_results_spec'] # to control what displays
     }

--- a/spec/features/view_work_spec.rb
+++ b/spec/features/view_work_spec.rb
@@ -22,7 +22,8 @@ RSpec.feature "View a Work", js: true do
       description_tesim: ['Description 1', 'Description 2'],
       identifier_tesim: ['ark 123'],
       subject_tesim: ['Subj 1', 'Subj 2'],
-      resource_type_tesim: ['still image'],
+      human_readable_resource_type_tesim: ['still image'],
+      human_readable_resource_type_sim: ['still image'],
       human_readable_rights_statement_tesim: ['copyrighted'],
       genre_tesim: ['Genre 1', 'Genre 2', 'Genre 3'],
       named_subject_tesim: ["Named Subject 1", "Named Subject 2", "Named Subject 3", "Named Subject 4"],
@@ -100,12 +101,12 @@ RSpec.feature "View a Work", js: true do
 
   scenario 'displays facetable fields as links' do
     visit solr_document_path(id)
-    expect(page.find('dd.blacklight-subject_tesim')).to have_link    'Subj 1'
-    expect(page.find('dd.blacklight-subject_tesim')).to have_link    'Subj 2'
-    expect(page.find('dd.blacklight-resource_type_tesim')).to have_link    'still image'
-    expect(page.find('dd.blacklight-genre_tesim')).to have_link    'Genre 1'
-    expect(page.find('dd.blacklight-genre_tesim')).to have_link    'Genre 2'
-    expect(page.find('dd.blacklight-named_subject_tesim')).to have_link    'Named Subject 1'
+    expect(page.find('dd.blacklight-subject_tesim')).to have_link 'Subj 1'
+    expect(page.find('dd.blacklight-subject_tesim')).to have_link 'Subj 2'
+    expect(page.find('dd.blacklight-human_readable_resource_type_tesim')).to have_link 'still image'
+    expect(page.find('dd.blacklight-genre_tesim')).to have_link 'Genre 1'
+    expect(page.find('dd.blacklight-genre_tesim')).to have_link 'Genre 2'
+    expect(page.find('dd.blacklight-named_subject_tesim')).to have_link 'Named Subject 1'
     expect(page.find('dd.blacklight-location_tesim')).to have_link 'Los Angeles'
     expect(page.find('dd.blacklight-photographer_tesim')).to have_link 'Poalillo, Charles'
     expect(page.find('dd.blacklight-language_tesim')).to have_link 'No linguistic content'

--- a/spec/presenters/ursus/materials_metadata_presenter_spec.rb
+++ b/spec/presenters/ursus/materials_metadata_presenter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Ursus::MaterialsMetadataPresenter do
   context 'with a solr document containing overview metadata' do
     describe '#terms' do
       it 'returns the Resource Type Key' do
-        expect(config['resource_type_tesim'].to_s).to eq('Resource Type')
+        expect(config['human_readable_resource_type_tesim'].to_s).to eq('Resource Type')
       end
 
       it 'returns the Format Key' do


### PR DESCRIPTION
There were changes made to Californica to the resource_type so we have to make the changes in Ursus too so the display of the resouce types in the facets and the view will be correct.

Once records are imported and indexed with https://github.com/UCLALibrary/californica/pull/594,

'resource_type` will store URI values.

English labels will be stored in `human_readable_resource_type` instead.

---

+ modified:   app/controllers/catalog_controller.rb