### PR TITLE
Change Facets sidebar headline URS-424

### DIFF
--- a/app/assets/stylesheets/ursus/_facets.scss
+++ b/app/assets/stylesheets/ursus/_facets.scss
@@ -4,6 +4,7 @@
   }
   .facets-heading {
     line-height: 1 !important;
+    color: $ucla-darker-blue !important;
   }
 
   #facet-year_isim > div > div > ul {

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -4,7 +4,7 @@ en:
     application_name: 'UCLA Library Digital Collections'
     search:
       facets:
-        title: 'Refine your search'
+        title: 'Browse items'
       zero_results:
         title: 'No results found.'
         modify_search: ''

--- a/spec/system/facet_labels_spec.rb
+++ b/spec/system/facet_labels_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'The facet sidebar', :clean, type: :system do
 
   it 'has the text Refine your search not limit' do
     visit('/catalog')
-    expect(page).to have_content('Refine your search')
+    expect(page).to have_content('Browse items')
   end
 
   it 'has a Subject button for the selected facet display' do


### PR DESCRIPTION
Connected to [URS-424](https://jira.library.ucla.edu/browse/URS-424)

Update facets sidebar title site-wide from "Refine your search" to "Browse items".

- [x] New section title
- [x] Update font color to $ucla-darker-blue (#005587)

<img width="709" alt="Screen Shot 2019-06-13 at 3 59 25 PM" src="https://user-images.githubusercontent.com/751697/59472897-eb41b780-8df4-11e9-910a-485ad84933f5.png">

---

+ modified: `app/assets/stylesheets/ursus/_facets.scss`
+ modified: `config/locales/blacklight.en.yml`
+ modified: `spec/system/facet_labels_spec.rb`