### PR TITLE
Fix the date sort

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -107,7 +107,7 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results / list view
     #   The   config.add_index_field ::Solrizer.solr_name('title', :stored_searchable), label: 'Title', itemprop: 'name', if: false
     config.add_index_field ::Solrizer.solr_name('description', :stored_searchable), itemprop: 'description', helper_method: :render_truncated_description
-    config.add_index_field ::Solrizer.solr_name('date_created', :stored_searchable), itemprop: 'dateCreated'
+    config.add_index_field 'sort_year_isi', label: 'Date Created'
     # config.add_index_field ::Solrizer.solr_name('normalized_date', :stored_searchable), itemprop: 'dateCreated'
     config.add_index_field ::Solrizer.solr_name('human_readable_resource_type', :stored_searchable), label: 'Resource Type', link_to_facet: ::Solrizer.solr_name('human_readable_resource_type', :facetable)
     config.add_index_field ::Solrizer.solr_name('photographer', :stored_searchable), label: 'Photographer', link_to_facet: ::Solrizer.solr_name('photographer', :facetable)
@@ -169,35 +169,29 @@ class CatalogController < ApplicationController
     # since we aren't specifying it otherwise.
     search_field_service = ::SearchFieldService.instance
     config.add_search_field('all_fields', label: 'All Fields') do |field|
-      title_name = ::Solrizer.solr_name('title', :stored_searchable)
       field.solr_parameters = {
-        qf: search_field_service.search_fields,
-        pf: title_name.to_s,
-        mm: '100%'
+        qf: search_field_service.search_fields
       }
     end
 
     config.add_search_field('subject') do |field|
-      solr_name = ::Solrizer.solr_name('subject', :stored_searchable)
       field.solr_local_parameters = {
-        qf: solr_name,
-        pf: solr_name
+        qf: '$subject_qf',
+        pf: '$subject_pf'
       }
     end
 
     config.add_search_field('title') do |field|
-      solr_name = ::Solrizer.solr_name('title', :stored_searchable)
       field.solr_local_parameters = {
-        qf: solr_name,
-        pf: solr_name
+        qf: '$title_qf',
+        pf: '$title_pf'
       }
     end
 
     config.add_search_field('collection') do |field|
-      solr_name = ::Solrizer.solr_name('collection', :stored_searchable)
       field.solr_local_parameters = {
-        qf: solr_name,
-        pf: solr_name
+        qf: '$collection_qf',
+        pf: '$collection_qf'
       }
     end
 
@@ -207,9 +201,18 @@ class CatalogController < ApplicationController
     # except in the relevancy case).
     # label is key, solr field is value
 
-    config.add_sort_field 'sort_title_isi desc, system_create_dtsi desc', label: 'Title'
-    config.add_sort_field 'sort_year_isi desc, system_create_dtsi desc', label: 'Year (earliest)'
-    config.add_sort_field 'score desc, system_create_dtsi desc', label: 'Relevance'
+    # This is searching the sort_title_tesi, which cannot be
+    # sorted alphabetically. It needs an alpha sort field in the
+    # schema.xml across californica and ursus
+
+    # config.add_sort_field 'title' do |field|
+    #  field.sort = 'sort_title_tesi desc, sort_title_tesi asc'
+    #  field.label = 'Title'
+    # end
+
+    config.add_sort_field 'score desc', label: 'Relevance'
+    config.add_sort_field 'sort_year_isi desc', label: 'Year (newest)'
+    config.add_sort_field 'sort_year_isi asc', label: 'Year (oldest)'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/services/search_field_service.rb
+++ b/app/services/search_field_service.rb
@@ -19,7 +19,8 @@ class SearchFieldService
     ::Solrizer.solr_name('photographer', :stored_searchable),
     ::Solrizer.solr_name('publisher', :stored_searchable),
     ::Solrizer.solr_name('subject', :stored_searchable),
