### PR TITLE
Constrain search-bar width and update facets filter-chain styling

### DIFF
--- a/app/assets/stylesheets/ursus/_buttons.scss
+++ b/app/assets/stylesheets/ursus/_buttons.scss
@@ -75,9 +75,17 @@
   margin-bottom: 0.2rem !important;
 }
 
+a.catalog_startOverLink,
+a.catalog_startOverLink:active,
+a.catalog_startOverLink:focus,
 a.catalog_startOverLink:visited {
-  color: $white !important;
+  color: $ucla-darkest-blue !important;
+  font-weight: 600 !important;
 }
+
+// a.catalog_startOverLink:visited {
+//   color: $white !important;
+// }
 
 a.catalog_startOverLink:focus {
   box-shadow: 0 0 0 0.1rem rgba(38, 143, 255, 0.5) !important;

--- a/app/assets/stylesheets/ursus/_facets.scss
+++ b/app/assets/stylesheets/ursus/_facets.scss
@@ -1,11 +1,6 @@
 #facets {
   .navbar {
-    padding-top: 0;
-    padding-bottom: 0;
-
-    .facets-heading {
-      margin-bottom: 0 !important;
-    }
+    padding-top: 0.5rem;
   }
   .facets-heading {
     line-height: 1 !important;

--- a/app/assets/stylesheets/ursus/_home.scss
+++ b/app/assets/stylesheets/ursus/_home.scss
@@ -2,6 +2,7 @@
 
 #main-container {
   width: $container-padding;
+  margin-top: 1rem;
 }
 
 p {

--- a/app/assets/stylesheets/ursus/_searchbar.scss
+++ b/app/assets/stylesheets/ursus/_searchbar.scss
@@ -1,13 +1,13 @@
 @import 'variables';
 
-.navbar + .container > .ursus-search-bar {
+#search-bar-container {
   padding-bottom: 0 !important;
 }
 
 .ursus-search-bar {
   margin-top: 20px;
-  padding: 0!important;
- .search-query-form {
+  padding: 0 !important;
+  .search-query-form {
     flex: 0 0 100% !important;
     max-width: 100% !important;
     padding: 0 !important;
@@ -15,7 +15,7 @@
 }
 
 .input-group {
-  border: 10px solid #003B5C;
+  border: 10px solid #003b5c;
 }
 
 .blacklight-catalog {
@@ -27,23 +27,23 @@
   }
 }
 
-.new-search-link{
+.new-search-link {
   padding-right: 15px;
 }
 
-.back-to-search-link{
+.back-to-search-link {
   margin-right: 20px;
 }
 
 .back-and-new-links-show {
   float: right;
-  clear:left;
+  clear: left;
   padding-top: 6px;
 }
 
 .back-and-new-container {
   height: 46px;
-  background-color: #F5F5F5;
+  background-color: #f5f5f5;
   border-top: 1px solid #dee2e6;
   margin-top: 30px;
   margin-bottom: 30px;
@@ -81,57 +81,69 @@
   color: $white;
 }
 
-#appliedParams {
-  .btn-group {
-    .constraints-label {
-      background-color: indigo;
-      color: $white;
-    }
-    .filter-name {
-      color: $white;
-    }
-    .applied-filter .filter-name:after {
-      color: $white !important;
-    }
-    .filter-value {
-      color: $white;
-    }
-    .constraint-value {
-      background: $ucla-blue;
-    }
-    .constraint-value.btn-outline-secondary {
-      background: $ucla-blue;
-    }
-    .constraint-value.btn-outline-secondary:hover {
-      background: $gray !important;
-    }
-    .remove {
-      background-color: $ucla-blue !important;
-    }
-    .remove:hover {
-      background-color: $gray !important;
-      border: none !important;
-    }
-    .remove-icon {
-      color: white !important;
-      font-weight: 700;
-    }
-  }
+.filter-box {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  background-color: $ucla-lightest-blue;
+  padding-right: 15px;
+  padding-left: 15px;
+  margin-top: -1rem;
+  margin-bottom: 1.5rem;
 }
-.applied-filter .filter-name:after {
-  color: $white !important;
+@media screen and (max-width: 767px) {
+  .filter-box {
+    display: block;
+  }
 }
 
 .filters-applied {
-  color: $gray;
-  font-weight: 700;
+  color: $ucla-darkest-blue;
+  font-weight: 600;
 }
 
-.filter-box {
-  // width: 1180px;
-  display: flex;
-  background-color: $ucla-lightest-blue;
-  padding-left: 15px;
-  padding-top: 10px;
-  margin-bottom: 20px;
+#appliedParams {
+  padding-top: 15px !important;
+
+  .btn-group {
+    margin-bottom: 0.35rem;
+
+    .constraints-container {
+      flex: 0 0 88% !important;
+      max-width: 100% !important;
+    }
+
+    .constraint-value,
+    .remove {
+      color: $white !important;
+      background: $ucla-blue !important;
+      border: 0 !important;
+    }
+    .filter-name:after {
+      color: $white !important;
+    }
+    .constraint-value:hover {
+      color: $ucla-darkest-blue !important;
+      background: $light-gray !important;
+      .filter-name:after {
+        color: $ucla-darkest-blue !important;
+      }
+    }
+    .remove:hover {
+      background: red !important;
+      margin-left: -1px !important;
+    }
+  }
+}
+
+.startover-container {
+  flex: 0 0 12% !important;
+  max-width: 100px !important;
+  align-self: center;
+}
+@media screen and (max-width: 767px) {
+  .startover-container {
+    padding-bottom: 10px;
+  }
 }

--- a/app/assets/stylesheets/ursus/_searchbar.scss
+++ b/app/assets/stylesheets/ursus/_searchbar.scss
@@ -1,16 +1,21 @@
 @import 'variables';
 
-.input-group {
-  border: 10px solid #003B5C;
-  width: 1180px !important;
-}
-.ursus-search-bar {
-  margin-top: 20px;
-  padding-bottom: 0px !important;
+.navbar + .container > .ursus-search-bar {
+  padding-bottom: 0 !important;
 }
 
-#main-container {
-  padding-top: 0px !important;
+.ursus-search-bar {
+  margin-top: 20px;
+  padding: 0!important;
+ .search-query-form {
+    flex: 0 0 100% !important;
+    max-width: 100% !important;
+    padding: 0 !important;
+  }
+}
+
+.input-group {
+  border: 10px solid #003B5C;
 }
 
 .blacklight-catalog {
@@ -123,11 +128,10 @@
 }
 
 .filter-box {
-  width: 1180px;
+  // width: 1180px;
   display: flex;
   background-color: $ucla-lightest-blue;
   padding-left: 15px;
   padding-top: 10px;
-  margin-left: -8px;
   margin-bottom: 20px;
 }

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -1,9 +1,9 @@
 <% if query_has_constraints? %>
-  <div id="appliedParams" class="clearfix constraints-container">
-    <h2 class="sr-only"><%= t('blacklight.search.search_constraints_header') %></h2>
-    <span class='filters-applied'>Filters applied: </span>
-    <span class="constraints-label sr-only"><%= t('blacklight.search.filters.title') %></span>
+  <div id='appliedParams' class='clearfix constraints-container'>
+
+    <h2 class='sr-only'><%= t('blacklight.search.search_constraints_header') %></h2>
+    <span class='filters-applied'>Filters Applied: </span>
     <%= render_constraints(params) %>
-    <%=link_to t('blacklight.search.start_over'), start_over_path, class: "catalog_startOverLink btn btn-primary" %>
+
   </div>
 <% end %>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -10,7 +10,10 @@
 <!-- This adds the Filtered result (breadcrumbs) -->
 <% content_for(:container_header) do -%>
   <h1 class='sr-only top-content-title'><%= t('blacklight.search.header') %></h1>
-  <div class='filter-box'><%= render 'constraints' %></div>
+  <div class='filter-box'>
+    <%= render 'constraints' %>
+    <%= render 'startover' %>
+  </div>
 <% end %>
 
 <h4 class='catalog-results'><%= @response['response'].dig(:numFound) %> Catalog Results <%= render_results_collection_tools wrapping_class: "search-widgets" %></h4>

--- a/app/views/catalog/_startover.html.erb
+++ b/app/views/catalog/_startover.html.erb
@@ -1,0 +1,5 @@
+<% if query_has_constraints? %>
+  <div class='startover-container'>
+    <%=link_to t('blacklight.search.start_over'), start_over_path, class: "catalog_startOverLink" %>
+  </div>
+<% end %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -23,10 +23,12 @@
 
 <!-- Searchbar -->
 <% unless controller.controller_name == 'catalog' && controller.action_name == 'show' %>
-<div class='container'>  
+<div class='container' id='search-bar-container'>  
   <div class='navbar-search navbar navbar-light bg-faded ursus-search-bar' role='navigation'>
     
       <%= render_search_bar %>
     </div>
   </div>
 <% end %>
+
+

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -23,8 +23,9 @@
 
 <!-- Searchbar -->
 <% unless controller.controller_name == 'catalog' && controller.action_name == 'show' %>
+<div class='container'>  
   <div class='navbar-search navbar navbar-light bg-faded ursus-search-bar' role='navigation'>
-    <div class='container'>
+    
       <%= render_search_bar %>
     </div>
   </div>


### PR DESCRIPTION
Fixed search bar overflow on tablet and mobile.
Revised styling and layout of facets filter-chain section.
Removed light-blue background showing up on search page without a filter-chain.
Repositioned "Start over" button.

Changes also apply to URS-371.

<img width="816" alt="Screen Shot 2019-05-22 at 4 29 01 PM" src="https://user-images.githubusercontent.com/24995224/58215789-69a4b100-7cb0-11e9-91d0-a8cff3d2fc10.png">

<img width="1219" alt="Screen Shot 2019-05-22 at 4 29 18 PM" src="https://user-images.githubusercontent.com/24995224/58215838-9bb61300-7cb0-11e9-942e-5ae633efca7b.png">


