### PR TITLE
Add Summary metadata field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -161,6 +161,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'rights_holder_tesim'
     config.add_show_field 'services_contact_ssm', label: 'Rights services contact'
     config.add_show_field 'subject_tesim', link_to_facet: 'subject_sim', separator_options: BREAKS
+    config.add_show_field 'summary_tesim', label: 'Summary'
     config.add_show_field 'support_tesim', label: 'Support'
     config.add_show_field 'title_tesim'
     config.add_show_field 'uniform_title_tesim'

--- a/app/services/search_field_service.rb
+++ b/app/services/search_field_service.rb
@@ -21,6 +21,7 @@ class SearchFieldService
     ::Solrizer.solr_name('place_of_origin', :stored_searchable),
     ::Solrizer.solr_name('publisher', :stored_searchable),
     ::Solrizer.solr_name('subject', :stored_searchable),
+    ::Solrizer.solr_name('summary', :stored_searchable),
     ::Solrizer.solr_name('title', :stored_searchable),
     ::Solrizer.solr_name('uniform_title', :stored_searchable),
     'ark_ssi'

--- a/config/metadata/note_metadata.yml
+++ b/config/metadata/note_metadata.yml
@@ -1,2 +1,3 @@
 description_tesim: 'Description'
 caption_tesim: 'Caption'
+summary_tesim: 'Summary'

--- a/spec/services/search_field_service_spec.rb
+++ b/spec/services/search_field_service_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe SearchFieldService do
                                                          contributor_tesim creator_tesim description_tesim genre_tesim
                                                          identifier_tesim local_identifier_ssm location_tesim medium_tesim
                                                          named_subject_tesim normalized_date_tesim
-                                                         photographer_tesim place_of_origin_tesim publisher_tesim subject_tesim title_tesim uniform_title_tesim ark_ssi ].join(' '))
+                                                         photographer_tesim place_of_origin_tesim publisher_tesim subject_tesim summary_tesim title_tesim uniform_title_tesim ark_ssi ].join(' '))
   end
 end


### PR DESCRIPTION
Connected to [CAL-712](https://jira.library.ucla.edu/browse/CAL-712)

### Add a metadata field for Summary

property | summary
-- | --
label | Summary
predicate | http://id.loc.gov/ontologies/bibframe/Summary
required | no
multiple | yes
type | string (english tokenization)
import from | Summary
searchable | yes
faceted | no
search results | hide
item view | show
grouping | Notes

---

<img width="666" alt="Screen Shot 2019-08-15 at 5 57 21 PM" src="https://user-images.githubusercontent.com/751697/63136391-9f42f880-bf86-11e9-8046-49cf3a45dd69.png">

---

Changes to be committed:
+ modified: `app/controllers/catalog_controller.rb`
+ modified: `app/services/search_field_service.rb`
+ modified: `config/metadata/note_metadata.yml`
+ modified: `spec/services/search_field_service_spec.rb`