### PR TITLE
Update facets sidebar appearance and display only view icons on smaller devices

### DIFF
--- a/app/assets/stylesheets/ursus/_buttons.scss
+++ b/app/assets/stylesheets/ursus/_buttons.scss
@@ -82,3 +82,9 @@ a.catalog_startOverLink:visited {
 a.catalog_startOverLink:focus {
   box-shadow: 0 0 0 0.1rem rgba(38, 143, 255, 0.5) !important;
 }
+
+@media screen and (max-width: 767px) {
+  .view-name {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/ursus/_facets.scss
+++ b/app/assets/stylesheets/ursus/_facets.scss
@@ -1,9 +1,9 @@
 #facets {
+  margin-bottom: 1.5em;
+
   #facet-year_isim > div > div > ul {
     display: none;
   }
-
-  margin-bottom: 1.5em;
 
   .slider_js .slider-selection {
     background: #c3d7ee;
@@ -113,7 +113,32 @@
     .btn[aria-expanded='true'] {
       font-weight: bold;
       text-decoration: none;
-      color: red !important;
+    }
+  }
+}
+
+@media screen and (max-width: 991px) {
+  #facets {
+    .navbar {
+      background-color: #f5f5f5;
+    }
+  }
+
+  .facets-toggleable-sm .navbar-toggler {
+    display: block;
+  }
+  .facets-toggleable-sm .facets-collapse {
+    display: block !important;
+  }
+  .collapse:not(.show) {
+    display: none !important;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  #facets {
+    .navbar {
+      padding-left: 1rem !important;
     }
   }
 }

--- a/app/assets/stylesheets/ursus/_facets.scss
+++ b/app/assets/stylesheets/ursus/_facets.scss
@@ -1,5 +1,15 @@
 #facets {
-  margin-bottom: 1.5em;
+  .navbar {
+    padding-top: 0;
+    padding-bottom: 0;
+
+    .facets-heading {
+      margin-bottom: 0 !important;
+    }
+  }
+  .facets-heading {
+    line-height: 1 !important;
+  }
 
   #facet-year_isim > div > div > ul {
     display: none;
@@ -119,8 +129,26 @@
 
 @media screen and (max-width: 991px) {
   #facets {
+    margin-bottom: 1.5em;
+
     .navbar {
-      background-color: #f5f5f5;
+      background-color: $ucla-lightest-blue;
+      margin-top: 1rem;
+      margin-bottom: 1rem;
+      padding-top: 0.5rem;
+      padding-bottom: 0.5rem;
+
+      .facets-heading {
+        color: $ucla-darkest-blue;
+      }
+    }
+
+    .navbar-toggler {
+      border-color: transparent !important;
+    }
+
+    button:focus {
+      outline: none !important;
     }
   }
 
@@ -132,6 +160,34 @@
   }
   .collapse:not(.show) {
     display: none !important;
+  }
+  .svg-icon {
+    width: 1.5em;
+    height: 1.5em;
+    -webkit-transform: rotate(90deg);
+    transform: rotate(90deg);
+    transition: -webkit-transform 0.25s ease;
+    transition: transform 0.25s ease;
+    transition: transform 0.25s ease, -webkit-transform 0.25s ease;
+  }
+
+  .navbar-toggler.navbar-toggler-right[aria-expanded='true'] {
+    .svg-icon {
+      -webkit-transform: rotate(270deg);
+      transform: rotate(270deg);
+      transition: -webkit-transform 0.25s ease;
+      transition: transform 0.25s ease;
+      transition: transform 0.25s ease, -webkit-transform 0.25s ease;
+    }
+  }
+
+  .svg-icon path {
+    fill: $ucla-darkest-blue;
+  }
+
+  .svg-icon {
+    stroke: $ucla-darkest-blue;
+    stroke-width: 0.05rem;
   }
 }
 

--- a/app/assets/stylesheets/ursus/_sort-pagination.scss
+++ b/app/assets/stylesheets/ursus/_sort-pagination.scss
@@ -16,11 +16,24 @@
   }
 }
 
+@media screen and (max-width: 991px) {
+  .catalog-results {
+    padding-left: 1rem;
+  }
+}
+
 .rectangle {
   background-color: #f5f5f5;
   border: none;
   margin-top: 1em;
   padding: 1em 0.5em;
+}
+
+@media screen and (max-width: 991px) {
+  .rectangle {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
 }
 
 .sort-pagination {

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -1,0 +1,23 @@
+<% # main container for facets/limits menu -%>
+<% if has_facet_values? %>
+<div id="facets" class="facets sidenav facets-toggleable-sm">
+
+  <div class="navbar">
+    <h2 class="facets-heading">
+      <%= t('blacklight.search.facets.title') %>
+    </h2>
+
+    <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#facet-panel-collapse" aria-controls="facet-panel-collapse" aria-expanded="false" aria-label="Toggle facets">
+     
+      <svg class="svg-icon" viewBox="0 0 20 20">
+      <path fill="none" d="M8.388,10.049l4.76-4.873c0.303-0.31,0.297-0.804-0.012-1.105c-0.309-0.304-0.803-0.293-1.105,0.012L6.726,9.516c-0.303,0.31-0.296,0.805,0.012,1.105l5.433,5.307c0.152,0.148,0.35,0.223,0.547,0.223c0.203,0,0.406-0.08,0.559-0.236c0.303-0.309,0.295-0.803-0.012-1.104L8.388,10.049z"></path>
+    </svg>
+     
+    </button>
+  </div>
+
+  <div id="facet-panel-collapse" class="facets-collapse collapse">
+    <%= render_facet_partials %>
+  </div>
+</div>
+<% end %>

--- a/app/views/catalog/_view_type_group.html.erb
+++ b/app/views/catalog/_view_type_group.html.erb
@@ -4,7 +4,7 @@
     <div class="view-type-group btn-group">
       <% document_index_view_controls.each do |view, config| %>
         <%= link_to url_for(search_state.to_h.merge(view: view)), title: view_label(view), class: "btn btn-outline-secondary view-type-#{ view.to_s.parameterize } #{"active" if document_index_view_type == view}" do %>
-          <%= render_view_type_group_icon view %> <%= view.capitalize %> View
+          <%= render_view_type_group_icon view %> <span class="view-name"><%= view.capitalize %> View</span>
           <span class="caption"><%= view_label(view) %></span>
         <% end %>
       <% end %>


### PR DESCRIPTION
Add background color to facets header section for tablet and mobile.
Close facets sidebar at 991px and display toggle icon
Change facet hamburger icon to a toggle angle.
Switch view type buttons to display icons only at tablet and mobile.

<img width="506" alt="updated facet sidebar header" src="https://user-images.githubusercontent.com/24995224/57947321-73cf4580-7893-11e9-83a8-ee0bac42b427.png">
