### PR TITLE
quick fix for collection facet bug

### DIFF
--- a/app/presenters/ursus/collection_block_presenter.rb
+++ b/app/presenters/ursus/collection_block_presenter.rb
@@ -30,7 +30,7 @@ module Ursus
     end
 
     def collection_description
-      description = collection_document['description_tesim']
+      description = Array.wrap(collection_document['description_tesim'])
       description[0]
     end
 


### PR DESCRIPTION
This fixes a where clicking a collection facet results in an error if
the collection description can't be found. It is submitted without
tests, which should follow asap.