### PR TITLE
Replace placeholder text in search bar

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -4,10 +4,18 @@
   <% if search_fields.length > 1 %>
     <label for="search_field" class="sr-only"><%= t('blacklight.search.form.search_field.label') %></label>
   <% end %>
-  <div class="input-group">
-    <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
-    <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search-q q form-control", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) }  %>
 
+  <div class="input-group">
+  <% url = request.original_url %>
+  <% if url.include?('member_of_collections_ssim') %>
+    <% placeholder_text = t('blacklight.search.form.search.placeholder_collection') %>
+    <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
+    <%= text_field_tag :q, params[:q], placeholder: "#{placeholder_text}", class: "search-q q form-control", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) } %>
+  <% else %>
+    <% placeholder_text = t('blacklight.search.form.search.placeholder') %>
+    <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
+    <%= text_field_tag :q, params[:q], placeholder: "#{placeholder_text}", class: "search-q q form-control", id: "q", autofocus: presenter.autofocus?, data: { autocomplete_enabled: presenter.autocomplete_enabled?, autocomplete_path: search_action_path(action: :suggest) } %>
+  <% end %>
     <span class="input-group-append">
       <button type="submit" class="btn search-btn" id="search">
         <%= blacklight_icon :search %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -14,6 +14,7 @@ en:
       form:
         search:
           placeholder: 'Search UCLA Library Digital Collections'
+          placeholder_collection: 'Search this collection'
       new_search: 'New Search'
       fields:
         facet:

--- a/spec/system/collection_block_view_spec.rb
+++ b/spec/system/collection_block_view_spec.rb
@@ -26,6 +26,19 @@ RSpec.feature "Search results page", :clean do
     expect(page).to have_content 'Date created'
     expect(page).to have_content 'Repository'
     expect(page).to have_content 'Languages'
+    expect(page).to have_xpath("//input[@placeholder='Search this collection']")
+  end
+
+  context 'the placeholder displays the correct search prompt' do
+    it 'when on a search open to a particular collection' do
+      visit '/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Photographic%20Collection'
+      expect(page).to have_xpath("//input[@placeholder='Search this collection']")
+    end
+
+    it 'when on the home page' do
+      visit '/'
+      expect(page).to have_xpath("//input[@placeholder='Search UCLA Library Digital Collections']")
+    end
   end
 
   context 'when collection data is missing' do


### PR DESCRIPTION
Connected to [URS-477](https://jira.library.ucla.edu/browse/URS-477)

### Replace placeholder text in search bar at collection level to indicate scoped search.

<img width="975" alt="Screen Shot 2019-10-04 at 12 37 28 PM" src="https://user-images.githubusercontent.com/751697/66235047-0e45ef00-e6a4-11e9-9368-70df255e53f0.png">

---

#### When a search at the level is scoped to the collection, not the entire catalog
<img width="1009" alt="Screen Shot 2019-10-04 at 12 37 42 PM" src="https://user-images.githubusercontent.com/751697/66235054-100fb280-e6a4-11e9-8806-3900d996388e.png">

---

modified:   app/views/catalog/_search_form.html.erb
modified:   config/locales/blacklight.en.yml
modified:   spec/system/collection_block_view_spec.rb