### PR TITLE
Update copyright icon in Ursus footer

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -23,6 +23,6 @@
 
 <div class='copyright'>
   <div class='uc-regents'>
-    @ 2019 UC Regents. All rights reserved.
+    &#169; 2019 UC Regents. All rights reserved.
   </div>
 </div>


### PR DESCRIPTION
Connected to [URS-596](https://jira.library.ucla.edu/browse/URS-596)

Change to copyright icon/entity to: `&#169;` &#169;

<img width="431" alt="Screen Shot 2020-01-22 at 5 12 43 PM" src="https://user-images.githubusercontent.com/751697/72948963-c07cf180-3d3b-11ea-8f91-cbf5401e1515.png">

---

Changes to be committed:
+ modified: `app/views/shared/_footer.html.erb`