### PR TITLE
Add contrast to Callisto navbar background at lower resolution

### DIFF
--- a/app/assets/stylesheets/sinai/_search_searchbar.scss
+++ b/app/assets/stylesheets/sinai/_search_searchbar.scss
@@ -6,7 +6,8 @@
 
 .search-form {
   .custom-select {
-    background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3e%3cpath fill='%23800020' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right 0.75rem center/8px 10px !important;
+    background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3e%3cpath fill='%23800020' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e")
+      no-repeat right 0.75rem center/8px 10px !important;
     background-color: $callisto-drk-beige !important;
   }
 
@@ -16,4 +17,9 @@
     color: $gray-80;
     font-weight: 600;
   }
+}
+
+// Search bar search icon
+.input-group-append svg g {
+  stroke: $callisto-drk-red;
 }

--- a/app/assets/stylesheets/sinai/_show.scss
+++ b/app/assets/stylesheets/sinai/_show.scss
@@ -1,22 +1,22 @@
-.item-page-wrapper{
+.item-page-wrapper {
   margin-top: 100px;
 }
 .primary-metadata {
-  h5{
+  h5 {
     font-size: 24px;
   }
-  .document-metadata{
+  .document-metadata {
     padding: 1rem 0;
   }
   .item-label {
     font-weight: bold;
-        color: $gray-40;
-        font-size: 14px;
-        letter-spacing: 1.5px;
-        text-align: right;
-        text-transform: uppercase;
+    color: $gray-40;
+    font-size: 14px;
+    letter-spacing: 1.5px;
+    text-align: right;
+    text-transform: uppercase;
   }
-  
+
   .item-value {
     font-size: 18px;
   }
@@ -27,14 +27,13 @@
   font-weight: 600;
 }
 
-.secondary-metadata{
-  
-  hr{
-    border-top-color:$white;
+.secondary-metadata {
+  hr {
+    border-top-color: $white;
     margin-right: 30px;
     margin-left: -5px;
   }
-  .access-condition-metadata{
+  .access-condition-metadata {
     padding-bottom: 50px;
   }
 
@@ -48,18 +47,17 @@
     padding-bottom: 6px;
     padding-top: 3px;
   }
-  
+
   .item-value {
     font-size: 15px;
-    padding-right: 16px; 
+    padding-right: 16px;
   }
 }
-
 
 .item-title h1 {
   margin: 0 auto 10px auto;
   max-width: 900px;
-  font-size: 2rem;
+  font-size: 1.65rem;
 }
 
 dl {
@@ -76,38 +74,16 @@ h3 {
   color: black;
 }
 
-.sort-pagination, .pagination-search-widgets {
+.sort-pagination,
+.pagination-search-widgets {
   border-bottom: 0px !important;
 }
 
-@media screen and (max-width: 768px) {
-  .primary-metadata{
-  
-  .item-label {
-    text-align: left;
-    font-size: 13px;
-  }
-  .item-value {
-    font-size: 16px;
-  }
-  }
-  .secondary-metadata{
-    .item-label {
-      text-align: left;
-      font-size: 13px;
-    }
-    .item-value {
-      font-size: 16px;
-    }
-  }
-
-}
 @media screen and (max-width: 992px) {
-  .item-page-wrapper{
+  .item-page-wrapper {
     width: 100%;
   }
-  .primary-metadata{
-  
+  .primary-metadata {
     .item-label {
       text-align: left;
       font-size: 13px;
@@ -116,7 +92,7 @@ h3 {
       font-size: 16px;
     }
   }
-  .secondary-metadata{
+  .secondary-metadata {
     .item-label {
       text-align: left;
       font-size: 13px;
@@ -124,5 +100,29 @@ h3 {
     .item-value {
       font-size: 16px;
     }
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .primary-metadata {
+    .item-label {
+      text-align: left;
+      font-size: 13px;
+    }
+    .item-value {
+      font-size: 16px;
+    }
+  }
+  .secondary-metadata {
+    .item-label {
+      text-align: left;
+      font-size: 13px;
+    }
+    .item-value {
+      font-size: 16px;
+    }
+  }
+  .item-title h1 {
+    font-size: 1.35rem;
   }
 }

--- a/app/assets/stylesheets/sinai/_sinai_navbar.scss
+++ b/app/assets/stylesheets/sinai/_sinai_navbar.scss
@@ -2,7 +2,6 @@
 
 .sinai-site-navbar {
   background-color: $white !important;
-  padding: 0.25rem 0 100 0 !important;
   font-family: Helvetica, sans-serif;
 
   .navbar-logo-block {
@@ -54,8 +53,10 @@
 
 @media (max-width: 991px) {
   .sinai-site-navbar {
+    padding: 0 !important;
     .navbar-logo-block {
       height: 45px;
+      padding: 2rem 1rem;
     }
 
     .navbar-toggler {
@@ -67,8 +68,12 @@
     }
 
     .navbar-nav.nav {
-      background-color: $white;
+      background-color: $callisto-beige;
       width: 100%;
+      padding: 1rem 1rem;
+      &:hover {
+        background-color: $callisto-drk-beige;
+      }
     }
 
     .navbar-collapse {
@@ -77,16 +82,22 @@
 
     .nav-item a {
       margin-right: 0;
-    }
-
-    .nav-item {
-      padding: 12px 15px;
-      border-bottom: 1px solid $callisto-light-red;
-    }
-
-    .nav-item:hover {
-      a {
+      &::after {
+        content: " ";
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        border-bottom: 0;
+        -webkit-transition: none;
+        transition: none;
+      }
+      &:hover {
         color: $callisto-drk-red !important;
+        text-decoration: underline;
+      }
+      &:hover::after {
+        right: 0%;
       }
     }
   }
@@ -106,6 +117,9 @@
 
 @media (max-width: 374px) {
   .sinai-site-navbar {
+    .navbar-logo-block {
+      padding: 0rem 1rem;
+    }
     .sinai-navbar-logo a {
       font-size: 0.9rem;
       font-weight: 600;
@@ -116,6 +130,9 @@
       justify-content: unset;
       align-items: flex-start;
       height: 50px;
+    }
+    .navbar-nav.nav {
+      padding: 0.85rem;
     }
   }
 }


### PR DESCRIPTION
- Add contrasting background to Callisto navbar for tablet resolution and smaller
- Remove nav link animation at tablet resolution and smaller
- Update color for searchbar search icon to callisto-red
- Adjust font size of item level page heading

**Before:**
<img width="736" alt="Screen Shot 2020-01-31 at 12 04 10 PM" src="https://user-images.githubusercontent.com/24995224/73573911-534b1980-4429-11ea-8546-e3695ae51b88.png">

<img width="165" alt="Screen Shot 2020-01-31 at 1 00 13 PM" src="https://user-images.githubusercontent.com/24995224/73574091-af15a280-4429-11ea-97b4-55bd6131ff0a.png">


**After:**
<img width="626" alt="Screen Shot 2020-01-31 at 12 36 02 PM" src="https://user-images.githubusercontent.com/24995224/73573905-4d553880-4429-11ea-9fc5-210599039df9.png">

<img width="178" alt="Screen Shot 2020-01-31 at 1 00 20 PM" src="https://user-images.githubusercontent.com/24995224/73574103-b341c000-4429-11ea-8195-d2950a400fb7.png">
