### PR TITLE
Constrain site width to prevent expanding page elements

### DIFF
--- a/app/assets/stylesheets/ursus/_variables.scss
+++ b/app/assets/stylesheets/ursus/_variables.scss
@@ -1,4 +1,5 @@
 @import 'colors';
+@import 'bootstrap/functions';
 @import 'bootstrap';
 @import 'bootstrap/variables';
 
@@ -6,10 +7,11 @@ $grid-columns: 12;
 $grid-gutter-width: 30px;
 
 $grid-breakpoints: (
+  xxs: 0,
   // Extra small screen / phone
-    xs: 0,
+    xs: 767px,
   // Small screen / phone
-    sm: 767px,
+    sm: 991px,
   // Medium screen / tablet
     md: 991px,
   // Large screen / desktop
@@ -19,13 +21,16 @@ $grid-breakpoints: (
 );
 
 $container-max-widths: (
-  sm: 540px,
-  md: 720px,
-  lg: 960px,
-  xl: 1140px
+  xs: 767px,
+  sm: 991px,
+  md: 991px,
+  lg: 992px,
+  xl: 1200px
 );
 
 //== Typography
 $font-family-sans-serif: 'Helvetica', 'Arial', sans-serif;
 
-$container-padding: 90%;
+$container-padding: 95%;
+
+@import 'bootstrap';

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,5 @@
 <footer class="footer">
-  <div class="<%= container_classes %>">
+  <div class="container-fluid">
 
     <div class="footer-links">
       <a href="http://digital2.library.ucla.edu/copyright.html">Copyright and Collections</a>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-md navbar-dark bg-dark topbar" role="navigation">
-  <div class="<%= container_classes %>">
+  <div class="container-fluid">
 
     <div class="navbar-logo-block">
       <a href="https://library.ucla.edu" class="navbar-brand"></a>

--- a/config/initializers/layout_helper_behavior.rb
+++ b/config/initializers/layout_helper_behavior.rb
@@ -37,7 +37,7 @@ module Blacklight
     # overwritten to return 'container-fluid' for Bootstrap full-width layout
     # @return [String]
     def container_classes
-      'container-fluid'
+      'container'
     end
   end
 end


### PR DESCRIPTION
Changed container_classes method to call bootstrap
"container" class instead of "container-fluid"

In header and footer, manually added "container-fluid" class

Changed site max-width to 1200px

Update variables file with bootstrap function import