### PR TITLE
Add content to UCLA Library logo link

### DIFF
--- a/app/assets/stylesheets/ursus/_navbar.scss
+++ b/app/assets/stylesheets/ursus/_navbar.scss
@@ -23,6 +23,9 @@
   flex: unset !important;
   overflow: unset !important;
   width: 118px !important;
+  .logo-name {
+    display: none;
+  }
 }
 
 .navbar-text-logo {

--- a/app/assets/stylesheets/ursus/_variables.scss
+++ b/app/assets/stylesheets/ursus/_variables.scss
@@ -11,7 +11,7 @@ $grid-breakpoints: (
   // Extra small screen / phone
     xs: 767px,
   // Small screen / phone
-    sm: 991px,
+    sm: 990px,
   // Medium screen / tablet
     md: 991px,
   // Large screen / desktop
@@ -22,7 +22,7 @@ $grid-breakpoints: (
 
 $container-max-widths: (
   xs: 767px,
-  sm: 991px,
+  sm: 990px,
   md: 991px,
   lg: 992px,
   xl: 1200px

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -2,7 +2,7 @@
   <div class="container-fluid">
 
     <div class="navbar-logo-block">
-      <a href="https://library.ucla.edu" class="navbar-brand"></a>
+      <a href="https://library.ucla.edu" class="navbar-brand"><span class="logo-name">UCLA Library Logo</span></a>
       <span class="navbar-pipe"></span>
       <%= link_to 'Digital Collections', root_path, class: 'navbar-text-logo' %>
     </div>


### PR DESCRIPTION
Add content/text to the anchor element for UCLA Library logo.
Fixes pa11y error.

Adjust values of bootstrap max-width variables 
to resolve rspec alerts.