### PR TITLE
Remove visible </span> tag for disabled buttons

### DIFF
--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -3,12 +3,12 @@
 <ul class="pagination">
   <li class='page-item'>
     <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'page-link', data: { blacklight_modal: "preserve" } do %>
-      <span class="disabled page-link" tabindex='-1' disabled aria-disabled="true"><%= raw(t('views.pagination.previous')) %></span>
+      <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn btn-disabled' %>
     <% end %>
   </li>
   <li class='page-item' >
     <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'page-link',  data: { blacklight_modal: "preserve" } do %>
-      <span class="disabled page-link" tabindex='-1' disabled aria-disabled="true"><%= raw(t('views.pagination.next')) %></span>
+      <%= content_tag :span, raw(t('views.pagination.next')), class: 'disabled btn btn-disabled' %>
     <% end %>
   </li>
 </div>


### PR DESCRIPTION
Before:
<img width="799" alt="Screen Shot 2020-02-27 at 7 46 15 PM" src="https://user-images.githubusercontent.com/751697/75508753-090e7700-599a-11ea-9b73-1a999412484a.png">
Now:
<img width="1005" alt="Screen Shot 2020-02-27 at 7 46 57 PM" src="https://user-images.githubusercontent.com/751697/75508755-09a70d80-599a-11ea-97f5-860b23304a46.png">

Blacklight 16 Days ago:  
Fix visible </span> tag for disabled buttons
https://github.com/projectblacklight/blacklight/commit/07f14aec5f7cbdf6d210ae989284901288ffa45f
