### PR TITLE
Fix of Implement Callisto authentication 2

### DIFF
--- a/db/migrate/20200110024207_create_sinai_tokens.rb
+++ b/db/migrate/20200110024207_create_sinai_tokens.rb
@@ -1,6 +1,5 @@
 class CreateSinaiTokens < ActiveRecord::Migration[5.1]
     def change
-        drop_table :sinai_tokens
         create_table :sinai_tokens do |t|
         t.string :sinai_token
   


### PR DESCRIPTION
removed drop table because the build was complaining, 
the table probably does not yet exist on test, stage or production