### PR TITLE
Manifest from service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ gem 'bootstrap', '~> 4.0'
 gem 'coveralls', require: false
 gem 'devise'
 gem 'devise-guests', '~> 0.6'
+gem 'flipflop'
 gem 'font-awesome-rails', '~> 4.7', '>= 4.7.0.2'
 gem 'httparty'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,8 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
+    flipflop (2.6.0)
+      activesupport (>= 4.0)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
     globalid (0.4.2)
@@ -424,6 +426,7 @@ DEPENDENCIES
   dotenv-rails
   equivalent-xml
   factory_bot_rails
+  flipflop
   font-awesome-rails (~> 4.7, >= 4.7.0.2)
   httparty
   jquery-rails

--- a/app/services/iiif_service.rb
+++ b/app/services/iiif_service.rb
@@ -4,4 +4,12 @@ class IiifService
   def src(request, document)
     "#{request&.base_url}/uv/uv.html#?manifest=#{Rails.application.config.iiif_url}/#{document.id}/manifest"
   end
+
+  def iiif_manifest_url(document)
+    if Flipflop.use_manifest_store? && document[:iiif_manifest_url_ssi]
+      document[:iiif_manifest_url_ssi]
+    else
+      "#{Rails.application.config.iiif_url}/#{document.id}/manifest"
+    end
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,10 @@ Bundler.require(*Rails.groups)
 
 module Ursus
   class Application < Rails::Application
+    # Before filter for Flipflop dashboard. Replace with a lambda or method name
+    # defined in ApplicationController to implement access control.
+    config.flipflop.dashboard_access_filter = -> { head :forbidden }
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 Rails.application.configure do
+  # Before filter for Flipflop dashboard. Replace with a lambda or method name
+  # defined in ApplicationController to implement access control.
+  config.flipflop.dashboard_access_filter = nil
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 Rails.application.configure do
+  # Before filter for Flipflop dashboard. Replace with a lambda or method name
+  # defined in ApplicationController to implement access control.
+  config.flipflop.dashboard_access_filter = nil
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+Flipflop.configure do
+  # Strategies will be used in the order listed here.
+  strategy :cookie
+  strategy :active_record
+  strategy :default
+
+  # Other strategies:
+  #
+  # strategy :sequel
+  # strategy :redis
+  #
+  # strategy :query_string
+  # strategy :session
+  #
+  # strategy :my_strategy do |feature|
+  #   # ... your custom code here; return true/false/nil.
+  # end
+
+  # Declare your features, e.g:
+  #
+  # feature :world_domination,
+  #   default: true,
+  #   description: "Take over the world."
+end

--- a/config/features.rb
+++ b/config/features.rb
@@ -23,4 +23,8 @@ Flipflop.configure do
   # feature :world_domination,
   #   default: true,
   #   description: "Take over the world."
+
+  feature :use_manifest_store,
+          default: false,
+          description: "Load IIIF manifests from the external manifest-store service when possible."
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 
 # frozen_string_literal: true
 Rails.application.routes.draw do
+  mount Flipflop::Engine => "/flipflop"
   get '/about', to: 'static#about'
 
   concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new

--- a/db/migrate/20190830185129_create_features.rb
+++ b/db/migrate/20190830185129_create_features.rb
@@ -1,0 +1,10 @@
+class CreateFeatures < ActiveRecord::Migration[5.1]
+  def change
+    create_table :flipflop_features do |t|
+      t.string :key, null: false
+      t.boolean :enabled, null: false, default: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180918212347) do
+ActiveRecord::Schema.define(version: 20190830185129) do
 
   create_table "bookmarks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "user_id", null: false
@@ -22,6 +22,13 @@ ActiveRecord::Schema.define(version: 20180918212347) do
     t.datetime "updated_at", null: false
     t.index ["document_id"], name: "index_bookmarks_on_document_id"
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
+
+  create_table "flipflop_features", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "key", null: false
+    t.boolean "enabled", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "searches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/services/iiif_service_spec.rb
+++ b/spec/services/iiif_service_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IiifService do
+  let(:service) { described_class.new }
+  let(:solr_document) do
+    SolrDocument.new(id: 'abc123',
+                     iiif_manifest_url_ssi: 'https://manifest.store/abc123/manifest')
+  end
+
+  before do
+    allow(Rails.application.config).to receive(:iiif_url).and_return('https://californica.url/concern/works')
+  end
+
+  describe '#iiif_manifest_url' do
+    context 'when a url is stored and feature enabled' do
+      it 'uses that url' do
+        allow(Flipflop).to receive(:use_manifest_store?).and_return(true)
+        expect(service.iiif_manifest_url(solr_document)).to eq 'https://manifest.store/abc123/manifest'
+      end
+    end
+
+    context 'when a url is stored but feature is disabled' do
+      it 'builds a local url' do
+        allow(Flipflop).to receive(:use_manifest_store?).and_return(false)
+        expect(service.iiif_manifest_url(solr_document)).to eq 'https://californica.url/concern/works/abc123/manifest'
+      end
+    end
+
+    context 'when nothing is stored' do
+      let(:solr_document) { SolrDocument.new(id: 'abc123') }
+
+      it 'builds a local url' do
+        allow(Flipflop).to receive(:use_manifest_store?).and_return(true)
+        expect(service.iiif_manifest_url(solr_document)).to eq 'https://californica.url/concern/works/abc123/manifest'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Feature is wrapped in a Flipflop toggle. If the flag is disabled, or if the 'iiif_manifest_url' field is empty, then defaults to serving a manifest directly from californica.

The flag is disabled by default, because we need to wait for CORS headers to be set on the service's end before the feature will work.