### PR TITLE
cache CollectionBlockPresenter.collection_document

### DIFF
--- a/app/presenters/ursus/collection_block_presenter.rb
+++ b/app/presenters/ursus/collection_block_presenter.rb
@@ -24,9 +24,11 @@ module Ursus
     end
 
     def collection_document
-      return unless @response['response']['docs'].first['member_of_collections_ssim']
-      collection_id = @response['response']['docs'].first['member_of_collection_ids_ssim'][0]
-      SolrDocument.find(collection_id)
+      @collection_document ||= begin
+        return unless @response['response']['docs'].first['member_of_collections_ssim']
+        collection_id = @response['response']['docs'].first['member_of_collection_ids_ssim'][0]
+        SolrDocument.find(collection_id)
+      end
     end
 
     def collection_description

--- a/spec/presenters/ursus/collection_block_presenter_spec.rb
+++ b/spec/presenters/ursus/collection_block_presenter_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe Ursus::CollectionBlockPresenter do
   end
 
   describe '#collection_document' do
+    it 'caches the SolrDocument' do
+      allow(SolrDocument).to receive(:find).and_return('First Solr Call')
+      collection_presenter.collection_document
+      allow(SolrDocument).to receive(:find).and_return('Second Solr Call')
+      expect(collection_presenter.collection_document).to eq 'First Solr Call'
+    end
+
     it 'can get the collection document' do
       expect(collection_presenter.collection_document[:id]).to eq('coll123')
     end


### PR DESCRIPTION
As is, an object of this class makes a new call to SolrDocument.find for every metadata field that is requested. Unless Blacklight::Solr::Document is written to cache these requests (which we don't want to count on) it will make a fresh network call to solr each time.

If it is querying Solr for each field, that could be contributing to the performance issues Sharon has noted on these collection pages.