### PR TITLE
Add search dropdown

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -176,6 +176,30 @@ class CatalogController < ApplicationController
       }
     end
 
+    config.add_search_field('subject') do |field|
+      solr_name = ::Solrizer.solr_name('subject', :stored_searchable)
+      field.solr_local_parameters = {
+        qf: solr_name,
+        pf: solr_name
+      }
+    end
+
+    config.add_search_field('title') do |field|
+      solr_name = ::Solrizer.solr_name('title', :stored_searchable)
+      field.solr_local_parameters = {
+        qf: solr_name,
+        pf: solr_name
+      }
+    end
+
+    config.add_search_field('collection') do |field|
+      solr_name = ::Solrizer.solr_name('collection', :stored_searchable)
+      field.solr_local_parameters = {
+        qf: solr_name,
+        pf: solr_name
+      }
+    end
+
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the SOLR field to sort by and
     # whether the sort is ascending or descending (it must be asc or desc

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -4,16 +4,11 @@
     <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
   <% end %>
   <div class="input-group">
-    <% if search_fields.length > 1 %>
-        <%= select_tag(:search_field,
-                       options_for_select(search_fields, h(params[:search_field])),
-                       title: t('blacklight.search.form.search_field.title'),
-                       id: "search_field",
-                       class: "custom-select search-field") %>
-    <% elsif search_fields.length == 1 %>
-      <%= hidden_field_tag :search_field, search_fields.first.last %>
-    <% end %>
-
+    <%= select_tag(:search_field,
+                   options_for_select(search_fields, h(params[:search_field])),
+                   title: t('blacklight.search.form.search_field.title'),
+                   id: "search_field",
+                   class: "custom-select search-field") %>
     <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
     <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q form-control", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) }  %>
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe CatalogController, type: :controller do
     let(:search_fields) { controller.blacklight_config.search_fields.keys }
 
     let(:expected_search_fields) do
-      ['all_fields']
+      ['all_fields', "collection", "subject", "title"]
     end
 
     it { expect(search_fields).to contain_exactly(*expected_search_fields) }

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -21,6 +21,7 @@ RSpec.feature "Search results page" do
       description_tesim: ['Description 1', 'Description 2'],
       date_created_tesim: ["Date 1"],
       human_readable_resource_type_tesim: ['still image'],
+      subject_tesim: ['Testing', 'RSpec'],
       photographer_tesim: ['Person 1', 'Person 2'],
       location_tesim: ['search_results_spec'], # to control what displays,
       thumbnail_path_ss: ["/assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png"]
@@ -36,8 +37,10 @@ RSpec.feature "Search results page" do
       description_tesim: ['Description 3', 'Description 4'],
       date_created_tesim: ["Date 1"],
       human_readable_resource_type_tesim: ['still image'],
+      subject_tesim: ['Testing', 'Minitest'],
       photographer_tesim: ['Person 1'],
-      location_tesim: ['search_results_spec'] # to control what displays
+      location_tesim: ['search_results_spec'], # to control what displays
+      collection_tesim: ['Slide Film', 'Analog', 'Photographs']
     }
   end
 
@@ -51,7 +54,8 @@ RSpec.feature "Search results page" do
       date_created_tesim: ["Date 1"],
       human_readable_resource_type_tesim: ['still image'],
       photographer_tesim: ['Person 1'],
-      location_tesim: ['search_results_spec'] # to control what displays
+      location_tesim: ['search_results_spec'], # to control what displays
+      collection_tesim: ['Photographs', 'Digital']
     }
   end
 
@@ -119,5 +123,28 @@ RSpec.feature "Search results page" do
     expect(page).to have_content 'Description: Description 1'
     expect(page).to have_content 'Resource Type: still image'
     expect(page).to have_content 'Date Created: Date 1'
+  end
+
+  scenario 'visiting the home page and getting the correct search field options' do
+    visit '/' do
+      expect(page.html).to match(/<option value="all_fields">All Fields<\/option>/)
+      expect(page.html).to match(/<option value="title">Title<\/option>/)
+      expect(page.html).to match(/<option value="subject">Subject<\/option>/)
+      expect(page.html).to match(/<option value="description">Collection<\/option>/)
+    end
+  end
+
+  scenario 'using the drop down search and getting the correct results' do
+    visit '/catalog?search_field=title&q=Title One' do
+      expect(page).to have_content('1 Catalog Results')
+    end
+
+    visit '/catalog?search_field=subject&q=Minitest' do
+      expect(page).to have_content('1 Catalog Results')
+    end
+
+    visit '/catalog?search_field=collection&q=photographs' do
+      expect(page).to have_content('2 Catalog Results')
+    end
   end
 end


### PR DESCRIPTION
This brings back the search dropdown with the
All, Title, Subject, and Collection options.

Connected to URS-370

<img width="1185" alt="Screen Shot 2019-05-10 at 11 24 16 AM" src="https://user-images.githubusercontent.com/751697/57548585-352b0f80-7316-11e9-90eb-be230709d1dc.png">
