### PR TITLE
Add a meta description to the item pages

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -5,7 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <!-- Internet Explorer use the highest version available -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="Description" content="The UCLA Library Digital Collections includes rare and unique digital materials developed by the UCLA Library to support education, research, service, and creative expression. This website is our new interface for discovery and engagement of these collections. See collections of historic photographs and manuscripts. More collections added weekly.">
+    <% if controller.controller_name == 'catalog' && controller.action_name == 'show' %>
+      <meta name="Description" content=<%= render_page_title %>>
+    <% else %>
+      <meta name="Description" content="The UCLA Library Digital Collections includes rare and unique digital materials developed by the UCLA Library to support education, research, service, and creative expression. This website is our new interface for discovery and engagement of these collections. See collections of historic photographs and manuscripts. More collections added weekly.">
+    <% end %>
+    <meta name="theme-color" content="#2774ae"/>
 
     <% if ENV["GOOGLE_TAG_MGR_ID"] %>
       <script id='analytics-script'>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
Connected to [URS-498](https://jira.library.ucla.edu/browse/URS-498)

Adds
+ meta description of the the title for each item page (show page)
+ theme color as $ucla-blue
    + The theme-color meta tag ensures that the address bar is branded when a user visits your site as a normal webpage. (this was failing in the lighthouse evaluation

<img width="995" alt="Screen Shot 2020-01-14 at 11 44 57 AM" src="https://user-images.githubusercontent.com/751697/72376770-6472f700-36c3-11ea-94c1-3433f32351ba.png">

---

Changes to be committed:
+ modified: `app/views/layouts/blacklight/base.html.erb`