### PR TITLE
Adds tests and fixes empty search results bug

### DIFF
--- a/app/views/catalog/_access_condition_metadata.html.erb
+++ b/app/views/catalog/_access_condition_metadata.html.erb
@@ -2,8 +2,8 @@
 <% access_condition = Ursus::AccessConditionMetadataPresenter.new(document: doc_presenter.fields_to_render).access_condition_terms %>
 
 <% if access_condition.length > 0 %>
-  <% doc_presenter = show_presenter(document) %>
-  <% access_condition = Ursus::AccessConditionMetadataPresenter.new(document: doc_presenter.fields_to_render).access_condition_terms %>
+  <!--% doc_presenter = show_presenter(document) % -->
+  <!--% access_condition = Ursus::AccessConditionMetadataPresenter.new(document: doc_presenter.fields_to_render).access_condition_terms %-->
   <div class='access-condition-metadata'>
     <h4 class='item-heading'>Access Condition</h4>
     <dl class='row document-metadata'>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,13 +1,13 @@
 <% if Flipflop.sinai? %><!-- SINAI -->
-  <% unless has_search_parameters? %>
+  <!--% unless has_search_parameters? % -->
     <%# if there are no input/search related params, display the "home" partial -%>
     <%= render 'shared/sitelinks_search_box' %>
-  <% else %>
+  <!--% else %-->
     <% content_for(:sidebar) do %>
       <%= render 'search_sidebar' %>
     <% end %>
     <%= render 'search_results' %>
-  <% end %>
+  <!--% end %-->
 
 <% else %><!-- URSUS -->
   <% content_for(:sidebar) do %>

--- a/spec/presenters/ursus/access_condition_metadata_presenter_spec.rb
+++ b/spec/presenters/ursus/access_condition_metadata_presenter_spec.rb
@@ -31,6 +31,22 @@ RSpec.describe Ursus::AccessConditionMetadataPresenter do
       it 'returns the Funding Note Key' do
         expect(config['funding_note_tesim'].to_s).to eq('Funding Note')
       end
+
+      context 'if the \'sinai\' feature flag is on' do
+        before do
+          allow(Flipflop).to receive(:sinai?).and_return(false)
+        end
+
+        let(:config) { YAML.safe_load(File.open(Rails.root.join('config', 'metadata/access_condition_metadata_sinai.yml'))) }
+
+        it 'returns the Local Rights Statement key' do
+          expect(config['local_rights_statement_ssim'].to_s).to eq('Local Rights statement')
+        end
+
+        it 'returns the Rights Contact Key' do
+          expect(config['services_contact_ssm'].to_s).to eq('Rights Services Contact')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
	Added tests for Access Condition Presenter and removed the unless block for search parameters, Sinai will not have allfields parameter.

        modified:   app/views/catalog/_access_condition_metadata.html.erb
	modified:   app/views/catalog/index.html.erb
	modified:   spec/presenters/ursus/access_condition_metadata_presenter_spec.rb