### PR TITLE
enable manifest-store by default

### DIFF
--- a/app/services/iiif_service.rb
+++ b/app/services/iiif_service.rb
@@ -2,7 +2,7 @@
 
 class IiifService
   def src(request, document)
-    "#{request&.base_url}/uv/uv.html#?manifest=#{iiif_manifest_url(document)}"
+    "#{request&.base_url}/uv/uv.html#?manifest=#{CGI.escape(iiif_manifest_url(document))}"
   end
 
   def iiif_manifest_url(document)

--- a/config/features.rb
+++ b/config/features.rb
@@ -25,6 +25,6 @@ Flipflop.configure do
   #   description: "Take over the world."
 
   feature :use_manifest_store,
-          default: false,
+          default: true,
           description: "Load IIIF manifests from the external manifest-store service when possible."
 end

--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -5,6 +5,7 @@
 <!DOCTYPE html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <link rel="icon" href="favicon.ico">
     <link rel="stylesheet" type="text/css" href="uv.css">

--- a/spec/services/iiif_service_spec.rb
+++ b/spec/services/iiif_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe IiifService do
   let(:service) { described_class.new }
   let(:solr_document) do
     SolrDocument.new(id: 'abc123',
-                     iiif_manifest_url_ssi: 'https://manifest.store/abc123/manifest')
+                     iiif_manifest_url_ssi: 'https://manifest.store/ark%3A%2Fabc%2F123/manifest')
   end
 
   before do
@@ -17,7 +17,7 @@ RSpec.describe IiifService do
     context 'when a url is stored and feature enabled' do
       it 'uses that url' do
         allow(Flipflop).to receive(:use_manifest_store?).and_return(true)
-        expect(service.iiif_manifest_url(solr_document)).to eq 'https://manifest.store/abc123/manifest'
+        expect(service.iiif_manifest_url(solr_document)).to eq 'https://manifest.store/ark%3A%2Fabc%2F123/manifest'
       end
     end
 


### PR DESCRIPTION
All changes outside `features.rb` are needed to ensure a properly-escaped manifest URL makes it into UV inside the iframe.