### PR TITLE
remove collection banner

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -48,7 +48,7 @@ class CatalogController < ApplicationController
       ### we want to only return works where visibility_ssi == open (not restricted)
     }
 
-    config.show.partials.insert(1, :collection_banner)
+    # config.show.partials.insert(1, :collection_banner)
     config.show.partials.insert(2, :uv)
 
     # solr field configuration for document/show views

--- a/spec/helpers/banner_helper_spec.rb
+++ b/spec/helpers/banner_helper_spec.rb
@@ -47,33 +47,4 @@ RSpec.describe BannerHelper, type: :helper do
       expect(collection?(doc)).to eq(false)
     end
   end
-
-  describe '#render_banner_tag' do
-    it 'returns an img tag for the banner' do
-      doc['id'] = '1'
-      doc['has_model_ssim'] = ['Collection']
-      stubbed_request
-      local_stubbed_request
-      expect(render_banner_tag(doc)).to be_in(["<div class='collection-banner' alt='Collection banner' style='background-image:url(http://localhost:3000/branding/3049304/banner/test.tif);'></div>",
-                                               "<div class='collection-banner' alt='Collection banner' style='background-image:url(http://californica-test.library.ucla.edu/branding/3049304/banner/test.tif);'></div>"]) # rubocop:disable Metrics/LineLength
-    end
-  end
-
-  describe '#get_img_path' do
-    it 'returns the url to the image' do
-      stubbed_request
-      local_stubbed_request
-      expect(get_img_path('1')).to be_in(['http://californica-test.library.ucla.edu/branding/3049304/banner/test.tif',
-                                          'http://localhost:3000/branding/3049304/banner/test.tif'])
-    end
-  end
-
-  describe '#get_branding_info' do
-    it 'returns an array with the path to the branding info' do
-      stubbed_request
-      local_stubbed_request
-      expect(get_branding_info('1')).to eq(['/opt/path',
-                                            'branding/3049304/banner/test.tif'])
-    end
-  end
 end

--- a/spec/system/view_metadata_only_work_spec.rb
+++ b/spec/system/view_metadata_only_work_spec.rb
@@ -15,10 +15,11 @@ RSpec.feature "View a metadata-only Work", js: true do
     {
       id: discovery_work_id,
       ark_ssi: ['ark:/123/111'],
-      has_model_ssim: ['Work'],
-      title_tesim: ['Work with Discovery Access'],
+      discover_access_group_ssim: ["public"],
       edit_access_group_ssim: ["admin"],
-      discover_access_group_ssim: ["public"]
+      has_model_ssim: ['Work'],
+      iiif_manifest_url_ssi: 'https://iiif.server/url/manifest',
+      title_tesim: ['Work with Discovery Access']
     }
   end
 
@@ -26,10 +27,11 @@ RSpec.feature "View a metadata-only Work", js: true do
     {
       id: open_work_id,
       ark_ssi: ['ark:/123/222'],
-      has_model_ssim: ['Work'],
-      title_tesim: ['Work with Open Access'],
       edit_access_group_ssim: ["admin"],
-      read_access_group_ssim: ["public"]
+      has_model_ssim: ['Work'],
+      iiif_manifest_url_ssi: 'https://iiif.server/url/manifest',
+      read_access_group_ssim: ["public"],
+      title_tesim: ['Work with Open Access']
     }
   end
 


### PR DESCRIPTION
The collection banner partial is currently being loaded (though it doesn't render anything). In the process, it makes a call to Californica (for branding info) and raises an error if this fails.

This commit disables the collection banner, but leaves related code (which won't be invoked). At some point we shoudl clean that up.