### PR TITLE
Pa11y fixes and global color update to site's linked texts

### DIFF
--- a/app/assets/stylesheets/blacklight.scss
+++ b/app/assets/stylesheets/blacklight.scss
@@ -1,4 +1,4 @@
 @import 'ursus/variables';
 @import 'blacklight/blacklight';
-@import 'ursus/card';
+@import 'ursus/about';
 @import 'ursus/facets';

--- a/app/assets/stylesheets/ursus/_about.scss
+++ b/app/assets/stylesheets/ursus/_about.scss
@@ -50,6 +50,10 @@
       font-size: 1em;
     }
 
+    .btn-link {
+      color: $ucla-darker-blue;
+    }
+
     .btn[aria-expanded='true'] {
       font-weight: bold;
       text-decoration: none;

--- a/app/assets/stylesheets/ursus/_citation.scss
+++ b/app/assets/stylesheets/ursus/_citation.scss
@@ -10,13 +10,6 @@
 .citation-link {
   font-size: 14px;
   letter-spacing: 1px;
-  a {
-    color: $ucla-blue !important;
-  }
-}
-
-.citation-link a:hover {
-  color: $ucla-darker-blue !important;
 }
 
 .link-and-icon {

--- a/app/assets/stylesheets/ursus/_colors.scss
+++ b/app/assets/stylesheets/ursus/_colors.scss
@@ -14,5 +14,5 @@ $ucla-tertiary-cyan: #00ffff;
 $ucla-tertiary-gray: #666666;
 $ucla-tertiary-orange: #ffb300;
 $gray: #525252;
-$border-outline-gray: #ddd;
+// $border-outline-gray: #ddd;
 $light-gray: #dddddd;

--- a/app/assets/stylesheets/ursus/_facets.scss
+++ b/app/assets/stylesheets/ursus/_facets.scss
@@ -15,12 +15,12 @@
   .border-success,
   .facet-limit-active {
     border-color: initial !important;
-    color: #ffff !important;
+    color: $white !important;
   }
 
   .facet-limit-active .card-header {
     background-color: $ucla-blue !important;
-    color: #ffff !important;
+    color: $white !important;
   }
 
   .facet-content {

--- a/app/assets/stylesheets/ursus/_feedback_link.scss
+++ b/app/assets/stylesheets/ursus/_feedback_link.scss
@@ -7,7 +7,7 @@
     display: inline-block;
   }
   .feedback-email {
-    color: $ucla-lighter-blue;
+    color: $ucla-lightest-blue;
   }
 }
 

--- a/app/assets/stylesheets/ursus/_feedback_link.scss
+++ b/app/assets/stylesheets/ursus/_feedback_link.scss
@@ -13,7 +13,7 @@
 
 .nav-item > .feedback-link:hover {
   background-color: $ucla-darkest-blue;
-  color: #fff !important;
+  color: $white !important;
 }
 
 @media screen and (max-width: 768px) {

--- a/app/assets/stylesheets/ursus/_footer.scss
+++ b/app/assets/stylesheets/ursus/_footer.scss
@@ -3,7 +3,7 @@
 .footer {
   margin-top: 2.5rem;
   background-color: $ucla-blue;
-  color: #ffffff;
+  color: $white;
   line-height: 1.5em;
 
   .footer-links {
@@ -14,19 +14,19 @@
     padding-bottom: 0.5em;
 
     a {
-      color: #ffffff;
+      color: $white !important;
       display: inline-block;
       padding: 0px 8px;
     }
 
     a:hover {
-      color: $ucla-gold;
+      color: $ucla-gold !important;
       text-decoration: underline;
     }
   }
 
   .footer-version {
-    color: #ffffff;
+    color: $white;
     font-size: 0.65em;
     text-align: center;
     padding-bottom: 1.5em;

--- a/app/assets/stylesheets/ursus/_gallery.scss
+++ b/app/assets/stylesheets/ursus/_gallery.scss
@@ -2,7 +2,7 @@
 
 #documents.row.gallery {
   .gallery-box {
-    outline: 1px solid #ddd;
+    outline: 1px solid $light-gray;
     padding: 5px;
     height: 200px;
     margin-bottom: 15px;
@@ -10,17 +10,17 @@
 
   .gallery-text {
     margin: 15px;
-   }
+  }
 
   .document-metadata dt {
     font-weight: normal;
     color: #808080;
-    }
+  }
 
   .document {
     .thumbnail {
       align: center;
-      outline: 1px solid #ddd;
+      outline: 1px solid $light-gray;
       margin: 5px;
       align: center;
     }
@@ -33,7 +33,7 @@
       color: $ucla-blue;
       padding-left: 1em;
       margin-bottom: 1.5em;
-      margin-right: .5em;
+      margin-right: 0.5em;
     }
   }
 }
@@ -41,7 +41,7 @@
 @media screen and (max-width: 1199px) {
   #documents.row.gallery {
     .gallery-box {
-      outline: 1px solid #ddd;
+      outline: 1px solid $light-gray;
       padding: 5px;
       height: 200px;
       margin-bottom: 10px;
@@ -55,7 +55,7 @@
 @media screen and (max-width: 450px) {
   #documents.row.gallery {
     .gallery-box {
-      outline: 1px solid #ddd;
+      outline: 1px solid $light-gray;
       padding: 5px;
       height: 200px;
       margin-bottom: 10px;
@@ -66,7 +66,7 @@
     .document {
       .thumbnail {
         align: center;
-        outline: 1px solid #ddd;
+        outline: 1px solid $light-gray;
         margin: 5px;
         align: center;
       }
@@ -79,7 +79,7 @@
         color: $ucla-blue;
         padding-left: 1em;
         margin-bottom: 1.5em;
-        margin-right: .5em;
+        margin-right: 0.5em;
       }
     }
   }

--- a/app/assets/stylesheets/ursus/_home.scss
+++ b/app/assets/stylesheets/ursus/_home.scss
@@ -7,12 +7,3 @@
 p {
   padding: 10px 0px;
 }
-
-.caption {
-  a {
-    color: $ucla-blue;
-  }
-  a:hover {
-    color: $ucla-darker-blue;
-  }
-}

--- a/app/assets/stylesheets/ursus/_navbar.scss
+++ b/app/assets/stylesheets/ursus/_navbar.scss
@@ -33,9 +33,13 @@
   position: relative;
   top: 0.25em;
   left: 0.5em;
-  color: #fff;
+  color: $white !important;
   font-size: 0.9em;
   letter-spacing: 0.05em;
+}
+
+.navbar-text-logo:visited {
+  color: $white !important;
 }
 
 .navbar-text-logo:hover {
@@ -53,26 +57,25 @@
 }
 
 .nav-item a {
-  color: #fff;
+  color: $white !important;
   font-weight: 300;
   font-size: 0.9em;
   letter-spacing: 0.05em;
   margin-right: 1em;
 }
 
+.nav-item a:visited {
+  color: $white !important;
+}
+
 .nav-item a:hover {
-  color: $ucla-gold;
+  color: $ucla-gold !important;
   text-decoration: none;
 }
 
 .nav-link {
-  color: #fff !important;
   padding-left: 1rem !important;
   padding-right: 1rem !important;
-}
-
-.nav-link:hover {
-  color: $ucla-gold !important;
 }
 
 .navbar > .container {
@@ -123,7 +126,7 @@
   .nav-item:nth-child(1):hover {
     background-color: $ucla-darkest-blue;
     a {
-      color: #fff !important;
+      color: $white !important;
       text-decoration: none;
     }
   }

--- a/app/assets/stylesheets/ursus/_old_collections_link.scss
+++ b/app/assets/stylesheets/ursus/_old_collections_link.scss
@@ -1,9 +1,3 @@
 .old-collections-link {
   margin-top: 1em;
-  a {
-    color: $ucla-blue;
-  }
-  a:hover {
-    color: $ucla-darker-blue;
-  }
 }

--- a/app/assets/stylesheets/ursus/_show.scss
+++ b/app/assets/stylesheets/ursus/_show.scss
@@ -14,15 +14,6 @@
   margin-bottom: 15px;
 }
 
-dd a {
-  color: $ucla-blue;
-  text-decoration: none;
-}
-
-dd a:hover {
-  color: $ucla-darker-blue;
-}
-
 dl {
   padding-left: 7px;
 }

--- a/app/assets/stylesheets/ursus/_sort-pagination.scss
+++ b/app/assets/stylesheets/ursus/_sort-pagination.scss
@@ -10,10 +10,10 @@
 }
 
 .sort-pagination,
-  .pagination-search-widgets {
-    border-bottom: 0px !important;
-    margin-bottom: 0em;
-  }
+.pagination-search-widgets {
+  border-bottom: 0px !important;
+  margin-bottom: 0em;
+}
 
 .rectangle {
   background-color: #f5f5f5;
@@ -27,7 +27,7 @@ a.page-link {
   margin-left: -1px;
   line-height: 1.25;
   color: $ucla-darker-blue;
-  background-color: #ffffff;
+  background-color: $white;
   border: 1px solid #dee2e6;
 }
 

--- a/app/assets/stylesheets/ursus/_title.scss
+++ b/app/assets/stylesheets/ursus/_title.scss
@@ -4,13 +4,7 @@
   .document-title-heading {
     font-weight: 400;
     font-size: 1rem;
-    color: $ucla-blue;
-    a {
-      color: $ucla-blue;
-    }
-    a:hover {
-      color: $ucla-darker-blue;
-    }
+    color: $ucla-darker-blue;
   }
   dl.document-metadata {
     margin-left: 1em;

--- a/app/assets/stylesheets/ursus/_variables.scss
+++ b/app/assets/stylesheets/ursus/_variables.scss
@@ -33,4 +33,16 @@ $font-family-sans-serif: 'Helvetica', 'Arial', sans-serif;
 
 $container-padding: 95%;
 
+//== Linked text colors
+$a-tags: 'a, a:active, a:hover, a:visited';
+$a-tags-hover: 'a:active, a:hover';
+
+#{$a-tags} {
+  color: $ucla-darker-blue !important;
+  text-decoration: none;
+}
+#{$a-tags-hover} {
+  color: $ucla-darker-blue !important;
+}
+
 @import 'bootstrap';

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,8 +1,8 @@
 <nav class='navbar navbar-expand-md navbar-dark bg-dark topbar' role='navigation'>
-  <div class="<%= container_classes %>">
+  <div class='container-fluid'>
 
     <div class='navbar-logo-block'>
-      <a href='https://library.ucla.edu' class='navbar-brand'></a>
+      <a href='https://library.ucla.edu' class='navbar-brand'><span class='logo-name'>UCLA Library Logo</span></a>
       <span class='navbar-pipe'></span>
       <%= link_to 'Digital Collections', root_path, class: 'navbar-text-logo' %>
     </div>
@@ -23,7 +23,7 @@
 
 <% unless controller.controller_name == 'catalog' && controller.action_name == 'show' %>
   <div class='navbar-search navbar navbar-light bg-faded' role='navigation'>
-    <div class="<%= container_classes %>">
+    <div class='container-fluid'>
       <%= render_search_bar  %>
     </div>
   </div>


### PR DESCRIPTION
Pa11y: Update navbar feedback link color for better contrast

Pa11y: Re-add content link back to UCLA Library Logo (accidentally removed in another ticket)

Set global color for <a> active and hover states to UCLA-darker-blue

Change .scss file name for about page
