### PR TITLE
Make the header image appear live

### DIFF
--- a/app/assets/stylesheets/ursus/_header_image_block.scss
+++ b/app/assets/stylesheets/ursus/_header_image_block.scss
@@ -6,6 +6,7 @@
     text-align: right;
     margin-right: 20px;
     font-size: 12px;
+    margin-right: 20px;
   }
   a:link {
     color: $gray !important;
@@ -25,7 +26,7 @@
   }
 }
 .jumbotron {
-  background-image: url('ucla_ladnn_cole_brothers_circus_elephants.jpg');
+  background-image: image-url('ucla_ladnn_cole_brothers_circus_elephants.jpg');
   background-size: cover;
   height: 600px;
   max-height: 600px;


### PR DESCRIPTION
The image is not appearing in https://ursus-test.library.ucla.edu/

The image is viewable locally but live it looks like this:  
<img width="1021" alt="Screen Shot 2019-06-19 at 12 46 26 PM" src="https://user-images.githubusercontent.com/751697/59795527-4a3d7b80-9290-11e9-8886-c0aaab9965eb.png">

---

+ modified: `app/assets/stylesheets/ursus/_header_image_block.scss`