### PR TITLE
Implement Callisto footer

### DIFF
--- a/app/assets/stylesheets/sinai-extras.scss
+++ b/app/assets/stylesheets/sinai-extras.scss
@@ -1,9 +1,10 @@
+@import "sinai/document";
 @import "sinai/facets";
+@import "sinai/footer";
 @import "sinai/gallery";
+@import "sinai/search_searchbar";
 @import "sinai/sinai_navbar";
 @import "sinai/sort_pagination";
-@import "sinai/search_searchbar";
-@import "sinai/document";
-@import "sinai/utilities";
+@import "sinai/search--filter";
 @import "sinai/search_results";
-@import "sinai/search--filter"
+@import "sinai/utilities";

--- a/app/assets/stylesheets/sinai/_footer.scss
+++ b/app/assets/stylesheets/sinai/_footer.scss
@@ -6,32 +6,18 @@ footer {
   .primary-footer-wrapper {
     display: flex;
     justify-content: space-evenly;
-    flex-wrap: wrap;
+    align-items: center;
+    .logo-wrapper {
+      flex: 0 0 19%;
+    }
+    .logo-wrapper:nth-child(2) {
+      mix-blend-mode: multiply;
+    }
+    .footer-logo {
+      max-width: 50%;
+      height: auto;
+    }
   }
-}
-// LOGOS
-.navbar-logo {
-  width:100px;
-}
-.logo1 {
-  width: 100px;
-  margin-top: 35px;
-}
-.logo2 {
-
-  mix-blend-mode: multiply;
-}
-.logo3 {
-
-}
-.logo4 {
-
-  margin-top: 20px;
-}
-.logo5 {
-
-  margin-top: 35px;
-  margin-right: 20px;
 }
 
 //----------------------------------------
