### PR TITLE
Replace search bar on show page

### DIFF
--- a/app/assets/stylesheets/ursus/_searchbar.scss
+++ b/app/assets/stylesheets/ursus/_searchbar.scss
@@ -13,3 +13,33 @@
     width: $container-padding;
   }
 }
+
+.new-search-link{
+  padding-right: 15px;
+}
+
+.back-to-search-link{
+  margin-right: 20px;
+}
+
+.back-and-new-links-show {
+  float: right;
+  clear:left;
+  padding-top: 6px;
+}
+
+.back-and-new-container {
+  height: 46px;
+  background-color: #F5F5F5;
+  border-top: 1px solid #dee2e6;
+  margin-top: 30px;
+  margin-bottom: 30px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.previous-next {
+  padding-left: 15px;
+  padding-top: 6px;
+  color: $ucla-blue;
+}

--- a/app/assets/stylesheets/ursus/_sort-pagination.scss
+++ b/app/assets/stylesheets/ursus/_sort-pagination.scss
@@ -10,10 +10,10 @@
 }
 
 .sort-pagination,
-.pagination-search-widgets {
-  border-bottom: 0px;
-  margin-bottom: 0em;
-}
+  .pagination-search-widgets {
+    border-bottom: 0px !important;
+    margin-bottom: 0em;
+  }
 
 .rectangle {
   background-color: #f5f5f5;

--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+##
+# URL helper methods
+module Blacklight::UrlHelperBehavior
+
+  # Create a link back to the index screen, keeping the user's facet, query and paging choices intact by using session.
+  # @example
+  #   link_back_to_catalog(label: 'Back to Search')
+  #   link_back_to_catalog(label: 'Back to Search', route_set: my_engine)
+  def link_back_to_catalog(opts = { label: nil })
+    scope = opts.delete(:route_set) || self
+    query_params = search_state.reset(current_search_session.try(:query_params)).to_hash
+
+    if search_session['counter']
+      per_page = (search_session['per_page'] || blacklight_config.default_per_page).to_i
+      counter = search_session['counter'].to_i
+
+      query_params[:per_page] = per_page unless search_session['per_page'].to_i == blacklight_config.default_per_page
+      query_params[:page] = ((counter - 1) / per_page) + 1
+    end
+
+    link_url = if query_params.empty?
+                 search_action_path(only_path: true)
+               else
+                 scope.url_for(query_params)
+               end
+    label = opts.delete(:label)
+
+    if link_url =~ /bookmarks/
+      label ||= t('blacklight.back_to_bookmarks')
+    end
+
+    if controller.controller_name == 'catalog' && controller.action_name == 'show'
+      label ||= t('blacklight.back_to_search_results')
+    end
+
+    label ||= t('blacklight.back_to_search')
+
+    link_to label, link_url, opts
+  end
+end

--- a/app/views/catalog/_paginate_compact.html.erb
+++ b/app/views/catalog/_paginate_compact.html.erb
@@ -1,7 +1,7 @@
 <%# Call with a Blacklight::Solr::Response or any other kaminari-compatible collection
     to render Blacklight's compact pagination info component:
 
-        <%= render :partial => "paginate_compact", :object => @response
--%>
+<%= render :partial => "paginate_compact", :object => @response-%>
+
 <h4><b><%= @response['response'].dig(:numFound) %></b> Catalog Results</h4>
 <%= paginate paginate_compact, :page_entries_info => page_entries_info(paginate_compact), :theme => :blacklight_compact %>

--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -1,0 +1,9 @@
+<% # Using the Bootstrap Pagination class  -%>
+<div class='pagination-search-widgets'>
+  <% if @search_context[:prev] || @search_context[:next] %>
+    <div class='total-results'>
+      <%= item_page_entry_info %> results &nbsp;
+      <%= link_to_previous_document @search_context[:prev] %> &nbsp; <%= link_to_next_document @search_context[:next] %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -1,12 +1,3 @@
-<!--
-<div class='container-fluid'>
-  <div class='row'>
-    <div class='col-sm-12 col-md-7 col-lg-6 col-xl-8'>
-    </div>
-    <div class='col-sm-12 col-md-5 col-lg-6 col-xl'>
-       <%#= render 'show_tools', class: 'citation-link' %>
-    </div>
-</div>-->
 <div class='container-fluid'>
   <div class='row'>
     <div class='col-md-7'>

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,0 +1,19 @@
+<%= render 'previous_next_doc' if @search_context %>
+
+<% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name).html_safe %>
+<% content_for(:head) { render_link_rel_alternates } %>
+
+<div id="document" class="document <%= render_document_class %>" itemscope  itemtype="<%= @document.itemtype %>">
+  <div id="doc_<%= @document.id.to_s.parameterize %>">
+    <%= render_document_partials @document, blacklight_config.view_config(:show).partials %>
+  </div>
+</div>
+
+<% if @document.respond_to?(:export_as_openurl_ctx_kev) %>
+  <!--
+       // COinS, for Zotero among others.
+       // This document_partial_name(@document) business is not quite right,
+       // but has been there for a while.
+  -->
+  <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(document_partial_name(@document)) %>"></span>
+<% end %>

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,4 +1,6 @@
-<%= render 'previous_next_doc' if @search_context %>
+<% if current_search_session && !controller.controller_name == 'catalog' && !controller.action_name == 'show' %>
+  <%= render 'previous_next_doc' if @search_context %>
+<% end %>
 
 <% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name).html_safe %>
 <% content_for(:head) { render_link_rel_alternates } %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,8 +1,20 @@
