### PR TITLE
Add collection-title metadata field to search results list view

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -111,13 +111,15 @@ class CatalogController < ApplicationController
     # handler defaults, or have no facets.
     config.add_facet_fields_to_solr_request!
 
-    # solr fields to be displayed in the index (search results / list view
+    # solr fields to be displayed in the index search results / list view
     #   The   config.add_index_field ::Solrizer.solr_name('title', :stored_searchable), label: 'Title', itemprop: 'name', if: false
+
     config.add_index_field 'description_tesim', itemprop: 'description', helper_method: :render_truncated_description
     config.add_index_field 'sort_year_isi', label: 'Date Created'
     # config.add_index_field ::Solrizer.solr_name('normalized_date', :stored_searchable), itemprop: 'dateCreated'
     config.add_index_field 'human_readable_resource_type_tesim', label: 'Resource Type', link_to_facet: 'human_readable_resource_type_sim'
     config.add_index_field 'photographer_tesim', label: 'Photographer', link_to_facet: 'photographer_sim'
+    config.add_index_field 'member_of_collections_ssim', label: 'Collection', link_to_facet: 'member_of_collections_ssim'
 
     # solr fields to be displayed in the show (single result) view
     # The ordering of the field names is the order of the display

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -1,22 +1,16 @@
 <% doc_presenter = index_presenter(document) %>
-  <div class="metadata-thumbnail-wrapper">
-    <%# default partial to display solr document fields in catalog index view -%>
+<div class="metadata-thumbnail-wrapper">
+  <%# default partial to display solr document fields in catalog index view -%>
 
-    <dl class="document-metadata dl-invert row">
-      <% doc_presenter.fields_to_render.each do |field_name, field| -%>
-        
-        <dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= render_index_field_label document, field: field_name %></dt>
+  <dl class="document-metadata dl-invert row">
 
-        <dd class="blacklight-<%= field_name.parameterize %> col-md-9"><%= doc_presenter.field_value field %></dd>
-       
-      <% end -%>
-    </dl>
+    <% doc_presenter.fields_to_render.each do | field_name, field | -%>
+      <dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= render_index_field_label document, field: field_name %></dt>
+      <dd class="blacklight-<%= field_name.parameterize %> col-md-9"><%= doc_presenter.field_value field %></dd>
+    <% end -%>
+  </dl>
 
-    <% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({}, counter: document_counter_with_offset(document_counter)) %>
-   
-    <div class="document-thumbnail">
-      <%= tn %>
-    </div>
-   
-    <% end %>
-  </div>
+  <% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({}, counter: document_counter_with_offset(document_counter)) %>
+    <div class="document-thumbnail"><%= tn %></div>
+  <% end %>
+</div>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe CatalogController, type: :controller do
       ['description_tesim',
        'sort_year_isi',
        'human_readable_resource_type_tesim',
-       'photographer_tesim']
+       'photographer_tesim',
+       'member_of_collections']
     end
     it { expect(index_fields).to contain_exactly(*expected_index_fields) }
   end


### PR DESCRIPTION
Connected to: [URS-476](https://jira.library.ucla.edu/browse/URS-476)

- [x] Add collection-title metadata field to search results (list view)
- [x] Place as last item

---

<img width="787" alt="Screen Shot 2019-10-08 at 2 53 27 PM" src="https://user-images.githubusercontent.com/751697/66436256-6ef26600-e9db-11e9-90ab-53dbbd312dc1.png">

---

Changes to be committed:
+ modified:   app/controllers/catalog_controller.rb
+ modified:   app/views/catalog/_index.html.erb
+ modified:   spec/controllers/catalog_controller_spec.rb