### PR TITLE
Update image grid links

### DIFF
--- a/app/views/catalog/_image_grid.html.erb
+++ b/app/views/catalog/_image_grid.html.erb
@@ -6,7 +6,7 @@
         <img src="<%= image_url('chavez.jpg') %>" alt="Carlos Chávez, portrait" Style="border: 1px solid #ddd; width:100%"/>
       </a>
       <div class="caption">
-        <%= link_to_featured_work('Carlos Chávez, portrait', 'br7004k7bh-03031') %>
+        <a href="/catalog/br7004k7bh-03031">Carlos Chávez, portrait</a>
       </div>
     </div>
     <div class="post-content">
@@ -20,7 +20,7 @@
         <img src="<%= image_url('swan.jpg') %>" alt="Swan float in the Tournament of Roses Parade, Pasadena, 1938" style="border: 1px solid #ddd; width:100%" />
       </a>
       <div class="caption">
-        <%= link_to_featured_work('Swan float in the Tournament of Roses Parade, Pasadena, 1938', '20rg5200zz-89112') %>
+        <a href="/catalog/20rg5200zz-89112">Swan float in the Tournament of Roses Parade, Pasadena, 1938</a>
       </div>
     </div>
     <div class="post-content">
@@ -37,7 +37,7 @@
         <img src="<%= image_url('tombstone.jpg') %>" alt="A slab of the St. Francis Dam visible after its disastrous 1928 collapse" style="border: 1px solid #ddd; width:100%"/>
       </a>
       <div class="caption">
-        <%= link_to_featured_work('Side view "The Tombstone", a slab of the St. Francis Dam visible after its disastrous 1928 collapse.', 'shz35200zz-89112') %>
+        <a href="/catalog/shz35200zz-89112">Side view "The Tombstone", a slab of the St. Francis Dam visible after its disastrous 1928 collapse.</a>
       </div>
     </div>
     <div class="post-content">
@@ -51,7 +51,7 @@
         <img src="<%= image_url('primary.jpg') %>" alt="Corridor filled with men and women tabulating ballots for California primary election in Los Angeles, Calif., 1954" style="border: 1px solid #ddd; width:100%"/>
       </a>
       <div class="caption">
-        <%= link_to_featured_work('Corridor filled with men and women tabulating ballots for California primary election in Los Angeles, Calif., 1954', 'xjzp2000zz-8911') %>
+        <a href="/catalog/20rg5200zz-89112">Corridor filled with men and women tabulating ballots for California primary election in Los Angeles, Calif., 1954</a>
       </div>
     </div>
     <div class="post-content">


### PR DESCRIPTION
This makes the links on the front page
go directly to the item. If the URLs
for these images change, this will need
to be updated.

Connected to URS-225