@@ -43,10 +29,8 @@ footer {
   font-family: Helvetica;
   font-size: 16px;
   background-color: $callisto-drk-beige;
+  padding: 30px 0 30px 20px;
   .footer-links {
-    text-align: left;
-    margin: 5px 25px 15px 100px;
-    padding-top: 12px;
     a {
       color: black !important;
       font-size: 1rem;
@@ -84,68 +68,34 @@ footer {
     color: $white;
     font-size: 0.75em;
     text-align: left;
-    margin-left: 100px;
+    margin-left: 0px;
     padding-top: 12px;
+    padding-left: 20px;
   }
 }
 
 //----------------------------------------
 
-@media (max-width: 875px){
-
+@media (max-width: 992px) {
   footer {
-    padding: 20px 10px 20px 30px;
-
     .primary-footer-wrapper {
-      display: flex;
-      justify-content: space-evenly;
       flex-wrap: wrap;
-    }
-  }
-  // LOGOS
-  .navbar-logo {
-    width: 80pxpx;
-  }
-  .logo1 {
-    width: 100px;
-    margin-top: 35px;
-  }
-  .logo2 {
-    width: 100px;
-    mix-blend-mode: multiply;
-  }
-  .logo3 {
-    width: 100px;
-  }
-  .logo4 {
-    width: 100px;
-    margin-top: 20px;
-  }
-  .logo5 {
-    width: 100px;
-    margin-top: 35px;
-    margin-right: 20px;
-  }
-
-  //-------
-
-  .secondary-footer-wrapper {
-    max-width: 768px;
-    width: 100%;
-    .footer-links {
-      margin: 5px 25px 15px 50px;
-      ul {
-        padding: 0;
-        display: inline;
+      .logo-wrapper {
+        flex: 0 0 33%;
       }
     }
   }
 
-  //-------
-
-  .copyright {
-    .uc-regents {
-      margin-left: 50px;
+  .secondary-footer-wrapper {
+    padding: 30px 0 10px 20px;
+    .footer-links {
+      ul {
+        padding: 0;
+        display: inline;
+        li {
+          margin-bottom: 16px;
+        }
+      }
     }
   }
 }

--- a/app/assets/stylesheets/sinai/_footer.scss
+++ b/app/assets/stylesheets/sinai/_footer.scss
@@ -1,0 +1,111 @@
+footer {
+  background-color: $callisto-beige;
+  font-family: Helvetica;
+  padding: 20px 0 20px 20px;
+  margin-top: 100px;
+
+  .primary-footer-wrapper {
+    display: flex !important;
+    max-width: 1440px;
+    width: 100%;
+  }
+
+  .secondary-footer-wrapper {
+    display: flex !important;
+    max-width: 1440px;
+    width: 100%;
+  }
+
+  ul {
+  padding: 0;
+  list-style-type: none;
+  }
+
+  li {
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: 1px;
+    line-height: 1.2rem;
+    padding: .75rem 0;
+    margin-left: 0;
+  }
+  .logo {
+    max-width: 12.5rem;
+    width: 100%;
+  }
+}
+
+.copyright {
+  background-color: $callisto-drk-red;
+  width: 100%;
+  height: 40px;
+  .uc-regents {
+    color: $white;
+    font-size: 0.75em;
+    text-align: left;
+    margin-left: 50px;
+    //margin-top: 12px;
+    padding-top: 12px;
+  }
+}
+
+// col-spans
+
+.col1 {
+  flex-basis: 25%;
+  align-self: center;
+  margin-right: 1rem;
+}
+.col2 {
+  flex-grow: 2;
+  flex-shrink: 0;
+  flex-basis: max-content;
+  li {
+    color: #fff;
+    a {
+      color: $white !important;
+      display: inline-block;
+    }
+    a:hover {
+      color: $ucla-gold !important;
+      text-decoration: underline;
+    }
+  }
+}
+.col3 {
+  flex-grow: 8;
+  li {
+    color: #FFD100;
+    a {
+      color: $ucla-gold !important;
+      display: inline-block;
+    }
+    a:hover {
+      color: $ucla-gold !important;
+      text-decoration: underline;
+    }
+  }
+}
+
+@media (max-width: 768px){
+  footer {
+    .footer-wrapper {
+      display: block !important;
+    }
+    .col2 {
+      margin-top: 1.5rem;
+    }
+  }
+}
+
+
+
+.svg-triangle{
+  margin: 0 auto;
+  width: 25px;
+  height: 25px;
+}
+
+.svg-triangle polygon {
+  fill:#800020;
+}

--- a/app/assets/stylesheets/sinai/_footer.scss
+++ b/app/assets/stylesheets/sinai/_footer.scss
@@ -1,39 +1,80 @@
 footer {
-  background-color: $callisto-beige;
-  font-family: Helvetica;
   padding: 20px 0 20px 20px;
   margin-top: 100px;
-
+  background-color: $callisto-beige;
+  max-width: 1440px;
   .primary-footer-wrapper {
-    display: flex !important;
-    max-width: 1440px;
-    width: 100%;
-  }
-
-  .secondary-footer-wrapper {
-    display: flex !important;
-    max-width: 1440px;
-    width: 100%;
-  }
-
-  ul {
-  padding: 0;
-  list-style-type: none;
-  }
-
-  li {
-    font-size: 1rem;
-    font-weight: 600;
-    letter-spacing: 1px;
-    line-height: 1.2rem;
-    padding: .75rem 0;
-    margin-left: 0;
-  }
-  .logo {
-    max-width: 12.5rem;
-    width: 100%;
+    display: flex;
+    justify-content: space-evenly;
+    flex-wrap: wrap;
   }
 }
+// LOGOS
+.navbar-logo {
+  width:100px;
+}
+.logo1 {
+  width: 100px;
+  margin-top: 35px;
+}
+.logo2 {
+
+  mix-blend-mode: multiply;
+}
+.logo3 {
+
+}
+.logo4 {
+
+  margin-top: 20px;
+}
+.logo5 {
+
+  margin-top: 35px;
+  margin-right: 20px;
+}
+
+//----------------------------------------
+
+.secondary-footer-wrapper {
+  display: flex;
+  max-width: 1440px;
+  width: 100%;
+  font-family: Helvetica;
+  font-size: 16px;
+  background-color: $callisto-drk-beige;
+  .footer-links {
+    text-align: left;
+    margin: 5px 25px 15px 100px;
+    padding-top: 12px;
+    a {
+      color: black !important;
+      font-size: 1rem;
+      font-weight: 600;
+      line-height: 1.2rem;
+      padding-right: 40px;
+    }
+    a:hover {
+      color: $callisto-drk-red !important;
+      text-decoration: none;
+    }
+    ul {
+      display: flex;
+      align-items: stretch; /* Default */
+      justify-content: space-between;
+      width: 100%;
+      margin: 0;
+      padding: 0;
+    }
+    li {
+      display: block;
+      flex: 0 1 auto; /* Default */
+      list-style-type: none;
+    }
+  }
+}
+
+//----------------------------------------
 
 .copyright {
   background-color: $callisto-drk-red;
@@ -43,69 +84,68 @@ footer {
     color: $white;
     font-size: 0.75em;
     text-align: left;
-    margin-left: 50px;
-    //margin-top: 12px;
+    margin-left: 100px;
     padding-top: 12px;
   }
 }
 
-// col-spans
+//----------------------------------------
 
-.col1 {
-  flex-basis: 25%;
-  align-self: center;
-  margin-right: 1rem;
-}
-.col2 {
-  flex-grow: 2;
-  flex-shrink: 0;
-  flex-basis: max-content;
-  li {
-    color: #fff;
-    a {
-      color: $white !important;
-      display: inline-block;
-    }
-    a:hover {
-      color: $ucla-gold !important;
-      text-decoration: underline;
-    }
-  }
-}
-.col3 {
-  flex-grow: 8;
-  li {
-    color: #FFD100;
-    a {
-      color: $ucla-gold !important;
-      display: inline-block;
-    }
-    a:hover {
-      color: $ucla-gold !important;
-      text-decoration: underline;
-    }
-  }
-}
+@media (max-width: 875px){
 
-@media (max-width: 768px){
   footer {
-    .footer-wrapper {
-      display: block !important;
-    }
-    .col2 {
-      margin-top: 1.5rem;
+    padding: 20px 10px 20px 30px;
+
+    .primary-footer-wrapper {
+      display: flex;
+      justify-content: space-evenly;
+      flex-wrap: wrap;
     }
   }
-}
+  // LOGOS
+  .navbar-logo {
+    width: 80pxpx;
+  }
+  .logo1 {
+    width: 100px;
+    margin-top: 35px;
+  }
+  .logo2 {
+    width: 100px;
+    mix-blend-mode: multiply;
+  }
+  .logo3 {
+    width: 100px;
+  }
+  .logo4 {
+    width: 100px;
+    margin-top: 20px;
+  }
+  .logo5 {
+    width: 100px;
+    margin-top: 35px;
+    margin-right: 20px;
+  }
 
+  //-------
 
+  .secondary-footer-wrapper {
+    max-width: 768px;
+    width: 100%;
+    .footer-links {
+      margin: 5px 25px 15px 50px;
+      ul {
+        padding: 0;
+        display: inline;
+      }
+    }
+  }
 
-.svg-triangle{
-  margin: 0 auto;
-  width: 25px;
-  height: 25px;
-}
+  //-------
 
-.svg-triangle polygon {
-  fill:#800020;
+  .copyright {
+    .uc-regents {
+      margin-left: 50px;
+    }
+  }
 }

--- a/app/assets/stylesheets/ursus/_search--searchbar.scss
+++ b/app/assets/stylesheets/ursus/_search--searchbar.scss
@@ -16,25 +16,29 @@
   }
 }
 
+
 .search-form {
   width: 100%;
   max-width: 990px;
 
+
+
   .custom-select {
-    background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3e%3cpath fill='%23ffffff' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e")
-      no-repeat right 0.75rem center/8px 10px !important;
-    background-color: $ucla-darkest-blue !important;
+    background: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' width='25px' height='25px' margin='0 auto' fill='%23800020' %3E%3Cpolygon points='0,0 25,0 12.5,25'/%3E%3C/svg%3E") no-repeat right 0.75rem center/8px 10px !important;
+    background-color: aqua;
     padding: 0 !important;
   }
 
   // Dropdown field
   #search_field {
-    background-color: $ucla-darkest-blue;
+    background-color: aquamarine;
     color: $white;
     font-weight: 600;
     padding-left: 1rem !important;
   }
 }
+
+
 
 @media (max-width: 576px) {
   .site-searchbar {

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,28 +1,5 @@
-<footer>
-  <div class='footer-wrapper'>
-    <div class="col1">
-      <%= link_to(image_tag('logo/ucla-library-logo.svg', class: 'logo', alt: 'UCLA Library Logo'), 'https://www.library.ucla.edu/', target: '_blank', rel: 'noopener') %>
-    </div>
-    <div class="col2">
-      <ul>
-        <li><%= link_to 'Copyright and Collections', '/copyrights_and_collections' %></li>
-        <li><%= link_to 'Privacy Policy', '/privacy_policy' %></li>
-        <li><%= link_to 'Contact Us', '/contact' %></li>
-      </ul>
-    </div>
-    <div class="col3">
-      <ul>
-        <li><%= link_to 'Visit Our Legacy Site', 'http://digital2.library.ucla.edu/', target: '_blank', rel: 'noopener' %></li>
-        <li><%= link_to 'Give Us Feedback', 'https://forms.gle/x2BV9dJMK241VsAJA', target: '_blank', rel: 'noopener' %></li>
-        
-        <!--<li>Migration Updates</li>-->
-      </ul>
-    </div>
-  </div>
-</footer>
-
-<div class='copyright'>
-  <div class='uc-regents'>
-    &#169; 2019 UC Regents. All rights reserved.
-  </div>
-</div>
+<% if Flipflop.sinai? %>
+  <%= render partial: 'shared/sinai_footer' %>
+<% else %>
+  <%= render partial: 'shared/ursus_footer' %>
+<% end %>

--- a/app/views/shared/_sinai_footer.html.erb
+++ b/app/views/shared/_sinai_footer.html.erb
@@ -1,19 +1,19 @@
 <footer>
   <div class='primary-footer-wrapper'>
-    <div class="logo1">
-      <%= link_to(image_tag('sinai/logo-uclalib-blk.svg', class: 'logo', alt: 'UCLA Library Logo'), 'https://www.library.ucla.edu/', target: '_blank', rel: 'noopener') %>
+    <div class="logo-wrapper">
+      <%= link_to(image_tag('sinai/logo-uclalib-blk.svg', class: 'footer-logo', alt: 'UCLA Library Logo'), 'https://www.library.ucla.edu/', target: '_blank', rel: 'noopener') %>
     </div>
-    <div class="logo2">
-      <%= image_tag('sinai/logo-sinai.png', class: 'navbar-logo sinai-logo', alt: 'UCLA Library Digital Collections Logo') %>
+    <div class="logo-wrapper">
+      <%= image_tag('sinai/logo-sinai.png', class: 'footer-logo', alt: 'UCLA Library Digital Collections Logo') %>
     </div>
-    <div class="logo3">
-      <%= image_tag('sinai/logo-emel.png', class: 'navbar-logo', alt: 'UCLA Library Digital Collections Logo') %>
+    <div class="logo-wrapper">
+      <%= image_tag('sinai/logo-emel.png', class: 'footer-logo', alt: 'UCLA Library Digital Collections Logo') %>
     </div>
-    <div class="logo4">
-      <%= image_tag('sinai/logo-ahmanson.png', class: 'navbar-logo', alt: 'UCLA Library Digital Collections Logo') %>
+    <div class="logo-wrapper">
+      <%= image_tag('sinai/logo-ahmanson.png', class: 'footer-logo', alt: 'UCLA Library Digital Collections Logo') %>
     </div>
-    <div class="logo5">
-      <%= image_tag('sinai/logo-arcadia.png', class: 'navbar-logo', alt: 'UCLA Library Digital Collections Logo') %>
+    <div class="logo-wrapper">
+      <%= image_tag('sinai/logo-arcadia.png', class: 'footer-logo', alt: 'UCLA Library Digital Collections Logo') %>
     </div>
   </div>
 </footer>

--- a/app/views/shared/_sinai_footer.html.erb
+++ b/app/views/shared/_sinai_footer.html.erb
@@ -1,0 +1,33 @@
+<footer>
+  <div class='primary-footer-wrapper'>
+    <div class="col1">
+    https://catalin.red/how-to-create-triangle-shapes/
+  <svg xmlns="http://www.w3.org/2000/svg" width="25px" height="25px" margin="0 auto" fill="#800020" >
+    <polygon points="0,0 25,0 12.5,25"/>
+  </svg>
+  
+    </div>
+    <div class="col2">
+      <%= link_to(image_tag('logo/ucla-library-logo.svg', class: 'logo', alt: 'UCLA Library Logo'), 'https://www.library.ucla.edu/', target: '_blank', rel: 'noopener') %>
+    </div>
+    <div class="col3">
+      <%= link_to(image_tag('logo/ucla-library-logo.svg', class: 'logo', alt: 'UCLA Library Logo'), 'https://www.library.ucla.edu/', target: '_blank', rel: 'noopener') %>
+    </div>
+  </div>
+
+  <div class='secondary-footer-wrapper'>
+    <div class="col4">
+      <%= link_to(image_tag('logo/ucla-library-logo.svg', class: 'logo', alt: 'UCLA Library Logo'), 'https://www.library.ucla.edu/', target: '_blank', rel: 'noopener') %>
+    </div>
+    <div class="col5">
+      <%= link_to(image_tag('logo/ucla-library-logo.svg', class: 'logo', alt: 'UCLA Library Logo'), 'https://www.library.ucla.edu/', target: '_blank', rel: 'noopener') %>
+    </div>
+  </div>
+</footer>
+
+<div class='copyright'>
+  <div class='uc-regents'>
+
+    &#169; 2020
+  </div>
+</div>

--- a/app/views/shared/_sinai_footer.html.erb
+++ b/app/views/shared/_sinai_footer.html.erb
@@ -1,33 +1,36 @@
 <footer>
   <div class='primary-footer-wrapper'>
-    <div class="col1">
-    https://catalin.red/how-to-create-triangle-shapes/
-  <svg xmlns="http://www.w3.org/2000/svg" width="25px" height="25px" margin="0 auto" fill="#800020" >
-    <polygon points="0,0 25,0 12.5,25"/>
-  </svg>
-  
+    <div class="logo1">
+      <%= link_to(image_tag('sinai/logo-uclalib-blk.svg', class: 'logo', alt: 'UCLA Library Logo'), 'https://www.library.ucla.edu/', target: '_blank', rel: 'noopener') %>
     </div>
-    <div class="col2">
-      <%= link_to(image_tag('logo/ucla-library-logo.svg', class: 'logo', alt: 'UCLA Library Logo'), 'https://www.library.ucla.edu/', target: '_blank', rel: 'noopener') %>
+    <div class="logo2">
+      <%= image_tag('sinai/logo-sinai.png', class: 'navbar-logo sinai-logo', alt: 'UCLA Library Digital Collections Logo') %>
     </div>
-    <div class="col3">
-      <%= link_to(image_tag('logo/ucla-library-logo.svg', class: 'logo', alt: 'UCLA Library Logo'), 'https://www.library.ucla.edu/', target: '_blank', rel: 'noopener') %>
+    <div class="logo3">
+      <%= image_tag('sinai/logo-emel.png', class: 'navbar-logo', alt: 'UCLA Library Digital Collections Logo') %>
     </div>
-  </div>
-
-  <div class='secondary-footer-wrapper'>
-    <div class="col4">
-      <%= link_to(image_tag('logo/ucla-library-logo.svg', class: 'logo', alt: 'UCLA Library Logo'), 'https://www.library.ucla.edu/', target: '_blank', rel: 'noopener') %>
+    <div class="logo4">
+      <%= image_tag('sinai/logo-ahmanson.png', class: 'navbar-logo', alt: 'UCLA Library Digital Collections Logo') %>
     </div>
-    <div class="col5">
-      <%= link_to(image_tag('logo/ucla-library-logo.svg', class: 'logo', alt: 'UCLA Library Logo'), 'https://www.library.ucla.edu/', target: '_blank', rel: 'noopener') %>
+    <div class="logo5">
+      <%= image_tag('sinai/logo-arcadia.png', class: 'navbar-logo', alt: 'UCLA Library Digital Collections Logo') %>
     </div>
   </div>
 </footer>
 
-<div class='copyright'>
-  <div class='uc-regents'>
-
-    &#169; 2020
+<div class='secondary-footer-wrapper'>
+  <div class='footer-links'>
+    <ul>
+      <li><%= link_to 'UCLA Library Digital Collections', 'https://www.library.ucla.edu/'  %></li>
+      <li><%= link_to 'Contact Us', 'https://www.library.ucla.edu/' %></li>
+    </ul>
   </div>
 </div>
+
+<div class='copyright'>
+  <div class="uc-regents">
+    © <span id="copyright-year"></span> UC Regents. All rights reserved.
+  </div>
+</div>
+
+<script>$("#copyright-year").text(new Date().getFullYear());</script>

--- a/app/views/shared/_ursus_footer.html.erb
+++ b/app/views/shared/_ursus_footer.html.erb
@@ -1,0 +1,28 @@
+<footer>
+  <div class='footer-wrapper'>
+    <div class="col1">
+      <%= link_to(image_tag('logo/ucla-library-logo.svg', class: 'logo', alt: 'UCLA Library Logo'), 'https://www.library.ucla.edu/', target: '_blank', rel: 'noopener') %>
+    </div>
+    <div class="col2">
+      <ul>
+        <li><%= link_to 'Copyright and Collections', '/copyrights_and_collections' %></li>
+        <li><%= link_to 'Privacy Policy', '/privacy_policy' %></li>
+        <li><%= link_to 'Contact Us', '/contact' %></li>
+      </ul>
+    </div>
+    <div class="col3">
+      <ul>
+        <li><%= link_to 'Visit Our Legacy Site', 'http://digital2.library.ucla.edu/', target: '_blank', rel: 'noopener' %></li>
+        <li><%= link_to 'Give Us Feedback', 'https://forms.gle/x2BV9dJMK241VsAJA', target: '_blank', rel: 'noopener' %></li>
+        
+        <!--<li>Migration Updates</li>-->
+      </ul>
+    </div>
+  </div>
+</footer>
+
+<div class='copyright'>
+  <div class='uc-regents'>
+    &#169; 2019 UC Regents. All rights reserved.
+  </div>
+</div>


### PR DESCRIPTION
Connected to [URS-584](https://jira.library.ucla.edu/browse/URS-584)

- [x] Create footer for logos
    - [x] Background color: callisto-beige
    - [x] Update UCLA logo to black version
    - [x] Add partner logos:
        - [x] St. Catherines
        - [x] EMEL
        - [x] Ahmanson
        - [x] Arcadia
    - [x] Update secondary footer background color: callisto-drk-beige
    - [x] Update tertiary (copyright) footer background color: callisto-drk-red
    - [x]  Update text and/or links to secondary and tertiary footers
        - [x] Update: Remove "Copyrights and Collections" and "Privacy Policy" links
    - [x] Make footers responsive See screenshots and Invision boards
    - [x] Update copyright year

 This jquery code auto updates the year: `$("#copyright-year").text(new Date().getFullYear());`
```
<div class="uc-regents">
© <span id="copyright-year"></span> UC Regents. All rights reserved.
</div>
```

---

### Screenshots
#### SINAI
#### URSUS
![Screen Shot 2020-01-29 at 11 23 09 AM](https://user-images.githubusercontent.com/751697/73389807-cc136f80-4289-11ea-80c7-faf049a31e1f.png)

---

+ `app/assets/stylesheets/sinai-extras.scss`
+ `app/assets/stylesheets/sinai/_footer.scss`
+ `app/assets/stylesheets/ursus/_search--searchbar.scss`
+ `app/views/shared/_footer.html.erb`
+ `app/views/shared/_sinai_footer.html.erb`
+ `app/views/shared/_ursus_footer.html.erb `