-<% if current_search_session %>
-  <div id="appliedParams" class="clearfix constraints-container">
-    <%= link_to t('blacklight.search.start_over'), start_over_path, class: "catalog_startOverLink btn btn-primary" %>
+<% if current_search_session && controller.controller_name == 'catalog' && controller.action_name == 'show' %>
+
+  <div id='appliedParams' class='back-and-new-container'>
+    <div class= 'previous-next'><%= render 'previous_next_doc' if @search_context %></div>
+    <div class='back-new'>
+      <%= link_to t('blacklight.search.new_search'), start_over_path, class: 'new-search-link back-and-new-links-show' %>
+      <%= link_back_to_catalog class: 'back-and-new-links-show back-to-search-link' %>
+    </div>
+  </div>
+
+<% elsif current_search_session %>
+
+  <div id='appliedParams' class='clearfix constraints-container'>
+    <%= link_to t('blacklight.search.start_over'), start_over_path, class: 'catalog_startOverLink btn btn-primary' %>
     <%= link_back_to_catalog class: 'btn btn-outline-secondary' %>
   </div>
+
 <% end %>
 
 <%= render_document_main_content_partial %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -23,8 +23,10 @@
 
 </nav>
 
-<div class="navbar-search navbar navbar-light bg-faded" role="navigation">
-  <div class="<%= container_classes %>">
-    <%= render_search_bar  %>
+<% unless current_page?(solr_document_path) %>
+  <div class="navbar-search navbar navbar-light bg-faded" role="navigation">
+    <div class="<%= container_classes %>">
+      <%= render_search_bar  %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,30 +1,28 @@
-<nav class="navbar navbar-expand-md navbar-dark bg-dark topbar" role="navigation">
+<nav class='navbar navbar-expand-md navbar-dark bg-dark topbar' role='navigation'>
   <div class="<%= container_classes %>">
 
-    <div class="navbar-logo-block">
-      <a href="https://library.ucla.edu" class="navbar-brand"></a>
-      <span class="navbar-pipe"></span>
+    <div class='navbar-logo-block'>
+      <a href='https://library.ucla.edu' class='navbar-brand'></a>
+      <span class='navbar-pipe'></span>
       <%= link_to 'Digital Collections', root_path, class: 'navbar-text-logo' %>
     </div>
 
