### PR TITLE
Add discovery and sinai to the suppress list

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -44,7 +44,7 @@ class CatalogController < ApplicationController
       mm: '100%',
       rows: 10,
       qf: 'title_tesim description_tesim creator_tesim keyword_tesim',
-      fq: '(((has_model_ssim:Work) OR (has_model_ssim:Collection)) AND !(visibility_ssi:restricted))'
+      fq: '(((has_model_ssim:Work) OR (has_model_ssim:Collection)) AND !((visibility_ssi:restricted) OR (visibility_ssi:discovery) OR (visibility_ssi:sinai)))'
       ### we want to only return works where visibility_ssi == open (not restricted)
     }
 

--- a/spec/support/works.rb
+++ b/spec/support/works.rb
@@ -83,7 +83,7 @@ THIRD_WORK = {
   member_of_collection_ids_ssim: ['coll123'],
   read_access_group_ssim: ["public"],
   thumbnail_url_ss: ["http://thumbnail/work3.jpg"],
-  visibility_ssi: ['discovery']
+  visibility_ssi: ['open']
 }.freeze
 
 FIRST_COLLECTION = {

--- a/spec/system/suppress_discovery_collection_spec.rb
+++ b/spec/system/suppress_discovery_collection_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Search results page', type: :system, js: true do
+  let(:id) { 'm8f11000zz-89113' }
+  let(:services_contact) do
+    'UCLA Charles E. Young Research Library Department of Special Collections Phone: (310)825-4988'
+  end
+  let(:description) do
+    'Walter E. Bennett (1921-1995) was the first salaried photographer for Time, where he worked from 1952 to 1982.'
+  end
+  let(:collection_attributes) do
+    {
+      id: id,
+      has_model_ssim: ['Collection'],
+      accessControl_ssim: ['7b1af782-af1f-46a6-9bd2-b53be0f1bb68'],
+      title_tesim: ['Zen and the Art of Motorcycle Maintenance: An Inquiry Into Values'],
+      collection_type_gid_ssim: ['gid://californica/hyrax-collectiontype/1'],
+      ark_ssi: 'ark:/21198/zz00011f8m',
+      local_identifier_ssm: ['Collection 686'],
+      normalized_date_tesim: ['1937/1983'],
+      photographer_tesim: ['Bennett, Walter E. (Walter Edward), 1921-1995'],
+      repository_tesim: ['University of California, Los Angeles. Library Special Collections'],
+      services_contact_ssm: ['UCLA'],
+      human_readable_resource_type_tesim: ['still image'],
+      description_tesim: ['description'],
+      rights_statement_tesim: ['http://vocabs.library.ucla.edu/rights/copyrighted'],
+      date_created_tesim: ['1937-1983'],
+      extent_tesim: ['still image'],
+      thumbnail_path_ss: '/assets/collection-a38b932554788aa578debf2319e8c4ba8a7db06b3ba57ecda1391a548a4b6e0a.png',
+      visibility_ssi: 'restricted',
+      read_access_group_ssim: ['discovery'],
+      ursus_id_ssi: '21198-zz00011f8m',
+      human_readable_type_tesim: ['Collection'],
+      license_tesim: ['https://creativecommons.org/licenses/by/4.0/'],
+      medium_tesim: ['b&w negative']
+    }
+  end
+  before do
+    solr = Blacklight.default_index.connection
+    solr.add(collection_attributes)
+    solr.commit
+    allow(Rails.application.config).to receive(:iiif_url).and_return('https://example.com')
+    allow_any_instance_of(IiifService).to receive(:src).and_return('/uv/uv.html#?manifest=/manifest.json')
+  end
+  it 'displays the metadata' do
+    visit solr_document_path(id)
+    expect(page).to_not have_content 'Zen and the Art of Motorcycle Maintenance: An Inquiry Into Values'
+    expect(page).to_not have_content 'Local identifier: Collection 686'
+    expect(page).to_not have_content 'Description: description'
+  end
+  it 'displays headings' do
+    visit solr_document_path(id)
+    expect(page).to_not have_content 'Item Overview'
+    expect(page).to_not have_content 'Notes'
+    expect(page).to_not have_content 'Physical Description'
+    expect(page).to_not have_content 'Keywords'
+    expect(page).to_not have_content 'Find This Item'
+    expect(page).to_not have_content 'Access Condition'
+  end
+end


### PR DESCRIPTION
[CAL-830](https://jira.library.ucla.edu/browse/CAL-830)
- added discovery and sinai to the suppress list
- changed THIRD_WORK in works.rb to "open" to pass existing test
- added test for discovery and sinai

1. In Californica, set Visibility of an item to "Discovery" (the forthcoming "Sinai" is also supported)
2. Search for the item in Ursus
3. Observe "No results found."