### PR TITLE
URS-669 Remove Bibliography and About features from Sinai home page

### DIFF
--- a/app/views/catalog/_homepage_sinai.html.erb
+++ b/app/views/catalog/_homepage_sinai.html.erb
@@ -56,7 +56,7 @@
           <h3 class="grid-subtitle-sm">About the Collection</h3>
           <p class="grid-text">Currently, the digital collection comprises 75 Arabic and Syriac manuscripts dating from the 7th to the 17th centuries. New manuscripts will be added regularly.</p>
       </div>
-     </div><!--Grid row2 - Medium images--> -->
+     </div>--><!--Grid row2 - Medium images-->
 
     </div><!--End of grid section-->
   </div><!--sinai-hmpg-content-wrapper-->

--- a/app/views/catalog/_homepage_sinai.html.erb
+++ b/app/views/catalog/_homepage_sinai.html.erb
@@ -18,11 +18,11 @@
         <div class="col-md-7 img-grid-lg"></div>
         <div class="
           text-grid
-          col-md-5 
-          d-flex 
-          flex-column 
-          justify-content-center 
-          align-items-start 
+          col-md-5
+          d-flex
+          flex-column
+          justify-content-center
+          align-items-start
           pt-4 pt-md-0 pl-0 pl-md-5">
           <h3 class="grid-subtitle">Manuscripts</h3>
           <p class="grid-text">Explore the Arabic and Syriac manuscripts of St. Catherine’s Monastery of the Sinai.</p>
@@ -31,32 +31,32 @@
       </div><!--Grid row1 - Large image-->
 
       <!--Grid row2 - Medium images-->
-      <div class="row mx-0 pt-5">
+      <!-- <div class="row mx-0 pt-5">
         <div class="col-md-3 img-grid-sm img-grid-sm-lf"></div>
           <div class="
-            text-grid 
-            col-md-3 
-            d-flex 
-            flex-column 
-            justify-content-center 
-            align-items-start 
+            text-grid
+            col-md-3
+            d-flex
+            flex-column
+            justify-content-center
+            align-items-start
             pt-4 pt-md-0 pl-0 pl-md-4">
             <h3 class="grid-subtitle-sm">Bibliography</h3>
             <p class="grid-text">A list of catalogues and resources related to the manuscripts of St. Catherine’s Monastery.</p>
           </div>
         <div class="col-md-3 img-grid-sm img-grid-sm-rt mt-4 mt-md-0"></div>
         <div class="
-          text-grid 
-          col-md-3 
-          d-flex 
-          flex-column 
-          justify-content-center 
+          text-grid
+          col-md-3
+          d-flex
+          flex-column
+          justify-content-center
           align-items-start 
           pt-4 pt-md-0 pl-0 pl-md-4">
           <h3 class="grid-subtitle-sm">About the Collection</h3>
           <p class="grid-text">Currently, the digital collection comprises 75 Arabic and Syriac manuscripts dating from the 7th to the 17th centuries. New manuscripts will be added regularly.</p>
       </div>
-     </div><!--Grid row2 - Medium images-->
+     </div><!--Grid row2 - Medium images--> -->
 
     </div><!--End of grid section-->
   </div><!--sinai-hmpg-content-wrapper-->


### PR DESCRIPTION
Connected to [URS-669](https://jira.library.ucla.edu/browse/URS-669)

This removes (comments out) the 2 empty features (bibliography and about) on the Sinai homepage.
- [x] The Sinai home page does not have the Bibliography feature.
- [x] The Sinai home page does not have the About feature.