### PR TITLE
[URS-617] Use flip-flop to set the meta description for both Ursus and Callisto in the base.html layout

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -9,7 +9,11 @@
     <% if controller.controller_name == 'catalog' && controller.action_name == 'show' %>
       <meta name="Description" content=<%= render_page_title %>>
     <% else %>
-    <meta name="Description" content="The UCLA Library Digital Collections includes rare and unique digital materials developed by the UCLA Library to support education, research, service, and creative expression. This website is our new interface for discovery and engagement of these collections. See collections of historic photographs and manuscripts. More collections added weekly.">
+      <% if Flipflop.sinai? %><!-- SINAI -->
+        <meta name="Description" content="St. Catherine's Monastery of the Sinai, in partnership with the Early Manuscripts Electronic Library (EMEL) and the UCLA Library, welcomes you to the Sinai Manuscripts Digital Library. Widely recognized as the world’s oldest continually operating library, St. Catherine’s holdings represent an unparalleled resource to study the history and literature of the Eastern Mediterranean from late antiquity until early modernity.">
+      <% else%><!-- URSUS -->
+        <meta name="Description" content="The UCLA Library Digital Collections includes rare and unique digital materials developed by the UCLA Library to support education, research, service, and creative expression. This website is our new interface for discovery and engagement of these collections. See collections of historic photographs and manuscripts. More collections added weekly.">
+      <% end %>
     <% end %>
     <meta name="theme-color" content="#2774ae"/>
 


### PR DESCRIPTION
Connected to [URS-617](https://jira.library.ucla.edu/browse/URS-617)

Use `flip-flop` to set the meta description for both Ursus and Callisto

---

screenshot for Ursus
![image](https://user-images.githubusercontent.com/611569/73959977-c04e2b80-48cf-11ea-8e5e-bfbf1ed9ab9a.png)

screenshot for Callisto/Sinai
![image](https://user-images.githubusercontent.com/611569/73959997-c7753980-48cf-11ea-8ead-e91636cdc56f.png)

---

+ modified: `app/views/layouts/blacklight/base.html.erb`