### PR TITLE
Fixes on the Home page

### DIFF
--- a/app/assets/stylesheets/ursus/_collection_box.scss
+++ b/app/assets/stylesheets/ursus/_collection_box.scss
@@ -1,13 +1,13 @@
 .featured-collections {
-    color: $ucla-darker-blue;
-    font-weight: bold;
-    border-bottom: solid 2px $ucla-darker-blue;
-    margin-right: 15px;
-    margin-left: 15px;
+  color: $ucla-darker-blue;
+  font-weight: bold;
+  border-bottom: solid 2px $ucla-darker-blue;
+  margin-right: 15px;
+  margin-left: 15px;
 }
 
 .collection-link:hover {
-    text-decoration: none;    
+  text-decoration: none;
 }
 .collection-box {
   min-height: 300px;
@@ -15,45 +15,53 @@
   color: $white;
   display: flex;
   align-items: flex-end;
-
   h5 {
-      margin-left: 0.5em;
-      font-weight: bold;		      
+    margin-left: 0.5em;
+    font-weight: bold;
   }
 }
 
 .collection-box-one {
-    background-image: image-url('ladnn_collection.jpg');
-    background-size: cover;
+  background-image: image-url('ladnn_collection.jpg');
+  background-size: cover;
+  margin-top: 10px;
+  margin-right: -10px;
+  margin-bottom: 20px;
 }
 
 .collection-box-two {
-    background-image: image-url('bennett_collection.jpg');
-    background-size: cover;
+  background-image: image-url('bennett_collection.jpg');
+  background-size: cover;
+  margin-top: 10px;
+  margin-right: -10px;
+  margin-bottom: 20px;
+}.featured-collections {
+  color: $ucla-darker-blue;
+  font-weight: bold;
+  border-bottom: solid 2px $ucla-darker-blue;
 }
 
 .collection-box-three {
-    background-image: image-url('will_connell_collection.jpg');
-    background-size: cover;
+  background-image: image-url('will_connell_collection.jpg');
+  background-size: cover;
+  margin-top: 10px;
 }
 
-
 .collection-box-four {
-    background-image: image-url('collection_of_california_postcards.jpg');
-    background-size: cover;
+  background-image: image-url('collection_of_california_postcards.jpg');
+  background-size: cover;
+  margin-right: -10px;
+  margin-bottom: 20px;
 }
 
 .collection-box-five {
-    background-image: image-url('ethiopic_manuscript.jpg');
-    background-size: cover;
+  background-image: image-url('ethiopic_manuscript.jpg');
+  background-size: cover;
+  margin-right: -10px;
+  margin-bottom: 20px;
 }
 
 .collection-box-six {
-    background-image: image-url('arkotov_collection.jpg');
-    background-size: cover;
+  background-image: image-url('arkotov_collection.jpg');
+  background-size: cover;
 }
-
-
-
-
- 

--- a/app/views/catalog/_image_grid.html.erb
+++ b/app/views/catalog/_image_grid.html.erb
@@ -1,38 +1,38 @@
-<div class="container-fluid collection-boxes">
-    <div class="row">
-	<a class="col mb-2 collection-link" href="/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Los+Angeles+Daily+News+Negatives">
-	    <div class="collection-box collection-box-one">
-		<h5>Los Angeles Daily News Negatives</h5>
-	    </div>
-	</a>
-	<a class="col mb-2 collection-link" href="/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Bennett+%28Walter+E.%29+Photographic+Collection%2C+1937-1983+%28bulk+1952-1982%29">
-	    <div class="collection-box collection-box-two">
-		<h5>Walter E. Bennet Photographic Collection, 1937-1983</h5>
-	    </div>
-	</a>
-	<a class="col mb-2 collection-link" href="/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Connell+%28Will%29+Papers">
-	    <div class="collection-box collection-box-three">
-		<h5>Will Connell Papers</h5>
-	    </div>
-	</a>
-    </div>
+<div class='container-fluid collection-boxes'>
+  <div class='row'>
+    <a class='col collection-link' href="/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Los+Angeles+Daily+News+Negatives">
+      <div class='collection-box collection-box-one'>
+        <h5>Los Angeles Daily News Negatives</h5>
+      </div>
+    </a>
+    <a class="col collection-link" href="/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Bennett+%28Walter+E.%29+Photographic+Collection%2C+1937-1983+%28bulk+1952-1982%29">
+      <div class="collection-box collection-box-two">
+        <h5>Walter E. Bennet Photographic Collection, 1937-1983</h5>
+      </div>
+    </a>
+    <a class='col collection-link' href="/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Connell+%28Will%29+Papers">
+      <div class='collection-box collection-box-three'>
+        <h5>Will Connell Papers</h5>
+      </div>
+    </a>
+  </div>
 
