### PR TITLE
[URS-593] Add required styles for Callisto's item page

### DIFF
--- a/app/assets/stylesheets/sinai-extras.scss
+++ b/app/assets/stylesheets/sinai-extras.scss
@@ -8,6 +8,7 @@
 @import "sinai/search_results";
 @import "sinai/search--show-page";
 @import "sinai/secondary_metadata";
+@import "sinai/show";
 @import "sinai/sinai_navbar";
 @import "sinai/sort_pagination";
 @import "sinai/utilities";

--- a/app/assets/stylesheets/sinai-extras.scss
+++ b/app/assets/stylesheets/sinai-extras.scss
@@ -7,6 +7,7 @@
 @import "sinai/search--filter";
 @import "sinai/search_results";
 @import "sinai/search--show-page";
+@import "sinai/secondary_metadata";
 @import "sinai/sinai_navbar";
 @import "sinai/sort_pagination";
 @import "sinai/utilities";

--- a/app/assets/stylesheets/sinai-extras.scss
+++ b/app/assets/stylesheets/sinai-extras.scss
@@ -6,6 +6,7 @@
 @import "sinai/search_searchbar";
 @import "sinai/search--filter";
 @import "sinai/search_results";
+@import "sinai/search--show-page";
 @import "sinai/sinai_navbar";
 @import "sinai/sort_pagination";
 @import "sinai/utilities";

--- a/app/assets/stylesheets/sinai/_document.scss
+++ b/app/assets/stylesheets/sinai/_document.scss
@@ -1,10 +1,8 @@
-@import 'ursus/colors';
-
 #documents {
   .document-title-heading {
     font-weight: 400;
     font-size: 1rem;
-    color: $ucla-darker-blue;
+    color: black;
     flex: 0 0 100%;
     max-width: 100%;
   }
@@ -24,11 +22,11 @@
   .document-metadata-title {
     margin-right: 0px;
     margin-left: 30px;
-    color: $black;
+    color: black;
     font-weight: 500;
     font-size: 1.2rem;
     a:link {
-      color: $black !important;
+      color: black !important;
     }
   }
 
