### PR TITLE
Update facets filter chain banner area

### DIFF
--- a/app/assets/stylesheets/ursus/_search--filter.scss
+++ b/app/assets/stylesheets/ursus/_search--filter.scss
@@ -5,7 +5,6 @@
   flex-wrap: wrap;
   justify-content: space-between;
   align-items: flex-start;
-  background-color: $ucla-lightest-blue;
   padding-right: 15px;
   padding-left: 15px;
   margin-top: -1rem;
@@ -14,12 +13,14 @@
 @media screen and (max-width: 767px) {
   .filter-box {
     display: block;
+    height: 50px;
   }
 }
 
 .filters-applied {
   color: $ucla-darkest-blue;
   font-weight: 600;
+  padding-right: 5px;
 }
 
 #appliedParams {
@@ -35,22 +36,23 @@
 
     .constraint-value,
     .remove {
-      color: $white !important;
-      background: $ucla-blue !important;
-      border: 0 !important;
+      color: $ucla-darkest-blue !important;
+      border-left: 2px solid $ucla-darkest-blue;
+      background-color: $ucla-lightest-blue !important;
+      //border: 0 !important;
     }
     .filter-name:after {
-      color: $white !important;
-    }
-    .constraint-value:hover {
       color: $ucla-darkest-blue !important;
+    }
+    /*.constraint-value:hover {
+      color: $ucla-tertiary-gray !important;
       background: $light-gray !important;
       .filter-name:after {
         color: $ucla-darkest-blue !important;
       }
-    }
+    } */
     .remove:hover {
-      background: $ucla-gold !important;
+      background-color: #B22222 !important;
       margin-left: -1px !important;
     }
   }
@@ -60,7 +62,48 @@
   flex: 0 0 12% !important;
   max-width: 100px !important;
   align-self: center;
+  padding: 6px;
+
 }
+
+.search-startover {
+  float: right;
+  clear: left;
+  a {
+    height: 30px;
+    width: 138px;
+    color: $ucla-blue;
+    background-color: $white;
+    font-family: Helvetica;
+    font-size: 14px;
+    line-height: 17px;
+    text-align: center;
+    border: 1px solid $ucla-blue;
+    border-radius: 0px;
+    padding: 6px ;
+  }
+  a:hover {
+    height: 30px;
+    width: 138px;
+    color: $white !important;
+    background-color: $ucla-darker-blue;
+    font-family: Helvetica;
+    font-size: 14px;
+    line-height: 17px;
+    text-align: center;
+    border: 1px solid $ucla-darker-blue;
+    border-radius: 0px;
+    padding: 6px ;
+    text-decoration: none;
+  }
+}
+
+search-filter-container
+.results_container {
+  margin-bottom: 50px;
+}
+
+
 @media screen and (max-width: 767px) {
   .startover-container {
     padding-bottom: 10px;

--- a/app/assets/stylesheets/ursus/_selected_facet.scss
+++ b/app/assets/stylesheets/ursus/_selected_facet.scss
@@ -16,7 +16,6 @@ div#facets span.facet-label > span.selected {
 
   .remove-icon:hover {
     color: $ucla-gold;
-
   }
 }
 

--- a/app/views/catalog/_browse_results.html.erb
+++ b/app/views/catalog/_browse_results.html.erb
@@ -1,3 +1,8 @@
+<div class='search-filter-container'>
+  <%= render 'catalog/constraints' %>
+</div>
+
+<div class='results_container'>
 <% url = request.original_url %>
 <% if url.include?('has_model_ssim') && url.include?('Collection') %>
   <h4 class='catalog-results'><%= @response['response'].dig(:numFound) %> Collections <%= render_results_collection_tools wrapping_class: "search-widgets" %></h4>
@@ -21,3 +26,4 @@
 
 <div class='rectangle'><%= render 'results_pagination' %></div>
 <%= render 'old_collections' %>
+</div>

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -1,9 +1,9 @@
 <% if query_has_constraints? %>
   <div id='appliedParams' class='clearfix constraints-container'>
-
     <h2 class='sr-only'><%= t('blacklight.search.search_constraints_header') %></h2>
-    <span class='filters-applied'>Filters Applied: </span>
+    <span class='filters-applied'>You searched for: </span>
     <%= render_constraints(params) %>
-
+    <%= render 'catalog/startover' %>
   </div>
 <% end %>
+<hr>

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -14,10 +14,7 @@
   <% if url.include?('has_model_ssim') && url.include?('Collection') %>
   <div class='space'></div>
   <% else %>
-    <div class='filter-box'>
-      <%= render 'constraints' %>
-      <%= render 'startover' %>
-    </div>
+    <div class='space'></div>
   <% end %>
 <% end %>
 

--- a/app/views/catalog/_startover.html.erb
+++ b/app/views/catalog/_startover.html.erb
@@ -1,5 +1,5 @@
 <% if query_has_constraints? %>
-  <div class='startover-container'>
+  <div class='startover-container search-startover'>
     <%=link_to t('blacklight.search.start_over'), '/catalog?utf8=%E2%9C%93&q=&search_field=all_fields', class: "catalog_startOverLink" %>
   </div>
 <% end %>

--- a/spec/system/next_previous_on_show_spec.rb
+++ b/spec/system/next_previous_on_show_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'the result bar displays the correct links', :clean, type: :syste
   it 'has expected fields on initial search page and show page' do
     visit '/catalog?q=Person&search_field=all_fields'
     expect(page).to have_content '2 Catalog Results'
-    expect(page).to have_content 'Filters Applied: Person'
+    expect(page).to have_content 'You searched for: Person'
     expect(page).to have_content 'Start Over'
     click_link('Title One', match: :first)
     expect(page).to have_content '1 of 2 results'


### PR DESCRIPTION
Connected to [URS-538](https://jira.library.ucla.edu/browse/URS-538)
- [x] Relocate the filter chain from beneath the search bar to above the results body (See design)
- [x] Remove light blue background
- [x] Change background of filter labels to light blue
- [x] Hover over "x" icon of a filter label should be red, not yellow
- [x] The Start Over button remains aligned to the right side of the panel as the list of applied filters grows
- [x] Update "Filters Applied:" to "You searched for:"
- [x] Add a border around Start Over
- [x] Responsive

<img width="935" alt="Screen Shot 2019-12-10 at 2 38 56 PM" src="https://user-images.githubusercontent.com/751697/70575219-e028d380-1b5a-11ea-9cae-6fca13c7a12a.png">

---

Changes to be committed:
+ modified:   `app/assets/stylesheets/ursus/_search--filter.scss`
+ modified:   `app/assets/stylesheets/ursus/_selected_facet.scss`
+ modified:   `app/views/catalog/_browse_results.html.erb`
+ modified:   `app/views/catalog/_constraints.html.erb`
+ modified:   `app/views/catalog/_search_results.html.erb`
+ modified:   `app/views/catalog/_startover.html.erb`