### PR TITLE
Added a variable check to avoid showing just items text

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,7 @@ Lint/RequireParentheses:
 Metrics/AbcSize:
   Exclude:
     - app/helpers/blacklight/url_helper_behavior.rb
+    - app/controllers//catalog_controller.rb
 
 Metrics/BlockLength:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ Lint/RequireParentheses:
 Metrics/AbcSize:
   Exclude:
     - app/helpers/blacklight/url_helper_behavior.rb
-    - app/controllers//catalog_controller.rb
+    - app/controllers/catalog_controller.rb
 
 Metrics/BlockLength:
   Enabled: true

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -275,12 +275,11 @@ class CatalogController < ApplicationController
       additional_export_formats(@document, format)
     end
     if @document[:has_model_ssim][0] == 'Collection'
-      @response_collection = search_service.facet_field_response('member_of_collections_ssim')
-      @display_facet = @response_collection.aggregations["member_of_collections_ssim"]
-      @display_facet.items.each do |facet_item|
-        if facet_item.value == @document[:title_tesim][0]
-          @collection_count = facet_item.hits
-        end
+      facet_member_of_collections = blacklight_config.facet_fields['member_of_collections_ssim']
+      @response_collection = search_service.facet_field_response(facet_member_of_collections.key, "f.member_of_collections_ssim.facet.contains" => @document[:title_tesim][0])
+      @display_facet = @response_collection.aggregations[facet_member_of_collections.field]
+      if @display_facet&.items && @display_facet.items.first
+        @collection_count = @display_facet.items.first.hits
       end
     end
   end

--- a/app/views/catalog/_collection_masthead_overlay.html.erb
+++ b/app/views/catalog/_collection_masthead_overlay.html.erb
@@ -1,7 +1,9 @@
 <div class='collection-masthead-overlay'>
   <h1><%= document[:title_tesim][0] %></h1>
   <div class='item-info'>
+    <% if collection_count %>
     <div class='collection-count'><%= collection_count %> items</div>
+    <% end %>
     <%= link_to  'Browse items in this collection', "/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=#{document[:title_tesim][0]}", class:'btn btn-lg btn-browse' %>
   </div>
 </div>

--- a/app/views/catalog/_homepage_banner.html.erb
+++ b/app/views/catalog/_homepage_banner.html.erb
@@ -17,7 +17,22 @@
     </div>
 
 <% end %>
+
 <% if controller.controller_name == 'catalog' && @document && @document[:has_model_ssim] && @document[:has_model_ssim][0] == 'Collection' %>
+
+<!--<div style="display:none">
+  <%#= @pagination_collection.total_count %>
+</div>
+<div style="display:none">
+  <%#= @display_facet.items %>
+</div>
+<div style="display:none;">
+  <%#= @pagination_collection.items %>
+</div>
+<div style="display:none;">
+  <%#= @response_collection %>
+</div> -->
+
 <div class="collection-masthead" style="background-image: linear-gradient(
   to bottom,
   rgba(0, 0, 0, 0),


### PR DESCRIPTION
modified:   app/controllers/catalog_controller.rb
modified:   app/views/catalog/_collection_masthead_overlay.html.erb
modified:   app/views/catalog/_homepage_banner.html.erb

The following line can be used to override the facet.limit
#### "f.member_of_collections_ssim.facet.limit" => 100,

I used  facet.contains filter to restrict the facet results to contain the required collection
 #### {"f.member_of_collections_ssim.facet.contains" => @document[:title_tesim][0]}