-    <button class="navbar-toggler custom-toggler" type="button" data-toggle="collapse" data-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
+    <button class='navbar-toggler custom-toggler' type='button' data-toggle='collapse' data-target='#user-util-collapse' aria-controls='user-util-collapse' aria-expanded='false' aria-label='Toggle navigation'>
+      <span class='navbar-toggler-icon'></span>
     </button>
 
-    <div class="collapse navbar-collapse justify-content-md-end" id="user-util-collapse">
-    <ul class="navbar-nav nav ml-auto">
-      <li class="nav-item"><a href="/about" class="nav-link">About</a></li>
-      <li class="nav-item"><a href="mailto:dlp@library.ucla.edu" class="nav-link feedback-link">Give us feedback<br><span class="feedback-email">at dlp@library.ucla.edu</span></a></li>
+    <div class='collapse navbar-collapse justify-content-md-end' id='user-util-collapse'>
+    <ul class='navbar-nav nav ml-auto'>
+      <li class='nav-item'><a href='/about' class='nav-link'>About</a></li>
+      <li class='nav-item'><a href='mailto:dlp@library.ucla.edu' class='nav-link feedback-link'>Give us feedback<br><span class='feedback-email'>at dlp@library.ucla.edu</span></a></li>
     </ul>
   </div>
 
   </div>
-
-
 </nav>
 
-<% unless current_page?(solr_document_path) %>
-  <div class="navbar-search navbar navbar-light bg-faded" role="navigation">
+<% unless controller.controller_name == 'catalog' && controller.action_name == 'show' %>
+  <div class='navbar-search navbar navbar-light bg-faded' role='navigation'>
     <div class="<%= container_classes %>">
       <%= render_search_bar  %>
     </div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -6,14 +6,15 @@ en:
       facets:
         title: 'Refine your search'
       zero_results:
-        title: "No results found."
-        modify_search: ""
-        use_fewer_keywords: "Remove some filters or terms from your query and search again."
-        search_fields: "you searched by %{search_fields}"
-        search_everything: "try searching everything"
+        title: 'No results found.'
+        modify_search: ''
+        use_fewer_keywords: 'Remove some filters or terms from your query and search again.'
+        search_fields: 'you searched by %{search_fields}'
+        search_everything: 'try searching everything'
       form:
         search:
           placeholder: 'Search UCLA Library Digital Collections'
+      new_search: 'New Search'
       fields:
         facet:
           date_created_tesim: 'Date Created'
@@ -95,3 +96,4 @@ en:
           title_tesim: 'Title'
     tools:
       citation: 'Cite This Item'
+    back_to_search_results: 'Back to Search Results'


### PR DESCRIPTION
Connected to URS-357
<img width="1240" alt="Screen Shot 2019-05-07 at 2 43 28 PM" src="https://user-images.githubusercontent.com/751697/57336300-47b90500-70da-11e9-9404-ab89a8267fe1.png">

ACCEPTANCE
- [x] Replace with a search "nav menu"
- [x] height: 46px;
- [x] width: 1150px;
- [x] background-color: #F5F5F5;
- [x] Display search result count and item count "# of # results"
- [x] Display "Previous" and "Next" (with icons), "Back to Search" and "New Search" text
- [x] color: #005587;
- [x] font-size: 14px;

---

+ modified:   app/assets/stylesheets/ursus/_searchbar.scss
+ modified:   app/assets/stylesheets/ursus/_sort-pagination.scss
+ modified:   app/views/catalog/_paginate_compact.html.erb
+ modified:   app/views/catalog/_show.html.erb
+ modified:   app/views/catalog/_show_main_content.html.erb
+ modified:   app/views/catalog/show.html.erb
+ modified:   app/views/shared/_header_navbar.html.erb
+ modified:   config/locales/blacklight.en.yml
+ new file:   app/helpers/blacklight/url_helper_behavior.rb
+ new file:   app/views/catalog/_previous_next_doc.html.erb