### PR TITLE
Remove the nav menu background gap at tablet resolution

### DIFF
--- a/app/assets/stylesheets/ursus/_navbar.scss
+++ b/app/assets/stylesheets/ursus/_navbar.scss
@@ -2,9 +2,7 @@
 
 .site-navbar {
   background-color: $ucla-blue !important;
-  padding: 0.25rem 0.75rem !important;
-  // padding-left: 0.75em !important;
-  // padding-right: 0.75em !important;
+  padding: 0.25rem 0 0 0 !important;
 
   .navbar-logo-block {
     height: 50px;
@@ -21,18 +19,18 @@
     color: #ffd100;
     font-weight: 700;
     position: relative;
-    top: 0.22em;
-    left: 0.4em;
-    font-size: 1.25em;
-    letter-spacing: 0.05em;
+    top: 0.22rem;
+    left: 0.4rem;
+    font-size: 1.25rem;
+    letter-spacing: 0.05rem;
   }
 
   .nav-item a {
     color: $white !important;
     font-weight: 600;
     font-size: 0.9em;
-    letter-spacing: 0.05em;
-    margin-right: 2em;
+    letter-spacing: 0.05rem;
+    margin-right: 2rem;
 
     &:hover {
       color: $ucla-gold !important;
@@ -44,7 +42,8 @@
     a {
       color: $ucla-gold !important;
       font-weight: 600;
-      letter-spacing: 0.05em;
+      letter-spacing: 0.05rem;
+      margin-right: 0;
     }
     a:hover {
       color: $ucla-gold !important;
@@ -53,67 +52,43 @@
   }
 }
 
-@media (max-width: 990px) {
-  .navbar-toggler {
-    border-color: transparent !important;
-    outline: none !important;
-  }
-
-  .navbar-toggler.custom-toggler {
-    padding-left: 0;
-    padding-right: 0;
-  }
-
-  .custom-toggler .navbar-toggler-icon:hover {
-    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='rgba(255,209,0, 1.0)' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E") !important;
-  }
-
+@media (max-width: 991px) {
   .site-navbar {
     .navbar-logo-block {
       height: 45px;
+      padding-left: 0.75rem;
     }
 
-    .nav-item a,
-    .nav-item-feedback a {
-      padding-left: 15px;
+    .navbar-toggler {
+      border-color: transparent !important;
     }
-  }
 
-  .navbar-nav.nav {
-    background-color: $ucla-darker-blue;
-    display: inline-block;
-    width: 100%;
-    align-items: normal;
-    position: static;
-    margin-top: 20px;
-  }
+    .navbar-nav.nav {
+      background-color: $ucla-darker-blue;
+      width: 100%;
+    }
 
-  .navbar-collapse {
-    margin-bottom: -8px;
-    min-width: 768px;
-    position: relative;
-    left: -15px;
-  }
+    .navbar-collapse {
+      background: $ucla-darker-blue;
+    }
 
-  .nav-item a {
-    margin-right: 0;
-  }
+    .nav-item a {
+      margin-right: 0;
+    }
 
-  .nav-item,
-  .nav-item-feedback {
-    padding-left: 30px;
-    padding: 12px 0;
-  }
+    .nav-item {
+      padding: 12px 15px;
+    }
 
-  .nav-item:nth-child(1) {
-    border-bottom: 1px solid #c3d7ee;
-  }
+    .nav-item {
+      border-bottom: 1px solid #c3d7ee;
+    }
 
-  .nav-item:hover {
-    background-color: $ucla-darkest-blue;
-    a {
-      color: $white !important;
-      text-decoration: none;
+    .nav-item:hover {
+      background-color: $ucla-darkest-blue;
+      a {
+        color: $ucla-gold !important;
+      }
     }
   }
 }
@@ -136,6 +111,7 @@
       flex-direction: column;
       justify-content: unset;
       align-items: flex-start;
+      height: 50px;
     }
     .beta-logo {
       left: 0;

--- a/app/assets/stylesheets/ursus/_search--searchbar.scss
+++ b/app/assets/stylesheets/ursus/_search--searchbar.scss
@@ -2,8 +2,8 @@
 
 .site-searchbar {
   background-color: $ucla-darker-blue;
-  height: 70px;
-  max-height: 70px;
+  height: 66px;
+  max-height: 66px;
 
   :-ms-input-placeholder,
   ::-ms-input-placeholder,
@@ -40,6 +40,13 @@
   .site-searchbar {
     ::placeholder {
       font-size: 0.75rem;
+    }
+  }
+  .search-form {
+    .custom-select {
+      font-size: 0.75rem;
+      min-height: 38px;
+      padding: 0 1rem 0 0 !important;
     }
   }
 }

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -25,7 +25,7 @@ function toggleFunction() {
     <div class='collapse navbar-collapse' id='user-util-collapse'>
       <ul class='navbar-nav nav ml-auto'>
         <li class='nav-item'><a href='/about'>About</a></li>
-        <li class='nav-item-feedback'><a href='https://forms.gle/x2BV9dJMK241VsAJA' target='_blank' >Give us feedback</a></li>
+        <li class='nav-item nav-item-feedback'><a href='https://forms.gle/x2BV9dJMK241VsAJA' target='_blank' >Give us feedback</a></li>
       </ul>
     </div>
 


### PR DESCRIPTION
- Dark-blue background of nav items spans full width
- Divider/border-bottom added after "Give Us Feedback"
- Search bar dropdown button text resized for mobile resolution - cramped text fixed 
- CSS refactored

Before
<img width="500" alt="nav-menu-gap-before" src="https://user-images.githubusercontent.com/24995224/70915191-6cb61480-1fe7-11ea-8611-809e02cbe681.png">

After
<img width="500" alt="nav-menu-gap-after" src="https://user-images.githubusercontent.com/24995224/70915195-6de74180-1fe7-11ea-8b98-f4587212b2ca.png">
