### PR TITLE
Collection facet fix 2

### DIFF
--- a/app/presenters/ursus/collection_block_presenter.rb
+++ b/app/presenters/ursus/collection_block_presenter.rb
@@ -30,7 +30,7 @@ module Ursus
     end
 
     def collection_description
-      description = collection_document['description_tesim']
+      description = Array.wrap(collection_document['description_tesim'])
       description[0]
     end
 

--- a/app/presenters/ursus/collection_block_presenter.rb
+++ b/app/presenters/ursus/collection_block_presenter.rb
@@ -35,17 +35,17 @@ module Ursus
     end
 
     def collection_date_created
-      date = collection_document['date_created_tesim']
+      date = Array.wrap(collection_document['date_created_tesim'])
       date[0]
     end
 
     def collection_repository
-      repo = collection_document['repository_tesim']
+      repo = Array.wrap(collection_document['repository_tesim'])
       repo[0]
     end
 
     def collection_languages
-      languages = collection_document['languages_tesim']
+      languages = Array.wrap(collection_document['languages_tesim'])
       languages
     end
   end

--- a/spec/system/collection_block_view_spec.rb
+++ b/spec/system/collection_block_view_spec.rb
@@ -27,4 +27,13 @@ RSpec.feature "Search results page", :clean do
     expect(page).to have_content 'Repository'
     expect(page).to have_content 'Languages'
   end
+
+  context 'when collection data is missing' do
+    let(:collection) { { id: 'coll123' } }
+
+    it 'loads without an error' do
+      visit '/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Photographic%20Collection'
+      expect(page).to have_content 'Explore the Photographic Collection'
+    end
+  end
 end


### PR DESCRIPTION
Fixes a bug that caused CollectionBlockPresenter to error when collection metadata couldn't be found.

A previous PR fixed this bug for one method. This PR adds a similar fix to all applicable methods, plus a system test case that would have caught the bug.