### PR TITLE
Change fielded search config

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -181,26 +181,9 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('subject') do |field|
-      field.solr_local_parameters = {
-        qf: '$subject_qf',
-        pf: '$subject_pf'
-      }
-    end
-
-    config.add_search_field('title') do |field|
-      field.solr_local_parameters = {
-        qf: '$title_qf',
-        pf: '$title_pf'
-      }
-    end
-
-    config.add_search_field('collection') do |field|
-      field.solr_local_parameters = {
-        qf: '$collection_qf',
-        pf: '$collection_qf'
-      }
-    end
+    config.add_search_field 'title_tesim', label: 'Title'
+    config.add_search_field 'collection_tesim', label: 'Collection'
+    config.add_search_field 'subject_tesim', label: 'Subject'
 
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the SOLR field to sort by and

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe CatalogController, type: :controller do
     let(:search_fields) { controller.blacklight_config.search_fields.keys }
 
     let(:expected_search_fields) do
-      ['all_fields', "collection", "subject", "title"]
+      ['all_fields', "collection_tesim", "subject_tesim", "title_tesim"]
     end
 
     it { expect(search_fields).to contain_exactly(*expected_search_fields) }


### PR DESCRIPTION
This changes the fielded search to the simplest possbile
config. Previously, it used a more specific config that
was working in the specs and in the development enviornment,
but did not work when deployed to production servers.

This change was tested on `ursus-dev` and is working across
the environments.

Connected to URS-400