### PR TITLE
URS-660 Remove copyright from Sinai footer

### DIFF
--- a/app/views/shared/_sinai_footer.html.erb
+++ b/app/views/shared/_sinai_footer.html.erb
@@ -26,8 +26,4 @@
   </div>
 </div>
 
-<div class='copyright'>
-  <div class="uc-regents">
-    © <span>2020</span>
-  </div>
-</div>
+<div class='copyright'></div>


### PR DESCRIPTION
Connected to [URS-660](https://jira.library.ucla.edu/browse/URS-660)

<img width="570" alt="Screen Shot 2020-02-19 at 5 50 06 PM" src="https://user-images.githubusercontent.com/751697/74893078-4b9fd600-5340-11ea-801e-82b94de16248.png">

---

Changes to be committed:
+ modified: `app/views/shared/_sinai_footer.html.erb`