### PR TITLE
Fix Link on Linked Collection Name on show page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -138,7 +138,7 @@ class CatalogController < ApplicationController
     config.add_show_field ::Solrizer.solr_name('human_readable_resource_type', :stored_searchable), label: 'Resource Type', link_to_facet: ::Solrizer.solr_name('human_readable_resource_type', :facetable)
     config.add_show_field ::Solrizer.solr_name('format', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('identifier', :stored_searchable)
-    config.add_show_field ::Solrizer.solr_name('member_of_collections', :symbol), label: 'Collection', link_to_facet: ::Solrizer.solr_name('member_of_collections', :facetable)
+    config.add_show_field 'member_of_collections_ssim', label: 'Collection', link_to_facet: 'member_of_collections_ssim'
     config.add_show_field ::Solrizer.solr_name('caption', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('alternative_title', :stored_searchable)
     config.add_show_field ::Solrizer.solr_name('dimensions', :stored_searchable)


### PR DESCRIPTION
Connected to [URS-441](https://jira.library.ucla.edu/browse/URS-441)

Linked Collection Name on Item links to 404
See: https://ursus.library.ucla.edu/catalog/w3szd100zz-89112

The link to the collection name has the href="https://ursus.library.ucla.edu/catalog?f%5Bmember_of_collections_sim%5D%5B%5D=Arkatov+%28James%29+Collection" and returns a message:

"We're sorry, but something went wrong."

---

+ modified: `app/controllers/catalog_controller.rb`