### PR TITLE
Add search buttons to item-level pages

### DIFF
--- a/app/assets/stylesheets/ursus/_searchbar.scss
+++ b/app/assets/stylesheets/ursus/_searchbar.scss
@@ -31,26 +31,56 @@
 
 .new-search-link {
   padding-right: 15px;
+  margin-right: 2px;
+  float: right;
 }
 
 .back-to-search-link {
   margin-right: 20px;
+  float: right;
+  width: 175px !important;
 }
 
 .back-and-new-links-show {
   float: right;
   clear: left;
   padding-top: 6px;
+  a {
+    height: 30px;
+    width: 138px;
+    color: $ucla-darker-blue;
+    background-color: $white;
+    font-family: Helvetica;
+    font-size: 14px;
+    line-height: 17px;
+    text-align: center;
+    border: 1px solid $ucla-darker-blue;
+    border-radius: 0px;
+    }
+    a:hover {
+      height: 30px;
+      width: 138px;
+      color: $white !important;
+      background-color: $ucla-darker-blue;
+      font-family: Helvetica;
+      font-size: 14px;
+      line-height: 17px;
+      text-align: center;
+      border: 1px solid $ucla-darker-blue;
+      border-radius: 0px;
+      padding-bottom: 3px;
+    }
 }
 
 .back-and-new-container {
   height: 46px;
-  background-color: #f5f5f5;
-  border-top: 1px solid #dee2e6;
+  border-bottom: 1px solid #dee2e6;
   margin-top: 30px;
   margin-bottom: 30px;
   display: flex;
   justify-content: space-between;
+  padding-bottom: 50px;
+
 }
 
 .previous-next {
@@ -133,7 +163,7 @@
       }
     }
     .remove:hover {
-      background: red !important;
+      background: $ucla-gold !important;
       margin-left: -1px !important;
     }
   }
@@ -147,6 +177,20 @@
 @media screen and (max-width: 767px) {
   .startover-container {
     padding-bottom: 10px;
+  }
+  .back-and-new-container {
+    display: block !important;
+    margin: 0px;
+
+  }
+  .back-and-new-links-show {
+    display: block !important;
+    align: left;
+    margin: 5px 0px 30px 0px;
+    float: left;
+  }
+  .pagination-search-widgets {
+    margin-left: -15px;
   }
 }
 

--- a/app/views/catalog/_uv.html.erb
+++ b/app/views/catalog/_uv.html.erb
@@ -12,7 +12,6 @@
         allowfullscreen
         frameborder='0'>
     </iframe>
-      <!-- <div class='link-and-icon'><i class='fa fa-link' aria-hidden="true"></i><%= render 'show_tools' %></div> -->
   </div>
 </div>
 

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -2,16 +2,16 @@
 
   <div id='appliedParams' class='back-and-new-container'>
     <div class= 'previous-next'><%= render 'previous_next_doc' if @search_context %></div>
-    <div class='back-new'>
-      <%= link_to t('blacklight.search.new_search'), start_over_path, class: 'new-search-link back-and-new-links-show' %>
-      <%= link_back_to_catalog class: 'back-and-new-links-show back-to-search-link' %>
+    <div class='back-and-new-links-show' >
+      <%= link_to t('blacklight.search.new_search'), start_over_path, class: 'new-search-link btn' %>
+      <%= link_back_to_catalog label:'Back to Search Results', class: 'btn back-to-search-link' %>
     </div>
   </div>
 
 <% elsif current_search_session %>
 
   <div id='appliedParams' class='clearfix constraints-container'>
-    <%= link_to t('blacklight.search.start_over'), start_over_path, class: 'catalog_startOverLink btn btn-primary' %>
+    <%= link_to t('blacklight.search.start_over'), start_over_path, class: 'btn catalog_startOverLink' %>
     <%= link_back_to_catalog class: 'btn btn-outline-secondary' %>
   </div>
 

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -15,7 +15,7 @@ en:
         search:
           placeholder: 'Search'
           placeholder_collection: 'Search this collection'
-      new_search: 'New Search'
+      new_search: 'Start New Search'
       fields:
         facet:
           date_created_tesim: 'Date Created'


### PR DESCRIPTION
Connected to [URS-475](https://jira.library.ucla.edu/browse/URS-475)

Users easily miss the "Back to Search" and "New Search" links on an item level page and get confused about how to initiate a new search or return to their initial results. Turning the links into buttons could make them more visible to users.

Acceptance Criteria

- [x] Create prominent buttons for "Back to Search" and "Start New Search"

<img width="488" alt="Screen Shot 2019-12-02 at 3 41 50 PM" src="https://user-images.githubusercontent.com/751697/70004498-5609bb00-151b-11ea-8594-f86a4be15669.png">
<img width="1226" alt="Screen Shot 2019-12-02 at 3 42 07 PM" src="https://user-images.githubusercontent.com/751697/70004499-5609bb00-151b-11ea-9dcc-57ef6a8caca9.png">
<img width="1230" alt="Screen Shot 2019-12-02 at 3 42 17 PM" src="https://user-images.githubusercontent.com/751697/70004500-5609bb00-151b-11ea-8d95-255097fbd939.png">

---

Changes to be committed:
+ modified: `app/assets/stylesheets/ursus/_searchbar.scss`
+ modified: `app/views/catalog/_uv.html.erb`
+ modified: `app/views/catalog/show.html.erb`