### PR TITLE
Replace the collection link on the Search Results Page

### DIFF
--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -3,14 +3,21 @@
 <!-- default partial to display solr document fields in catalog index view -->
 
 <dl class="document-metadata dl-invert row">
-  <% doc_presenter.fields_to_render.each do | field_name, field | -%>
-    <dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= render_index_field_label document, field: field_name %></dt>
-    <dd class="blacklight-<%= field_name.parameterize %> col-md-9"><%= doc_presenter.field_value field %></dd>
-    <% if field_name == "Description" %>
-      <dt class="blacklight-<%= field_name.parameterize %> col-md-3"></dt>
-      <dd class="blacklight-<%= field_name.parameterize %> col-md-9">&nbsp;&nbsp;&nbsp;</dd>
-    <% end %>    
-  <% end -%>
+  <% doc_presenter.fields_to_render.each do | field_name, field | %>
+    <% if field_name == "member_of_collections_ssim" %>
+      <% if document[:member_of_collections_ssim] && document[:member_of_collection_ids_ssim] %>
+        <dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= render_index_field_label document, field: field_name %></dt>
+        <dd class="blacklight-<%= field_name.parameterize %> col-md-9"><%= link_to  document[:member_of_collections_ssim][0], "/catalog/#{document[:member_of_collection_ids_ssim][0]}" %></dd>
+      <% end %>
+        <% else %>
+      <dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= render_index_field_label document, field: field_name %></dt>
+      <dd class="blacklight-<%= field_name.parameterize %> col-md-9"><%= doc_presenter.field_value field %></dd>
+      <% if field_name == "Description" %>
+        <dt class="blacklight-<%= field_name.parameterize %> col-md-3"></dt>
+        <dd class="blacklight-<%= field_name.parameterize %> col-md-9">&nbsp;&nbsp;&nbsp;</dd>
+      <% end %>  
+    <% end %>  
+  <% end %>
 </dl>
 
   <% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({}, counter: document_counter_with_offset(document_counter)) %>


### PR DESCRIPTION
This change will take the user to the Collection Record Page instead of the Search Page for the Collection.