### PR TITLE
Create SASS variables for Callisto brand colors

### DIFF
--- a/app/assets/stylesheets/ursus/_colors.scss
+++ b/app/assets/stylesheets/ursus/_colors.scss
@@ -17,3 +17,17 @@ $ucla-tertiary-gray: #666666;
 $ucla-tertiary-orange: #ffb300;
 $gray: #525252;
 $light-gray: #dddddd;
+
+$callisto-drk-red: #800020;
+$callisto-light-red: rgba(128,0,32,.45);
+$callisto-drk-blue: #152B5A;
+$callisto-light-blue: #9CC9E1;
+$callisto-orange: #CB3208;
+$callisto-drk-beige: #E2DBCF;
+$callisto-beige: #F7F2EA;
+$white: #FFFFFF;
+$black: #000000;
+$gray-10: #E5E5E5;
+$gray-40: #999999;
+$gray-60: #666666;
+$gray-80: #333333;


### PR DESCRIPTION
Connected to [URS-583](https://jira.library.ucla.edu/browse/URS-583]

```css
$callisto-drk-red: #800020;
$callisto-light-red: rgba(128,0,32,.45);
$callisto-drk-blue: #152B5A;
$callisto-light-blue: #9CC9E1;
$callisto-orange: #CB3208;
$callisto-drk-beige: #E2DBCF;
$callisto-beige: #F7F2EA;
$white: #FFFFFF;
$black: #000000;
$gray-10: #E5E5E5;
$gray-40: #999999;
$gray-60: #666666;
$gray-80: #333333;
```

---

Changes to be committed:
+ modified: `app/assets/stylesheets/ursus/_colors.scss`