### PR TITLE
Delete border at base of search field on show page

### DIFF
--- a/app/assets/stylesheets/ursus/_show.scss
+++ b/app/assets/stylesheets/ursus/_show.scss
@@ -27,3 +27,7 @@ h3 {
   font-weight: 700;
   color: $ucla-darkest-blue;
 }
+
+.sort-pagination, .pagination-search-widgets {
+  border-bottom: 0px !important;
+}


### PR DESCRIPTION
+ modified:   app/assets/stylesheets/ursus/_show.scss

Before:
<img width="355" alt="Screen Shot 2019-05-30 at 3 00 49 PM" src="https://user-images.githubusercontent.com/751697/58667782-d68cfc00-82eb-11e9-83cb-a6d29aa90fe0.png">

After:
<img width="426" alt="Screen Shot 2019-05-30 at 3 00 36 PM" src="https://user-images.githubusercontent.com/751697/58667780-d5f46580-82eb-11e9-919c-3e8927753c62.png">

