### PR TITLE
WIP - Remove normalized date from SEARCH_FIELDS URS-191 (don't merge)

### DIFF
--- a/app/services/search_field_service.rb
+++ b/app/services/search_field_service.rb
@@ -15,7 +15,7 @@ class SearchFieldService
     ::Solrizer.solr_name('location', :stored_searchable),
     ::Solrizer.solr_name('medium', :stored_searchable),
     ::Solrizer.solr_name('named_subject', :stored_searchable),
-    ::Solrizer.solr_name('normalized_date', :stored_searchable),
+    # ::Solrizer.solr_name('normalized_date', :stored_searchable),
     ::Solrizer.solr_name('photographer', :stored_searchable),
     ::Solrizer.solr_name('publisher', :stored_searchable),
     ::Solrizer.solr_name('subject', :stored_searchable),

--- a/spec/services/search_field_service_spec.rb
+++ b/spec/services/search_field_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SearchFieldService do
     expect(search_field_service.search_fields).to eq(%w[ architect_tesim caption_tesim
                                                          contributor_tesim creator_tesim description_tesim genre_tesim
                                                          identifier_tesim local_identifier_ssm location_tesim medium_tesim
-                                                         named_subject_tesim normalized_date_tesim
+                                                         named_subject_tesim
                                                          photographer_tesim publisher_tesim subject_tesim title_tesim ].join(' '))
   end
 end


### PR DESCRIPTION
Connected to URS-191  
Depends on URS-388

This field is especially problematic because it's treated as text, and thus tokenizes on hyphens.   
Thus, '06-06-1932' matches any search that includes '06'   
(e.g. an identifier with an '-06' suffix) (including the hyphen)

- [x] Search for an identifier with a suffix like '-06' does not return matches from 'normalized_date'
- [x] This behavior is built into the test suite ursus-prod search behavior developed in URS-388

---

+ modified:   app/services/search_field_service.rb
+ modified:   spec/services/search_field_service_spec.rb