@@ -37,7 +35,7 @@
     margin-left: 1em;
     dt {
       font-weight: bold;
-      color: $ucla-darkest-blue;
+      color: black;
       font-size: 1rem;
     }
     dd {

--- a/app/assets/stylesheets/sinai/_search--show-page.scss
+++ b/app/assets/stylesheets/sinai/_search--show-page.scss
@@ -50,7 +50,7 @@
 
 .back-and-new-container {
   height: 46px;
-  border-bottom: 1px solid #dee2e6;
+  border-bottom: 1px solid $callisto-light-red;
   margin-top: 30px;
   margin-bottom: 30px;
   display: flex;

--- a/app/assets/stylesheets/sinai/_search--show-page.scss
+++ b/app/assets/stylesheets/sinai/_search--show-page.scss
@@ -10,11 +10,7 @@
   margin-right: 20px;
   float: right;
   width: 175px !important;
-  border-left: solid;
-  border-left: 1px solid $callisto-light-red !important;
-  border-right: 1px solid $callisto-light-red !important;
-  border-top: 0 none !important;
-  border-bottom: 0 none !important;
+  border: 1px solid $callisto-light-red !important;
 }
 
 .total-results {

--- a/app/assets/stylesheets/sinai/_search--show-page.scss
+++ b/app/assets/stylesheets/sinai/_search--show-page.scss
@@ -1,0 +1,82 @@
+
+.new-search-link {
+  padding-right: 15px;
+  margin-right: 2px;
+  float: right;
+}
+
+.back-to-search-link {
+  color: black !important;
+  margin-right: 20px;
+  float: right;
+  width: 175px !important;
+  border-left: solid;
+  border-left: 1px solid $callisto-light-red !important;
+  border-right: 1px solid $callisto-light-red !important;
+  border-top: 0 none !important;
+  border-bottom: 0 none !important;
+}
+
+.total-results {
+  color: black !important;
+}
+
+.back-and-new-links-show {
+  float: right;
+  clear: left;
+  padding-top: 6px;
+  a {
+    height: 30px;
+    width: 138px;
+    color: black;
+    background-color: $white;
+    font-family: Helvetica;
+    font-size: 14px;
+    line-height: 17px;
+    text-align: center;
+    border: 1px solid $ucla-darker-blue;
+    border-radius: 0px;
+  }
+  a:hover {
+    height: 30px;
+    width: 138px;
+    color: $callisto-beige !important;
+    background-color: $callisto-drk-red;
+    font-family: Helvetica;
+    font-size: 14px;
+    line-height: 17px;
+    text-align: center;
+    border: 1px solid $callisto-drk-red;
+    border-radius: 0px;
+    padding-bottom: 3px;
+  }
+}
+
+.back-and-new-container {
+  height: 46px;
+  border-bottom: 1px solid #dee2e6;
+  margin-top: 30px;
+  margin-bottom: 30px;
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 50px;
+}
+
+.previous-next {
+  padding-left: 15px;
+  padding-top: 6px;
+  color: black !important;
+}
+
+.previous {
+  color: black !important;
+}
+
+.next {
+  color: black !important;
+}
+
+.search-breadcrumbs {
+  margin-left: 10px;
+  margin-top: -9px;
+}

--- a/app/assets/stylesheets/sinai/_secondary_metadata.scss
+++ b/app/assets/stylesheets/sinai/_secondary_metadata.scss
@@ -1,0 +1,30 @@
+.secondary-metadata {
+  background: $callisto-beige;
+  padding-left: 1.5rem;
+  padding-right: 1rem;
+  dt: col-md-4;
+  .item-label {
+    width: 100%;
+    padding-right: 0px;
+  }
+  .item-value {
+    width: 100%;
+    padding-right: 0px;
+  }
+  dl {
+    margin-top: 0;
+    margin-bottom: .05rem;
+  }
+  .document-metadata {
+    padding-right: 0px;
+
+  }
+  hr {
+    margin-right: 2px;
+  }
+}
+.item-value {
+  width: 100%;
+  padding-right: 0px;
+  margin-bottom: 7px;
+}

--- a/app/assets/stylesheets/sinai/_show.scss
+++ b/app/assets/stylesheets/sinai/_show.scss
@@ -1,0 +1,128 @@
+.item-page-wrapper{
+  margin-top: 100px;
+}
+.primary-metadata {
+  h5{
+    font-size: 24px;
+  }
+  .document-metadata{
+    padding: 1rem 0;
+  }
+  .item-label {
+    font-weight: bold;
+        color: $gray-40;
+        font-size: 14px;
+        letter-spacing: 1.5px;
+        text-align: right;
+        text-transform: uppercase;
+  }
+  
+  .item-value {
+    font-size: 18px;
+  }
+}
+.item-heading {
+  padding-top: 17px;
+  padding-bottom: 10px;
+  font-weight: 600;
+}
+
+.secondary-metadata{
+  
+  hr{
+    border-top-color:$white;
+    margin-right: 30px;
+    margin-left: -5px;
+  }
+  .access-condition-metadata{
+    padding-bottom: 50px;
+  }
+
+  .item-label {
+    font-weight: bold;
+    color: $gray-40;
+    font-size: 13px;
+    letter-spacing: 1.5px;
+    text-align: right;
+    text-transform: uppercase;
+    padding-bottom: 6px;
+    padding-top: 3px;
+  }
+  
+  .item-value {
+    font-size: 15px;
+    padding-right: 16px; 
+  }
+}
+
+
+.item-title h1 {
+  margin: 0 auto 10px auto;
+  max-width: 900px;
+  font-size: 2rem;
+}
+
+dl {
+  padding-left: 7px;
+}
+
+h3 {
+  font-weight: 340;
+  font-size: 24px;
+}
+
+.field-name {
+  font-weight: 700;
+  color: black;
+}
+
+.sort-pagination, .pagination-search-widgets {
+  border-bottom: 0px !important;
+}
+
+@media screen and (max-width: 768px) {
+  .primary-metadata{
+  
+  .item-label {
+    text-align: left;
+    font-size: 13px;
+  }
+  .item-value {
+    font-size: 16px;
+  }
+  }
+  .secondary-metadata{
+    .item-label {
+      text-align: left;
+      font-size: 13px;
+    }
+    .item-value {
+      font-size: 16px;
+    }
+  }
+
+}
+@media screen and (max-width: 992px) {
+  .item-page-wrapper{
+    width: 100%;
+  }
+  .primary-metadata{
+  
+    .item-label {
+      text-align: left;
+      font-size: 13px;
+    }
+    .item-value {
+      font-size: 16px;
+    }
+  }
+  .secondary-metadata{
+    .item-label {
+      text-align: left;
+      font-size: 13px;
+    }
+    .item-value {
+      font-size: 16px;
+    }
+  }
+}

--- a/app/views/catalog/_keyword_metadata.html.erb
+++ b/app/views/catalog/_keyword_metadata.html.erb
@@ -2,7 +2,11 @@
 <% keyword = Ursus::KeywordMetadataPresenter.new(document: doc_presenter.fields_to_render).keyword_terms %>
 
 <% if keyword.length > 0 %>
-    <hr>
+    <% if Flipflop.sinai? %>
+        <hr class='divider__red'>
+      <% else %>
+        <hr>
+    <% end %>
     <h5>Keywords</h5>
     <dl class='row document-metadata'>
       <% keyword.each do |field_name, field| -%>

--- a/app/views/catalog/_note_metadata.html.erb
+++ b/app/views/catalog/_note_metadata.html.erb
@@ -2,7 +2,11 @@
 <% note = Ursus::NoteMetadataPresenter.new(document: doc_presenter.fields_to_render).note_terms %>
 
 <% if note.length > 0 %>
-    <hr>
+    <% if Flipflop.sinai? %>
+        <hr class='divider__red'>
+      <% else %>
+        <hr>
+    <% end %>
     <h5>Notes</h5>
     <dl class='row document-metadata'>
       <% note.each do |field_name, field| -%>

--- a/app/views/catalog/_physical_description_metadata.html.erb
+++ b/app/views/catalog/_physical_description_metadata.html.erb
@@ -2,7 +2,11 @@
 <% physical_description = Ursus::PhysicalDescriptionMetadataPresenter.new(document: doc_presenter.fields_to_render).physical_description_terms %>
 
 <% if physical_description.length > 0 %>
-    <hr>
+    <% if Flipflop.sinai? %>
+        <hr class='divider__red'>
+      <% else %>
+        <hr>
+    <% end %>
     <h5>Physical Description</h5>
     <dl class='row document-metadata'>
       <% physical_description.each do |field_name, field| -%>

--- a/app/views/catalog/_secondary_metadata.html.erb
+++ b/app/views/catalog/_secondary_metadata.html.erb
@@ -1,5 +1,9 @@
 <div class='secondary-metadata'>
   <%= render 'local_info_metadata', { document: document } %>
-  <hr>
+    <% if Flipflop.sinai? %>
+        <hr class='divider__red'>
+      <% else %>
+        <hr>
+    <% end %>
   <%= render 'access_condition_metadata', { document: document } %>
 </div>


### PR DESCRIPTION
- [x] update color for "back-to-search" link/button
  - [x] outline is callisto-light-red
  - [x] hover state color is callisto-drk-red with callisto-beige text
- [x] update divider line color to callisto-light-red
- [x] update secondary metadata background color to callisto-beige

Done outside of this PR:
- [x] Expand sizing of viewer area