### PR TITLE
Only display the first description in search results

### DIFF
--- a/app/helpers/ursus/catalog_helper.rb
+++ b/app/helpers/ursus/catalog_helper.rb
@@ -24,12 +24,9 @@ module Ursus
     def render_truncated_description(args)
       truncated_output = String.new
       content_tag :div, class: 'truncate-description' do
-        args[:value].each do |val|
-          description = val
-          button = "<span class='view-more' href>Read More <div class='down-arrow'>&raquo;</div></span></br>"
-          truncated_output << "<div class='description'>#{description}</div>#{button}</br>"
-        end
-
+        description = args[:value].first
+        button = "<span class='view-more' href>Read More <div class='down-arrow'>&raquo;</div></span></br>"
+        truncated_output << "<div class='description'>#{description}</div>#{button}</br>"
         return truncated_output.html_safe # rubocop:disable Rails/OutputSafety
       end
     end

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Search results page" do
     visit '/catalog?f%5Blocation_tesim%5D%5B%5D=search_results_spec'
     expect(page).to have_content 'Title One'
     expect(page).to have_content 'Description: Description 1'
-    expect(page).to have_content 'Description 2'
+    expect(page).not_to have_content 'Description 2'
     expect(page).to have_content 'Resource Type: still image'
     expect(page).to have_content 'Date Created: Date 1'
     expect(page).to have_content 'Photographer: Person 1'


### PR DESCRIPTION
Connected to URS-383

When an item has more than one description, we should only show one (the 'first') description in search results

+ https://ursus.library.ucla.edu/catalog?utf8=✓&search_field=all_fields&q=Telles+family+at+the+Sleepy+Lagoon+murder+case+acquittal
+ http://localhost:3003/catalog?f%5Bnamed_subject_sim%5D%5B%5D=Arrowhead+Mountain+Spring+Water

ACCEPTANCE  
- [x] When an item with more than one description is included in search results, only one description should be shown.
<img width="1213" alt="Screen Shot 2019-05-10 at 11 16 58 AM" src="https://user-images.githubusercontent.com/751697/57548226-445d8d80-7315-11e9-8291-74707c91b928.png">

---

+ modified:   app/helpers/ursus/catalog_helper.rb
+ modified:   spec/features/search_results_spec.rb