### PR TITLE
Re-size UV dynamically

### DIFF
--- a/app/assets/javascripts/uv_width.js
+++ b/app/assets/javascripts/uv_width.js
@@ -1,0 +1,3 @@
+$(document).on('turbolinks:load', function() {
+  $('#universal-viewer-iframe').width($('.uv-container').width())
+})


### PR DESCRIPTION
This adds a script that adjusts the
width of the UV display to 75% of the
document width when the page is loaded.

This will allow larger screens to view
more of the image.

Connected to URS-365