### PR TITLE
Add hover state to collection masthead browse button

### DIFF
--- a/app/assets/stylesheets/ursus/_header_image_block.scss
+++ b/app/assets/stylesheets/ursus/_header_image_block.scss
@@ -92,11 +92,17 @@
     }
 
     .btn-browse {
-      font-size: 17px;
-      color: $ucla-gold !important;
-      border: 2px solid $ucla-gold;
-      border-radius: 0;
+        font-size: 17px;
+        color: $ucla-gold !important;
+        border: 2px solid $ucla-gold;
+        border-radius: 0;
     }
+    .btn-browse:hover {
+      font-size: 17px;
+      color: black !important;
+      background-color: $ucla-gold;
+    }
+
   }
   span {
     color: $ucla-lighter-blue;


### PR DESCRIPTION
- [x] On hover, the button should have a solid ucla-gold fill and the text content should be black.

<img width="676" alt="Screen Shot 2019-12-12 at 10 58 28 AM" src="https://user-images.githubusercontent.com/751697/70740852-f35cb000-1cce-11ea-930d-d4aad3aebfdd.png">

---

Changes to be committed:
modified:   app/assets/stylesheets/ursus/_header_image_block.scss