### PR TITLE
Update search bar styling for focused search URS-384

### DIFF
--- a/app/assets/stylesheets/ursus/_searchbar.scss
+++ b/app/assets/stylesheets/ursus/_searchbar.scss
@@ -2,13 +2,21 @@
 
 .input-group {
   border: 10px solid #003B5C;
+  width: 1180px !important;
+}
+.ursus-search-bar {
+  margin-top: 20px;
+  padding-bottom: 0px !important;
+}
+
+#main-container {
+  padding-top: 0px !important;
 }
 
 .blacklight-catalog {
   .navbar-search {
     padding-left: 0;
   }
-
   .navbar-search > .container-fluid {
     width: $container-padding;
   }
@@ -42,4 +50,84 @@
   padding-left: 15px;
   padding-top: 6px;
   color: $ucla-blue;
+}
+
+.search-area {
+  margin-top: 20px;
+  display: flex;
+  background-color: $ucla-lightest-blue;
+  border-top: 6px solid $ucla-lightest-blue;
+  .btn {
+    background-color: $white;
+  }
+}
+.search-ucla {
+  margin-left: -15px;
+  margin-top: -15px;
+  max-width: 100%;
+}
+.search-breadcrumbs {
+  margin-left: 10px;
+  margin-top: -9px;
+}
+/* All Fields */
+#search_field {
+  background-color: $ucla-blue;
+  color: $white;
+}
+
+#appliedParams {
+  .btn-group {
+    .constraints-label {
+      background-color: indigo;
+      color: $white;
+    }
+    .filter-name {
+      color: $white;
+    }
+    .applied-filter .filter-name:after {
+      color: $white !important;
+    }
+    .filter-value {
+      color: $white;
+    }
+    .constraint-value {
+      background: $ucla-blue;
+    }
+    .constraint-value.btn-outline-secondary {
+      background: $ucla-blue;
+    }
+    .constraint-value.btn-outline-secondary:hover {
+      background: $gray !important;
+    }
+    .remove {
+      background-color: $ucla-blue !important;
+    }
+    .remove:hover {
+      background-color: $gray !important;
+      border: none !important;
+    }
+    .remove-icon {
+      color: white !important;
+      font-weight: 700;
+    }
+  }
+}
+.applied-filter .filter-name:after {
+  color: $white !important;
+}
+
+.filters-applied {
+  color: $gray;
+  font-weight: 700;
+}
+
+.filter-box {
+  width: 1180px;
+  display: flex;
+  background-color: $ucla-lightest-blue;
+  padding-left: 15px;
+  padding-top: 10px;
+  margin-left: -8px;
+  margin-bottom: 20px;
 }

--- a/app/assets/stylesheets/ursus/_selected_facet.scss
+++ b/app/assets/stylesheets/ursus/_selected_facet.scss
@@ -35,5 +35,5 @@ div#facets .card .btn {
   overflow-wrap: initial;
   margin-bottom: 0.5em;
   margin-left: 15px;
-  padding-left: 0;
+  padding: 0;
 }

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -1,0 +1,9 @@
+<% if query_has_constraints? %>
+  <div id="appliedParams" class="clearfix constraints-container">
+    <h2 class="sr-only"><%= t('blacklight.search.search_constraints_header') %></h2>
+    <span class='filters-applied'>Filters applied: </span>
+    <span class="constraints-label sr-only"><%= t('blacklight.search.filters.title') %></span>
+    <%= render_constraints(params) %>
+    <%=link_to t('blacklight.search.start_over'), start_over_path, class: "catalog_startOverLink btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,14 +1,10 @@
+<!-- This will render the searchbar when render_search_bar is called in the header_navbar partial -->
 <%= form_tag search_action_url, method: :get, class: 'search-query-form', role: 'search' do %>
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
   <% if search_fields.length > 1 %>
     <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
   <% end %>
   <div class="input-group">
-    <%= select_tag(:search_field,
-                   options_for_select(search_fields, h(params[:search_field])),
-                   title: t('blacklight.search.form.search_field.title'),
-                   id: "search_field",
-                   class: "custom-select search-field") %>
     <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
     <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q form-control", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) }  %>
 
@@ -17,5 +13,12 @@
         <%= blacklight_icon :search %>
       </button>
     </span>
+
+<!-- All Fields -->
+    <%= select_tag(:search_field,
+                   options_for_select(search_fields, h(params[:search_field])),
+                   title: t('blacklight.search.form.search_field.title'),
+                   id: "search_field",
+                   class: "custom-select search-field") %>
   </div>
 <% end %>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -7,10 +7,12 @@
   <%= json_api_link_tag %>
 <% end %>
 
+<!-- This adds the Filtered result (breadcrumbs) -->
 <% content_for(:container_header) do -%>
   <h1 class='sr-only top-content-title'><%= t('blacklight.search.header') %></h1>
-  <%= render 'constraints' %>
+  <div class='filter-box'><%= render 'constraints' %></div>
 <% end %>
+
 <h4 class='catalog-results'><%= @response['response'].dig(:numFound) %> Catalog Results <%= render_results_collection_tools wrapping_class: "search-widgets" %></h4>
 
 <div class='rectangle'> <%= render 'search_header' %> </div>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -21,10 +21,11 @@
   </div>
 </nav>
 
+<!-- Searchbar -->
 <% unless controller.controller_name == 'catalog' && controller.action_name == 'show' %>
-  <div class='navbar-search navbar navbar-light bg-faded' role='navigation'>
-    <div class='container-fluid'>
-      <%= render_search_bar  %>
+  <div class='navbar-search navbar navbar-light bg-faded ursus-search-bar' role='navigation'>
+    <div class='container'>
+      <%= render_search_bar %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
Update search bar styling for focused search

Connected to URS-384

- [x] Searchbar goes all the way across the page
- [x] "All Fields" button is blue w/ white text
- [x] "breadcrumb buttons" blue w/ white text
- [x] "Filters Appled:" text in front of the "breadcrumb buttons"
- [x] Move "Start Over" To the End of the "breadcrumb buttons"
<img width="1491" alt="Screen Shot 2019-05-17 at 4 42 36 PM" src="https://user-images.githubusercontent.com/751697/57961343-2b2f8080-78c3-11e9-877c-b9c92f9b05d6.png">

---

+ modified:   app/assets/stylesheets/ursus/_searchbar.scss
+ modified:   app/assets/stylesheets/ursus/_selected_facet.scss
+ modified:   app/views/catalog/_search_form.html.erb
+ modified:   app/views/catalog/_search_results.html.erb
+ modified:   app/views/shared/_header_navbar.html.erb
+ new file:   app/views/catalog/_constraints.html.erb