### PR TITLE
Add ark as key

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -58,13 +58,14 @@ class CatalogController < ApplicationController
     ## Default parameters to send on single-document requests to Solr. These settings are the Blackligt defaults (see SearchHelper#solr_doc_params) or
     ## parameters included in the Blacklight-jetty document requestHandler.
     #
-    # config.default_document_solr_params = {
-    #  qt: 'document',
-    #  ## These are hard-coded in the blacklight 'document' requestHandler
-    #  # fl: '*',
-    #  # rows: 1,
-    #  # q: '{!term f=id v=$id}'
-    # }
+    config.default_document_solr_params = {
+      :qt=>"standard", 
+      :q=>"{!term f=ark_ssi v=$ark_ssi}",
+      :fq=>"{!terms f=has_model_ssim v=Work,Collection}"
+    }
+    config.document_solr_path = 'select'
+    config.document_unique_id_param = 'ark_ssi'
+
 
     # solr field configuration for search results/index views
     # config.index.title_field = 'title_display'

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -3,7 +3,7 @@ class SolrDocument
   include Blacklight::Solr::Document
   include Blacklight::Gallery::OpenseadragonSolrDocument
 
-  # self.unique_key = 'id'
+  self.unique_key = 'ark_ssi'
 
   # Email uses the semantic field mappings below to generate the body of an email.
   SolrDocument.use_extension(Blacklight::Document::Email)


### PR DESCRIPTION
Connected to URS-334

This requires content that had been indexed with `ark_ssi.` 

The changes in UCLALibrary/californicaCAL-541 need to be completed   
and content will have to be re-ingested/re-indexed first;   
otherwise this PR will break in production.

---

+ modified:   `app/controllers/catalog_controller.rb`
+ modified:   `app/models/solr_document.rb`