### PR TITLE
Temporarily remove "Read More" toggle behavior

### DIFF
--- a/app/helpers/ursus/catalog_helper.rb
+++ b/app/helpers/ursus/catalog_helper.rb
@@ -27,7 +27,8 @@ module Ursus
         description = args[:value].first
         button = "<span class='view-more' href>Read More <div class='down-arrow'>&raquo;</div></span></br>"
         truncated_output << "<div class='description'>#{description}</div>#{button}</br>"
-        return truncated_output.html_safe # rubocop:disable Rails/OutputSafety
+        # return truncated_output.html_safe
+        return description
       end
     end
   end

--- a/spec/system/search_catalog_spec.rb
+++ b/spec/system/search_catalog_spec.rb
@@ -130,6 +130,6 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
     # Search for something
     fill_in 'q', with: 'carrot'
     click_on 'search'
-    expect(page).to have_content('Read More')
+    expect(page).not_to have_content('Read More')
   end
 end


### PR DESCRIPTION
Connected to [URS-570](https://jira.library.ucla.edu/browse/URS-570)

This temporarily removes the "Read More" toggle behavior on the desciptions until the inconsistant behavior in fixed.

---

Changes to be committed:
+ modified: `app/helpers/ursus/catalog_helper.rb`
+ modified: `spec/system/search_catalog_spec.rb`