### PR TITLE
Fix Overlap of Metadata field and value in first search result display

### DIFF
--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -1,14 +1,17 @@
 <% doc_presenter = index_presenter(document) %>
 <div class="metadata-thumbnail-wrapper">
-  <%# default partial to display solr document fields in catalog index view -%>
+<!-- default partial to display solr document fields in catalog index view -->
 
-  <dl class="document-metadata dl-invert row">
-
-    <% doc_presenter.fields_to_render.each do | field_name, field | -%>
-      <dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= render_index_field_label document, field: field_name %></dt>
-      <dd class="blacklight-<%= field_name.parameterize %> col-md-9"><%= doc_presenter.field_value field %></dd>
-    <% end -%>
-  </dl>
+<dl class="document-metadata dl-invert row">
+  <% doc_presenter.fields_to_render.each do | field_name, field | -%>
+    <dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= render_index_field_label document, field: field_name %></dt>
+    <dd class="blacklight-<%= field_name.parameterize %> col-md-9"><%= doc_presenter.field_value field %></dd>
+    <% if field_name = "Description" %>
+      <dt class="blacklight-<%= field_name.parameterize %> col-md-3"></dt>
+      <dd class="blacklight-<%= field_name.parameterize %> col-md-9">&nbsp;&nbsp;&nbsp;</dd>
+    <% end %>    
+  <% end -%>
+</dl>
 
   <% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({}, counter: document_counter_with_offset(document_counter)) %>
     <div class="document-thumbnail"><%= tn %></div>


### PR DESCRIPTION
Connected to [URS-433](https://jira.library.ucla.edu/browse/URS-433)

### Fix Overlap of Metadata field and value in first search result display 

This fix may work well enough but, IMHO, is not ideal.
From what I can tell, the CSS is such that the page display varies metadata indentation and spacing.
The metadata field overlap only occurs when there is only one field with data.
If this condition never occurs in practice then this is not a problem.

After much digging through the CSS and iterating through many settings; I finally added code that adds a blank row if only Description metadata field is present. I don't find this a good solution but it may be sufficient for the moment if the alternative is time consuming refactor the CSS.

The overlap is viewable by searching for ustad in californica-stage:

overlap_problem

(If that entry is not available locally, you can either search oust an an entry with only the Description field present or re-create locally by removing displayable metadata except for Description.