### PR TITLE
robots.txt files to allow or disallow web crawling

### DIFF
--- a/public/robots_allow.txt
+++ b/public/robots_allow.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:

--- a/public/robots_disallow.txt
+++ b/public/robots_disallow.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
I created two different robots.txt files, in addition to the default (empty) file, that will allow us to specify a configuration based on the server environment we're running the site in. This can be managed manually or via Ansible.