### PR TITLE
Remove "Cite this item" from item pages until issues can be resolved

### DIFF
--- a/app/views/catalog/_document_action.html.erb
+++ b/app/views/catalog/_document_action.html.erb
@@ -1,4 +1,4 @@
-<%= link_to document_action_label(document_action_config.key, document_action_config),
+<%#= link_to document_action_label(document_action_config.key, document_action_config),
             document_action_path(document_action_config, (local_assigns.has_key?(:url_opts) ? url_opts : {}).merge(({id: document} if document) || {})),
             id: document_action_config.fetch(:id, "#{document_action_config.key}Link"),
             data: {}.merge(({ blacklight_modal: "trigger" } if document_action_config.modal != false) || {}) %>

--- a/app/views/catalog/_uv.html.erb
+++ b/app/views/catalog/_uv.html.erb
@@ -12,7 +12,7 @@
         allowfullscreen
         frameborder='0'>
     </iframe>
-    <div class='link-and-icon'><i class='fa fa-link' aria-hidden="true"></i><%= render 'show_tools' %></div>
+      <!-- <div class='link-and-icon'><i class='fa fa-link' aria-hidden="true"></i><%= render 'show_tools' %></div> -->
   </div>
 </div>
 

--- a/spec/system/next_previous_on_show_spec.rb
+++ b/spec/system/next_previous_on_show_spec.rb
@@ -25,6 +25,6 @@ RSpec.describe 'the result bar displays the correct links', :clean, type: :syste
     expect(page).to have_content '1 of 2 results'
     expect(page).to have_content 'Back to Search'
     expect(page).to have_content 'New Search'
-    expect(page).to have_content 'Cite This Item'
+    expect(page).not_to have_content 'Cite This Item'
   end
 end

--- a/spec/system/view_work_spec.rb
+++ b/spec/system/view_work_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe 'View a Work', type: :system, js: true do
     expect(page).not_to have_content 'Tools'
 
     # we DO want the citation link
-    expect(page.find('a#citationLink')).to have_content 'Cite This Item'
+    # expect(page.find('a#citationLink')).to have_content 'Cite This Item'
 
     # we DO NOT want the SMS This or Email links
     expect(page).to_not have_content 'SMS This'


### PR DESCRIPTION
Connected to [URS-511](https://jira.library.ucla.edu/browse/URS-511)

Currently, the "Cite this item" has several issues that are not acceptable for the Dec. 10 launch. We would like the feature removed until we can resolve the issues.

Acceptance

"Cite this item" feature is not available on item pages in Ursus.

**I just commented it out so it will be there when we want to add it back in and fix it.**

---

Changes to be committed:
+ modified: `app/views/catalog/_document_action.html.erb`
+ modified: `app/views/catalog/_uv.html.erb`
+ modified: `spec/system/next_previous_on_show_spec.rb`
+ modified: `spec/system/view_work_spec.rb`