### PR TITLE
Fix: Thumbnail tag fails if document["title_tesim"] is nil

### DIFF
--- a/app/presenters/ursus/thumbnail_presenter.rb
+++ b/app/presenters/ursus/thumbnail_presenter.rb
@@ -9,7 +9,7 @@ module Ursus
     # @param [Hash] url_options to pass to #link_to_document
     # @return [String]
     def thumbnail_tag(image_options = {}, url_options = {})
-      alt_title = document["title_tesim"][0]
+      alt_title = Array.wrap(document["title_tesim"])[0]
       image_options[:alt] = alt_title
 
       value = thumbnail_value(image_options)


### PR DESCRIPTION
Connected to [449](https://jira.library.ucla.edu/browse/URS-449)

Changes to be committed:
+ modified: `app/presenters/ursus/thumbnail_presenter.rb`