### PR TITLE
Add a "Support" metadata field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -156,10 +156,10 @@ class CatalogController < ApplicationController
     config.add_show_field ::Solrizer.solr_name('rights_holder', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('photographer', :stored_searchable), label: 'Photographer', link_to_facet: ::Solrizer.solr_name('photographer', :facetable)
     config.add_show_field ::Solrizer.solr_name('services_contact', :displayable), label: 'Rights services contact'
+    config.add_show_field 'support_tesim', label: 'Support'
     config.add_show_field ::Solrizer.solr_name('uniform_title', :stored_searchable)
 
     config.add_show_field 'ark_ssi', label: 'ARK'
-    config.add_show_field 'support_tesim', label: 'Support'
     config.add_show_field 'oclc_tesim_ssi', label: 'OCLC Number'
     config.add_show_field 'longitude_tesim', label: 'Latitude'
     config.add_show_field 'latitude_tesim', label: 'Longitude'


### PR DESCRIPTION
x | x
---|---
property | support
label | Support
predicate | http://id.loc.gov/ontologies/bibframe/BaseMaterial
required | no
multiple | yes
type | string (english tokenization)
import from | Support
searchable | no
faceted | no
search results  | hide
item view | show
grouping | Physical Description

---

+ `modified: `app/controllers/catalog_controller.rb`