### PR TITLE
More search config

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -181,9 +181,19 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field 'title_tesim', label: 'Title'
-    config.add_search_field 'collection_tesim', label: 'Collection'
-    config.add_search_field 'subject_tesim', label: 'Subject'
+    config.add_search_field('title_tesim', label: 'Title') do |field|
+      field.solr_parameters = {
+        qf: 'title_tesim',
+        pf: ''
+      }
+    end
+
+    config.add_search_field('subject_tesim', label: 'Subject') do |field|
+      field.solr_parameters = {
+        qf: 'subject_tesim',
+        pf: ''
+      }
+    end
 
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the SOLR field to sort by and

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe CatalogController, type: :controller do
     let(:search_fields) { controller.blacklight_config.search_fields.keys }
 
     let(:expected_search_fields) do
-      ['all_fields', "collection_tesim", "subject_tesim", "title_tesim"]
+      ['all_fields', 'subject_tesim', 'title_tesim']
     end
 
     it { expect(search_fields).to contain_exactly(*expected_search_fields) }


### PR DESCRIPTION
This makes additional changes to the search
config to make the fielded searches accurate.

Collection is not currently being indexed, so
we are unable to use that in the search bar.

See:
https://github.com/UCLALibrary/californica/blob/b6e2a2daaca636b3453588edf2d02ceb7d98d87d/app/models/ucla_metadata.rb#L27
https://github.com/UCLALibrary/californica/blob/42cad7a1c7d4637aa188bc52a383a0133f45a6cd/solr/config/schema.xml#L221

Connected to URS-400