-    ::Solrizer.solr_name('title', :stored_searchable)
+    ::Solrizer.solr_name('title', :stored_searchable),
+    'ark_ssi'
   ].join(' ').freeze
   def search_fields
     SEARCH_FIELDS

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CatalogController, type: :controller do
 
     let(:expected_index_fields) do
       ['description_tesim',
-       'date_created_tesim',
+       'sort_year_isi',
        'human_readable_resource_type_tesim',
        'photographer_tesim']
     end

--- a/spec/features/search_results_spec.rb
+++ b/spec/features/search_results_spec.rb
@@ -20,6 +20,7 @@ RSpec.feature "Search results page" do
       identifier_tesim: ['ark 123'],
       description_tesim: ['Description 1', 'Description 2'],
       date_created_tesim: ["Date 1"],
+      sort_year_isi: 1923,
       human_readable_resource_type_tesim: ['still image'],
       subject_tesim: ['Testing', 'RSpec'],
       photographer_tesim: ['Person 1', 'Person 2'],
@@ -36,6 +37,7 @@ RSpec.feature "Search results page" do
       identifier_tesim: ['ark 456'],
       description_tesim: ['Description 3', 'Description 4'],
       date_created_tesim: ["Date 1"],
+      sort_year_isi: 1945,
       human_readable_resource_type_tesim: ['still image'],
       subject_tesim: ['Testing', 'Minitest'],
       photographer_tesim: ['Person 1'],
@@ -52,6 +54,7 @@ RSpec.feature "Search results page" do
       identifier_tesim: ['ark 456'],
       description_tesim: ['Description 3', 'Description 4', 'another desc'],
       date_created_tesim: ["Date 1"],
+      sort_year_isi: 1929,
       human_readable_resource_type_tesim: ['still image'],
       photographer_tesim: ['Person 1'],
       location_tesim: ['search_results_spec'], # to control what displays
@@ -65,7 +68,7 @@ RSpec.feature "Search results page" do
     expect(page).to have_content 'Description: Description 1'
     expect(page).not_to have_content 'Description 2'
     expect(page).to have_content 'Resource Type: still image'
-    expect(page).to have_content 'Date Created: Date 1'
+    expect(page).to have_content 'Date Created: 1923'
     expect(page).to have_content 'Photographer: Person 1'
   end
 
@@ -73,7 +76,7 @@ RSpec.feature "Search results page" do
     visit '/catalog?f%5Blocation_tesim%5D%5B%5D=search_results_spec'
     expect(page).to have_link 'Title One'
     expect(page).to have_link 'still image'
-    expect(page).not_to have_link 'Date 1'
+    expect(page).not_to have_link '1923'
     expect(page).to have_link 'Person 1'
   end
 
@@ -122,7 +125,7 @@ RSpec.feature "Search results page" do
     expect(page).to have_content 'Title One'
     expect(page).to have_content 'Description: Description 1'
     expect(page).to have_content 'Resource Type: still image'
-    expect(page).to have_content 'Date Created: Date 1'
+    expect(page).to have_content 'Date Created: 1923'
   end
 
   scenario 'visiting the home page and getting the correct search field options' do

--- a/spec/services/search_field_service_spec.rb
+++ b/spec/services/search_field_service_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe SearchFieldService do
                                                          contributor_tesim creator_tesim description_tesim genre_tesim
                                                          identifier_tesim local_identifier_ssm location_tesim medium_tesim
                                                          named_subject_tesim normalized_date_tesim
-                                                         photographer_tesim publisher_tesim subject_tesim title_tesim ].join(' '))
+                                                         photographer_tesim publisher_tesim subject_tesim title_tesim ark_ssi ].join(' '))
   end
 end


### PR DESCRIPTION
This changes the date sorting and display so that
the user is able to sort by the creation date
of an item both ascending and descending. This
also changes the display field for the date on the
index page to display the date that was used
for sorting.

This also adds the ARK field to the default
search so that users can search by the ARK.

Connected to URS-406
Connected to URS-409