### PR TITLE
Fix spelling error on Home page - on the Bennett collection image

### DIFF
--- a/app/views/catalog/_image_grid.html.erb
+++ b/app/views/catalog/_image_grid.html.erb
@@ -7,7 +7,7 @@
     </a>
     <a class="col-md-6 col-lg-4 col-xs-12 col-sm-6 collection-link" href="/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Bennett+%28Walter+E.%29+Photographic+Collection%2C+1937-1983+%28bulk+1952-1982%29">
       <div class="collection-box collection-box-two">
-        <h5>Walter E. Bennet Photographic Collection, 1937-1983</h5>
+        <h5>Walter E. Bennett Photographic Collection, 1937-1983</h5>
       </div>
     </a>
     <a class='col-md-6 col-lg-4 col-xs-12 col-sm-6 collection-link' href="/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Connell+%28Will%29+Papers">


### PR DESCRIPTION
The title on the home page has only one ’t” in Bennett, it should have 2

---

Changes to be committed:
+ modified: `app/views/catalog/_image_grid.html.erb`