### PR TITLE
Swap Mirador for UV in Callisto

### DIFF
--- a/app/assets/javascripts/media_viewer_width.js
+++ b/app/assets/javascripts/media_viewer_width.js
@@ -1,0 +1,7 @@
+$(document).on('turbolinks:load', function () {
+  $('#media-viewer-iframe').width($('.media-viewer-container').width())
+
+  $(window).on('resize', function () {
+    $('#media-viewer-iframe').width($('.media-viewer-container').width())
+  })
+})

--- a/app/assets/javascripts/uv_width.js
+++ b/app/assets/javascripts/uv_width.js
@@ -1,7 +1,0 @@
-$(document).on('turbolinks:load', function() {
-  $('#universal-viewer-iframe').width($('.uv-container').width())
-
-  $(window).on('resize', function(){
-    $('#universal-viewer-iframe').width($('.uv-container').width())
-  })
-})

--- a/app/assets/stylesheets/ursus/_univ-viewr.scss
+++ b/app/assets/stylesheets/ursus/_univ-viewr.scss
@@ -1,4 +1,4 @@
-.universal-viewer {
+.media-viewer {
   margin-bottom: 25px;
   display: flex;
   flex-direction: column;
@@ -6,7 +6,7 @@
 
 }
 
-.uv-container {
+.media-viewer-container {
   max-width: 900px;
   width: 100%;
   margin: 0 auto;

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -50,7 +50,7 @@ class CatalogController < ApplicationController
     config.default_solr_params[:fq] = '(((has_model_ssim:Work) OR (has_model_ssim:Collection)) AND !(visibility_ssi:restricted))' if Flipflop.sinai?
 
     # config.show.partials.insert(1, :collection_banner)
-    config.show.partials.insert(2, :uv)
+    config.show.partials.insert(2, :media_viewer)
 
     # solr field configuration for document/show views
     config.index.title_field = 'title_tesim'

--- a/app/services/iiif_service.rb
+++ b/app/services/iiif_service.rb
@@ -2,7 +2,11 @@
 
 class IiifService
   def src(request, document)
-    "#{request&.base_url}/uv/uv.html#?manifest=#{CGI.escape(iiif_manifest_url(document))}"
+    if Flipflop.sinai?
+      "#{request&.base_url}/mirador.html#?manifest=#{CGI.escape(iiif_manifest_url(document))}"
+    else
+      "#{request&.base_url}/uv/uv.html#?manifest=#{CGI.escape(iiif_manifest_url(document))}"
+    end
   end
 
   def iiif_manifest_url(document)

--- a/app/views/catalog/_media_viewer.html.erb
+++ b/app/views/catalog/_media_viewer.html.erb
@@ -1,14 +1,14 @@
 <% if can?(:read, document) %>
 
-<div class='uv-container'>
-  <div class='universal-viewer'>
+<div class='media-viewer-container'>
+  <div class='media-viewer'>
     <% iiif_service = IiifService.new %>
     <iframe
-        class='universal-viewer-iframe'
+        class='media-viewer-iframe'
         src=<%= iiif_service.src(request, document) %>
         width='924px'
         height='668px'
-        id='universal-viewer-iframe'
+        id='media-viewer-iframe'
         allowfullscreen
         frameborder='0'>
     </iframe>

--- a/public/mirador.html
+++ b/public/mirador.html
@@ -1,0 +1,60 @@
+<!--
+    This is what the embed iframe src links to. It doesn't need to communicate with the parent page, only fill the available space and look for #? parameters
+-->
+
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <link rel="icon" href="favicon.ico">
+  <link rel="stylesheet" type="text/css" href="https://unpkg.com/mirador@2.6.0/dist/css/mirador-combined.min.css">
+  <script src="https://unpkg.com/mirador@2.6.0/dist/mirador.min.js"></script>
+</head>
+
+<body>
+
+  <div id="viewer"></div>
+  <script type="text/javascript">
+    $(function () {
+      var urlParams = {};
+      var urlParts = window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function (m, key, value) {
+        urlParams[key] = value;
+      });
+
+      manifestURL = decodeURIComponent(urlParams['manifest']);
+
+      myMiradorInstance = Mirador({
+        "id": "viewer",
+        "layout": "1",
+        "buildPath": "https://unpkg.com/mirador@2.6.0/dist/",
+        "data": [{
+          "manifestUri": manifestURL,
+          "location": "UCLA"
+        }],
+        "windowObjects": [{
+          loadedManifest: manifestURL,
+          viewType: "ImageView",
+          slotAddress: "row1.column1"
+        }],
+        "annotationEndpoint": {
+          "name": "Local Storage",
+          "module": "LocalStorageEndpoint"
+        },
+        "windowSettings": {
+          "canvasControls": { // The types of controls available to be displayed on a canvas
+            "imageManipulation": {
+              "manipulationLayer": true,
+              "controls": {
+                "mirror": true
+              }
+            }
+          }
+        }
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/spec/services/iiif_service_spec.rb
+++ b/spec/services/iiif_service_spec.rb
@@ -37,4 +37,26 @@ RSpec.describe IiifService do
       end
     end
   end
+
+  describe '#src' do
+    before do
+      allow(Flipflop).to receive(:use_manifest_store?).and_return(true)
+    end
+
+    let(:request) { instance_double('ActionDispatch::Request', base_url: 'http://test.url') }
+
+    context 'by default' do
+      it 'links to universal viewer' do
+        allow(Flipflop).to receive(:sinai?).and_return(false)
+        expect(service.src(request, solr_document)).to eq 'http://test.url/uv/uv.html#?manifest=https%3A%2F%2Fmanifest.store%2Fark%253A%252Fabc%252F123%2Fmanifest'
+      end
+    end
+
+    context 'when the sinai feature flag is set' do
+      it 'links to mirador' do
+        allow(Flipflop).to receive(:sinai?).and_return(true)
+        expect(service.src(request, solr_document)).to eq 'http://test.url/mirador.html#?manifest=https%3A%2F%2Fmanifest.store%2Fark%253A%252Fabc%252F123%2Fmanifest'
+      end
+    end
+  end
 end

--- a/spec/system/view_metadata_only_work_spec.rb
+++ b/spec/system/view_metadata_only_work_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "View a metadata-only Work", js: true do
     }
   end
 
-  let(:css_selector_for_uv) { '.universal-viewer' }
+  let(:css_selector_for_uv) { '.media-viewer' }
 
   it 'only displays Universal Viewer if user has at least "read"-level access' do
     # Should see Universal Viewer

--- a/spec/system/view_work_spec.rb
+++ b/spec/system/view_work_spec.rb
@@ -104,9 +104,9 @@ RSpec.describe 'View a Work', type: :system, js: true do
 
   it 'loads UV on the page with the correct controls' do
     visit solr_document_path(id)
-    expect(page.html).to match(/universal-viewer-iframe/)
+    expect(page.html).to match(/media-viewer-iframe/)
 
-    within_frame(find('#universal-viewer-iframe')) do
+    within_frame(find('#media-viewer-iframe')) do
       # Don't show download
       expect(page).to have_selector('button.download', visible: false)
       # Show fullscreen


### PR DESCRIPTION
- renames the _uv.html.erb partial and associated css classes to be more generic, not specific to uv
- adds a standalone mirador as a static page
- links the media-viewer iframe to mirador instead of UV when the sinai? feature flag is set