### PR TITLE
Include "sinai" visibility results in sinai site

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -47,6 +47,7 @@ class CatalogController < ApplicationController
       fq: '(((has_model_ssim:Work) OR (has_model_ssim:Collection)) AND !((visibility_ssi:restricted) OR (visibility_ssi:discovery) OR (visibility_ssi:sinai)))'
       ### we want to only return works where visibility_ssi == open (not restricted)
     }
+    config.default_solr_params[:fq] = '(((has_model_ssim:Work) OR (has_model_ssim:Collection)) AND !(visibility_ssi:restricted))' if Flipflop.sinai?
 
     # config.show.partials.insert(1, :collection_banner)
     config.show.partials.insert(2, :uv)

--- a/spec/system/search_catalog_spec.rb
+++ b/spec/system/search_catalog_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
   before do
     delete_all_documents_from_solr
     solr = Blacklight.default_index.connection
-    solr.add([orange, banana])
-    solr.add([creator, contributor, publisher, genre, medium, named_subject])
+    solr.add([orange, banana, creator, contributor, publisher, genre, medium, named_subject, sinai_work])
     solr.commit
   end
 
@@ -84,6 +83,15 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
     }
   end
 
+  let(:sinai_work) do
+    {
+      id: '999',
+      has_model_ssim: ['Work'],
+      title_tesim: 'Sinai work RsYAM429',
+      visibility_ssi: 'sinai'
+    }
+  end
+
   it 'gets correct search results' do
     visit root_path
     # Search for something
@@ -131,5 +139,18 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
     fill_in 'q', with: 'carrot'
     click_on 'search'
     expect(page).not_to have_content('Read More')
+  end
+
+  context 'when the sinai? flag is disabled' do
+    before { allow(Flipflop).to receive(:sinai?).and_return(false) }
+
+    it 'doesn\'t return works with "sinai" visibility' do
+      visit root_path
+      fill_in 'q', with: 'RsYAM429'
+      click_on 'search'
+
+      expect(page).to_not have_link('Sinai work RsYAM429')
+      expect(page).to have_content('0 Catalog Results')
+    end
   end
 end


### PR DESCRIPTION
If the 'sinai?' feature flag is set, disables a search filter that excluded results with 'sinai' and 'discovery' visibilities.