### PR TITLE
Remove SOLR suffixes from display fields and facets & search results from Home page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -146,10 +146,10 @@ class CatalogController < ApplicationController
     config.add_show_field 'binding_note_tesim', label: 'Binding note'
     config.add_show_field 'caption_tesim'
     config.add_show_field 'collation_tesim'
-    config.add_show_field 'colophon_tesim'
+    config.add_show_field 'colophon_tesim', label: 'Colophon'
     config.add_show_field 'composer_tesim', label: 'Composer'
-    config.add_show_field 'condition_note_tesim'
-    config.add_show_field 'contents_note_tesim'
+    config.add_show_field 'condition_note_tesim', label: 'Condition note'
+    config.add_show_field 'contents_note_tesim', label: 'Contents note'
     config.add_show_field 'contributor_tesim'
     config.add_show_field 'creator_tesim'
     config.add_show_field 'date_created_tesim', separator_options: BREAKS
@@ -158,7 +158,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'description_tesim', separator_options: BREAKS
     config.add_show_field 'dimensions_tesim'
     config.add_show_field 'dlcs_collection_name_tesim' unless Flipflop.sinai?
-    config.add_show_field 'explicit_tesim'
+    config.add_show_field 'explicit_tesim', label: 'Explicit'
     config.add_show_field 'extent_tesim', separator_options: BREAKS
     config.add_show_field 'features_tesim'
     config.add_show_field 'foliation_tesim'
@@ -172,11 +172,11 @@ class CatalogController < ApplicationController
     config.add_show_field 'identifier_tesim'
     config.add_show_field 'illuminator_tesim', label: 'Illuminator'
     config.add_show_field 'illustrations_note_tesim', label: 'Illustrations note'
-    config.add_show_field 'incipit_tesim'
-    config.add_show_field 'inscription_tesim'
+    config.add_show_field 'incipit_tesim', label: 'Incipit'
+    config.add_show_field 'inscription_tesim', label: 'Inscription'
     config.add_show_field 'keyword_tesim'
     config.add_show_field 'latitude_tesim', label: 'Latitude'
-    config.add_show_field 'local_rights_statement_ssim'
+    config.add_show_field 'local_rights_statement_ssim', label: 'Local Rights statement'
     config.add_show_field 'location_tesim', link_to_facet: 'location_sim'
     config.add_show_field 'local_identifier_ssm', label: 'Local identifier', separator_options: BREAKS
     config.add_show_field 'longitude_tesim', label: 'Longitude'
@@ -194,7 +194,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'rights_country_tesim'
     config.add_show_field 'rights_holder_tesim'
     config.add_show_field 'scribe_tesim', label: 'Scribe'
-    config.add_show_field 'script_tesim'
+    config.add_show_field 'script_tesim', label: 'Script'
     config.add_show_field 'services_contact_ssm', label: 'Rights services contact'
     config.add_show_field 'subject_tesim', link_to_facet: 'subject_sim', separator_options: BREAKS
     config.add_show_field 'subject_topic_tesim', label: 'Subject topic'
@@ -203,7 +203,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'title_tesim'
     config.add_show_field 'toc_tesim', label: 'Table of Contents'
     config.add_show_field 'uniform_title_tesim'
-    config.add_show_field 'writing_and_hands_tesim'
+    config.add_show_field 'writing_and_hands_tesim', label: 'Writing and hands'
     config.add_show_field 'writing_system_tesim'
 
     # "fielded" search configuration. Used by pulldown among other places.

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,13 +1,14 @@
 <% if Flipflop.sinai? %><!-- SINAI -->
   <!--% unless has_search_parameters? % -->
+  <% if current_page?(root_path) %>
     <%# if there are no input/search related params, display the "home" partial -%>
     <%= render 'shared/sitelinks_search_box' %>
-  <!--% else %-->
+  <% else %>
     <% content_for(:sidebar) do %>
       <%= render 'search_sidebar' %>
     <% end %>
     <%= render 'search_results' %>
-  <!--% end %-->
+  <% end %>
 
 <% else %><!-- URSUS -->
   <% content_for(:sidebar) do %>


### PR DESCRIPTION
This PR  fixes 2 bugs
+ The display fields on the show page
+ The facet and search results are showing up on the Sinai Home Page

modified:   app/controllers/catalog_controller.rb
modified:   app/views/catalog/index.html.erb