### PR TITLE
remove stdin_open, tty: true from docker-compose.yml

### DIFF
--- a/docker-compose-standalone.yml
+++ b/docker-compose-standalone.yml
@@ -22,8 +22,6 @@ services:
       - .:/ursus
       - bundle_dir:/usr/local/bundle
     working_dir: /ursus
-    stdin_open: true
-    tty: true
   db:
     image: mysql:5.6
     volumes:

--- a/docker-compose-with-californica.yml
+++ b/docker-compose-with-californica.yml
@@ -4,8 +4,6 @@ services:
   web:
     image: uclalibrary/ursus
     hostname: ursus
-    stdin_open: true
-    tty: true
     env_file:
       - ./dotenv.sample
     environment:


### PR DESCRIPTION
These settings were added to support running byebug inside the container. I am removing them because they are not the best way to accomplish this, and we are running into trouble with docker on Travis. This might help.

The recommended way to access byebug is to shut down the web container and start it with `docker-compose up`:

```
docker-compose stop web
docker-compose run --service-ports web
```