### PR TITLE
Apps 423 emel authn callback fix2

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
   end
 
   def sinai_authn_check
-    return if ENV['SINAI_ID_BYPASS'] # skip auth in development
+    ###return if ENV['SINAI_ID_BYPASS'] # skip auth in development
     return if !Flipflop.sinai? || [login_path, version_path].include?(request.path) || sinai_authenticated?
     if ucla_token?
       set_auth_cookies
@@ -92,6 +92,7 @@ class ApplicationController < ActionController::Base
     end
 
     def redirect_target
-      "/login?callback=#{request.original_url}"
+      cookies[:request_original_url] = request.original_url
+      "/login"
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
   end
 
   def sinai_authn_check
-    ###return if ENV['SINAI_ID_BYPASS'] # skip auth in development
+    return if ENV['SINAI_ID_BYPASS'] # skip auth in development
     return if !Flipflop.sinai? || [login_path, version_path].include?(request.path) || sinai_authenticated?
     if ucla_token?
       set_auth_cookies

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -5,8 +5,8 @@ class LoginController < ApplicationController
   before_action :create_token
 
   def new
-    @requested_path = params[:callback]
     # save in order to allow later verification that the login page was accessed
+    @requested_path = cookies[:request_original_url]
     cookies[:requested_path] = @requested_path
   end
 


### PR DESCRIPTION
[APPS-423](https://jira.library.ucla.edu/browse/APPS-423)

Added code to ensure that multi-parameter querystrings are correctly passed to redirect the browser after successful login. The previous version was chopping after the first parameter. More details in the [ticket](https://jira.library.ucla.edu/browse/APPS-423).