### PR TITLE
Fix OCLC Number

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -175,7 +175,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'medium_tesim'
     config.add_show_field 'member_of_collections_ssim', label: 'Collection', link_to_facet: 'member_of_collections_ssim' unless Flipflop.sinai?
     config.add_show_field 'named_subject_tesim', link_to_facet: 'named_subject_sim', separator_options: BREAKS
-    config.add_show_field 'oclc_tesim_ssi', label: 'OCLC Number'
+    config.add_show_field 'oclc_ssi', label: 'OCLC Number'
     config.add_show_field 'page_layout_ssim', label: 'Page layout'
     config.add_show_field 'photographer_tesim', label: 'Photographer', link_to_facet: 'photographer_sim', separator_options: BREAKS
     config.add_show_field 'place_of_origin_tesim', separator_options: BREAKS

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -93,7 +93,7 @@ en:
           named_subject_tesim: 'Names'
           normalized_date_sim: 'Date'
           normalized_date_tesim: 'Normalized Date'
-          oclc_tesim_ssi: 'OCLC Number'
+          oclc_ssi: 'OCLC Number'
           photographer_tesim: 'Photographer'
           place_of_origin_tesim: 'Place of Origin'
           publisher_tesim: 'Publisher'

--- a/config/metadata/local_info_metadata.yml
+++ b/config/metadata/local_info_metadata.yml
@@ -1,4 +1,4 @@
 repository_tesim: 'Repository'
 local_identifier_ssm: 'Local identifier'
-oclc_tesim_ssi: 'OCLC Number'
+oclc_ssi: 'OCLC Number'
 ark_ssi: 'ARK'

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe CatalogController, type: :controller do
        "identifier_tesim", "illuminator_tesim", "illustrations_note_tesim",
        "keyword_tesim", "latitude_tesim", "location_tesim", "local_identifier_ssm",
        "longitude_tesim", "lyricist_tesim", "medium_tesim", "member_of_collections_ssim",
-       "named_subject_tesim", "oclc_tesim_ssi", "page_layout_ssim", "photographer_tesim",
+       "named_subject_tesim", "oclc_ssi", "page_layout_ssim", "photographer_tesim",
        "place_of_origin_tesim", "provenance_tesim", "publisher_tesim",
        "repository_tesim", "rights_country_tesim", "rights_holder_tesim",
        "scribe_tesim", "services_contact_ssm", "subject_tesim", "subject_topic_tesim",

--- a/spec/presenters/ursus/local_info_metadata_presenter_spec.rb
+++ b/spec/presenters/ursus/local_info_metadata_presenter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Ursus::LocalInfoMetadataPresenter do
       end
 
       it 'returns the OCLC Number Key' do
-        expect(config['oclc_tesim_ssi'].to_s).to eq('OCLC Number')
+        expect(config['oclc_ssi'].to_s).to eq('OCLC Number')
       end
 
       it 'returns the ARK Key' do

--- a/spec/support/works.rb
+++ b/spec/support/works.rb
@@ -37,7 +37,7 @@ FIRST_WORK = {
   architect_tesim: ['Alexander Butterfly'],
   # year_isim: ['1974'],
   place_of_origin_tesim: ['Dudley, MA'],
-  oclc_tesim_ssi: ['Powell Library'],
+  oclc_ssi: ['Powell Library'],
   format_tesim: ['Film Still'],
   support_tesim: ['Mom & Dad'],
   read_access_group_ssim: ["public"],


### PR DESCRIPTION
I noticed that the 'OCLC Number' was called oclc_tesim_ssi
So I changed it to oclc_ssi in all mplaces it occured.

Changes to be committed:
+ modified: `app/controllers/catalog_controller.rb`
+ modified: `config/locales/blacklight.en.yml`
+ modified: `config/metadata/local_info_metadata.yml`
+ modified: `spec/controllers/catalog_controller_spec.rb`
+ modified: `spec/presenters/ursus/local_info_metadata_presenter_spec.rb`
+ modified: `spec/support/works.rb`
