### PR TITLE
Fix inconsistent "Start Over" / new search behavior

### DIFF
--- a/app/views/catalog/_startover.html.erb
+++ b/app/views/catalog/_startover.html.erb
@@ -1,5 +1,5 @@
 <% if query_has_constraints? %>
   <div class='startover-container'>
-    <%=link_to t('blacklight.search.start_over'), start_over_path, class: "catalog_startOverLink" %>
+    <%=link_to t('blacklight.search.start_over'), '/catalog?utf8=%E2%9C%93&q=&search_field=all_fields', class: "catalog_startOverLink" %>
   </div>
 <% end %>


### PR DESCRIPTION
Connected to  [URS-474](https://jira.library.ucla.edu/browse/URS-474)

1. Clicking on "Start Over" should return user to [default search page](https://ursus.library.ucla.edu/catalog?utf8=%E2%9C%93&q=&search_field=all_fields)
2. Clearing all filters should return user to the [default search page](https://ursus.library.ucla.edu/catalog?utf8=%E2%9C%93&q=&search_field=all_fields)

Default search page:
https://ursus.library.ucla.edu/catalog?utf8=%E2%9C%93&q=&search_field=all_fields

---

Changes to be committed:
+ modified:   app/views/catalog/_startover.html.erb