-    <div class="row">
-	<a class="col mb-2 collection-link" href="/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Collection+of+California+Postcards">
-	    <div class="collection-box collection-box-four">
-		<div class="spacer"></div>
-		<h5>Collection of California Postcards</h5>
-	    </div>
-	</a>
-	<a class="col mb-2 collection-link" href="">
-	    <div class="collection-box collection-box-five">
-		<h5>Ethiopic Manuscripts</h5>
-	    </div>
-	</a>
-	<a class="col mb-2 collection-link"  href="/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Arkatov+%28James%29+Collection">
-	    <div class="collection-box collection-box-six">
-		<h5>James Arkatov World Music Photographs</h5>
-	    </div>
-	</a>
-    </div>
+  <div class='row'>
+    <a class="col mb-2 collection-link" href="/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Collection+of+California+Postcards">
+      <div class='collection-box collection-box-four'>
+        <div class='spacer'></div>
+          <h5>Collection of California Postcards</h5>
+        </div>
+    </a>
+    <a class='col mb-2 collection-link' href="">
+      <div class="collection-box collection-box-five">
+        <h5>Ethiopic Manuscripts</h5>
+      </div>
+    </a>
+    <a class='col mb-2 collection-link' href="/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Arkatov+%28James%29+Collection">
+      <div class="collection-box collection-box-six">
+        <h5>James Arkatov World Music Photographs</h5>
+      </div>
+    </a>
+  </div>
 </div>

--- a/app/views/catalog/_jumbotron.html.erb
+++ b/app/views/catalog/_jumbotron.html.erb
@@ -6,7 +6,7 @@
       <%= render 'ucla_home_rectangle' %>
     </div>
     <p class='header-image-block'>
-      <a class='header-image-block' href='/catalog/x2gp2000zz-89112'>Elephants from Cole Brothers Circus crossing Olive Street with police escort in Los Angeles, Calif., 1953</a><br>Collection: <a class='header-image-block' href='/catalog/x2gp2000zz-89112'>Los Angeles Daily News Negatives</a>
+      <a class='header-image-block' href='/catalog/x2gp2000zz-89112'>Elephants from Cole Brothers Circus crossing Olive Street with police escort in Los Angeles, Calif., 1953</a><br>Collection: <a class='header-image-block' href='/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Los+Angeles+Daily+News+Negatives'>Los Angeles Daily News Negatives</a>
     </p>
   </div>
 <% end %>


### PR DESCRIPTION
+ Corrects the link to the LADNN Collection link under the masthead image
+ Adjusts the margins in between the image grid

#### Also
+ Deletes tabs, extra lines, and extra spaces on some files
+ Changes double quotes to single when possible
+ Fixes code alignment for better readability
+ Deletes duplicate code

<img width="1117" alt="Screen Shot 2019-06-21 at 4 48 08 PM" src="https://user-images.githubusercontent.com/751697/59956301-6aae3700-9444-11e9-8532-ec109771293a.png">

---

+ modified:  `app/assets/stylesheets/ursus/_collection_box.scss`
+ modified: `app/views/catalog/_image_grid.html.erb`
+ modified: `app/views/catalog/_jumbotron.html.erb`