### PR TITLE
APPS-396: Use cap deploy to enable ursus sinai feature flag

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -49,3 +49,20 @@ append :linked_dirs, "tmp/sockets"
 
 append :linked_files, ".env.production"
 append :linked_files, "config/secrets.yml"
+
+### Ursus Feature Flags ################
+
+# Enable Sinai Manuscripts features
+if ENV['FEATURE_FLAG'] == 'sinaimanu'
+  namespace :ursus do
+    task :enable_sinai_manuscript_features do
+      on roles(:app) do
+        execute "cd #{deploy_to}/current; /usr/bin/env bundle exec rake ursus:sinai:on RAILS_ENV=production"
+      end
+    end
+  end
+
+  after 'deploy:published', 'ursus:enable_sinai_manuscript_features'
+end
+
+########################################


### PR DESCRIPTION
Instead of attempting to create a new deployment process, I believe adding [this code block](https://github.com/UCLALibrary/ursus/blob/73474a33dbf000584fdc9796a82ffa4cae9c1345/config/deploy.rb#L55-L68) to the `deploy.rb` file will allow us to run the necessary rake task to enable the sinai features. 

I also made changes to the corresponding ansible deploy role to put in place and track the feature flag environment variable. 