### PR TITLE
Add an "Uniform title" metadata field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -150,12 +150,13 @@ class CatalogController < ApplicationController
     config.add_show_field ::Solrizer.solr_name('rights_holder', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('photographer', :stored_searchable), label: 'Photographer', link_to_facet: ::Solrizer.solr_name('photographer', :facetable)
     config.add_show_field ::Solrizer.solr_name('services_contact', :displayable), label: 'Rights services contact'
+    config.add_show_field ::Solrizer.solr_name('uniform_title', :stored_searchable)
+
     config.add_show_field 'ark_ssi', label: 'ARK'
     config.add_show_field 'support_tesim', label: 'Support'
     config.add_show_field 'oclc_tesim_ssi', label: 'OCLC Number'
     config.add_show_field 'longitude_tesim', label: 'Latitude'
     config.add_show_field 'latitude_tesim', label: 'Longitude'
-    config.add_show_field 'uniform_title_tesim', label: 'Uniform Title'
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/services/search_field_service.rb
+++ b/app/services/search_field_service.rb
@@ -22,6 +22,7 @@ class SearchFieldService
     ::Solrizer.solr_name('publisher', :stored_searchable),
     ::Solrizer.solr_name('subject', :stored_searchable),
     ::Solrizer.solr_name('title', :stored_searchable),
+    ::Solrizer.solr_name('uniform_title', :stored_searchable),
     'ark_ssi'
   ].join(' ').freeze
   def search_fields

--- a/spec/services/search_field_service_spec.rb
+++ b/spec/services/search_field_service_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe SearchFieldService do
                                                          contributor_tesim creator_tesim description_tesim genre_tesim
                                                          identifier_tesim local_identifier_ssm location_tesim medium_tesim
                                                          named_subject_tesim normalized_date_tesim
-                                                         photographer_tesim place_of_origin_tesim publisher_tesim subject_tesim title_tesim ark_ssi ].join(' '))
+                                                         photographer_tesim place_of_origin_tesim publisher_tesim subject_tesim title_tesim uniform_title_tesim ark_ssi ].join(' '))
   end
 end


### PR DESCRIPTION
Connected to CAL-584

Add a new field for Uniform Titles

x | x
---|---
property |	uniform_title
label |	Uniform title
predicate |	http://purl.org/dc/elements/1.1/title
required |	no
multiple |	yes
type |	string (english tokenization)
import from |	AltTitle.uniform
searchable |	yes
faceted	| no
search results | hide
item view |	show
grouping |	Item Overview

<img width="839" alt="Screen Shot 2019-06-12 at 10 46 16 AM" src="https://user-images.githubusercontent.com/751697/59379364-44352100-8d0b-11e9-97be-e84945203d9f.png">

---

+ modified: `app/controllers/catalog_controller.rb`
+ modified: `app/services/search_field_service.rb`
+ modified: `spec/services/search_field_service_spec.rb`