### PR TITLE
Add place of origin metadata field CAL-586

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -139,7 +139,8 @@ class CatalogController < ApplicationController
     config.add_show_field ::Solrizer.solr_name('extent', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('funding_note', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('genre', :stored_searchable), link_to_facet: ::Solrizer.solr_name('genre', :facetable), separator_options: BREAKS
-    config.add_show_field ::Solrizer.solr_name("geographic_coordinates", :symbol)
+    config.add_show_field ::Solrizer.solr_name('place_of_origin', :stored_searchable), separator_options: BREAKS
+    config.add_show_field ::Solrizer.solr_name('geographic_coordinates', :symbol)
     config.add_show_field ::Solrizer.solr_name('location', :stored_searchable), link_to_facet: ::Solrizer.solr_name('location', :facetable)
     config.add_show_field 'local_identifier_ssm', label: 'Local identifier'
     config.add_show_field ::Solrizer.solr_name('medium', :stored_searchable)
@@ -154,8 +155,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'oclc_tesim_ssi', label: 'OCLC Number'
     config.add_show_field 'longitude_tesim', label: 'Latitude'
     config.add_show_field 'latitude_tesim', label: 'Longitude'
-    config.add_show_field 'uniform_title_tesim', label: 'Uniform title'
-    config.add_show_field 'place_of_origin_tesim', label: 'Place of Origin'
+    config.add_show_field 'uniform_title_tesim', label: 'Uniform Title'
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/services/search_field_service.rb
+++ b/app/services/search_field_service.rb
@@ -18,6 +18,7 @@ class SearchFieldService
     ::Solrizer.solr_name('named_subject', :stored_searchable),
     ::Solrizer.solr_name('normalized_date', :stored_searchable),
     ::Solrizer.solr_name('photographer', :stored_searchable),
+    ::Solrizer.solr_name('place_of_origin', :stored_searchable),
     ::Solrizer.solr_name('publisher', :stored_searchable),
     ::Solrizer.solr_name('subject', :stored_searchable),
     ::Solrizer.solr_name('title', :stored_searchable),

--- a/spec/services/search_field_service_spec.rb
+++ b/spec/services/search_field_service_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe SearchFieldService do
                                                          contributor_tesim creator_tesim description_tesim genre_tesim
                                                          identifier_tesim local_identifier_ssm location_tesim medium_tesim
                                                          named_subject_tesim normalized_date_tesim
-                                                         photographer_tesim publisher_tesim subject_tesim title_tesim ark_ssi ].join(' '))
+                                                         photographer_tesim place_of_origin_tesim publisher_tesim subject_tesim title_tesim ark_ssi ].join(' '))
   end
 end

--- a/spec/support/works.rb
+++ b/spec/support/works.rb
@@ -52,6 +52,7 @@ SECOND_WORK = {
   human_readable_resource_type_tesim: ['still image'],
   subject_tesim: ['Testing', 'RSpec'],
   photographer_tesim: ['Person 1', 'Person 2'],
+  place_of_origin_tesim: ['Boston, MA', 'Philadelphia, PA', 'New York, NY', 'Los Angeles, CA'],
   location_tesim: ['search_results_spec'], # to control what displays,
   thumbnail_path_ss: ["/assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png"],
   member_of_collection_ids_ssim: ['coll123']


### PR DESCRIPTION
Connected to [CAL-586](https://jira.library.ucla.edu/browse/CAL-586)

### Add a new field for Place of Origin
x | x
---|--- 
property	| place_of_origin
label | Place of origin
predicate	 | http://id.loc.gov/vocabulary/relators/prp.html
required	| no
multiple | yes
type	| string (english tokenization)
import from | 'Place of origin'
searchable | no
faceted | yes (but only in the Sinai Library Spotlight instance) 
search results	| hide
item view	| show
grouping	| Item Overview

---

+ modified: `app/controllers/catalog_controller.rb`
+ modified: `app/services/search_field_service.rb`
+ modified: `spec/services/search_field_service_spec.rb`
+ modified: `spec/support/works.rb`