### PR TITLE
sinai subtitle and footer updates per Tinu

### DIFF
--- a/app/assets/stylesheets/sinai/_inner_homepage.scss
+++ b/app/assets/stylesheets/sinai/_inner_homepage.scss
@@ -123,8 +123,8 @@
 
 @media (max-width: 767px) {
   .sinai-homepage-masthead {
-    height: 350px;
-    max-height: 350px;
+    height: 400px;
+    max-height: 400px;
   }
   .page-lead {
     margin: 60px 0;

--- a/app/assets/stylesheets/sinai/_sinai_navbar.scss
+++ b/app/assets/stylesheets/sinai/_sinai_navbar.scss
@@ -1,21 +1,21 @@
 @import "ursus/colors";
 
+nav.navbar:nth-of-type(1) {
+  padding: 1rem !important;
+}
+
 .sinai-site-navbar {
   background-color: $white !important;
   font-family: Helvetica, sans-serif;
 
-  .navbar-logo-block {
-    height: 50px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  .navbar-subtitle {
+    display: block;
   }
 
   .sinai-navbar-logo a {
     font-size: 1.5rem;
     font-weight: 600;
     color: $gray-80 !important;
-    line-height: 29px;
 
     &:hover {
       color: $callisto-drk-red !important;
@@ -23,12 +23,14 @@
     }
   }
 
+  .nav-item {
+    padding-top: 0;
+  }
+
   .nav-item a {
     color: $gray-80 !important;
     font-weight: 400;
-    font-size: 1em;
-    letter-spacing: 0.05rem;
-    margin-right: 2rem;
+    font-size: 1.15rem;
     text-decoration: none;
     position: relative;
 
@@ -51,12 +53,16 @@
   }
 }
 
-@media (max-width: 991px) {
+@media (max-width: 767px) {
+  nav.navbar:nth-of-type(1) {
+    padding: 1rem 0 0 0 !important;
+  }
   .sinai-site-navbar {
-    padding: 0 !important;
+    display: flex;
+    align-items: start;
     .navbar-logo-block {
-      height: 45px;
-      padding: 2rem 1rem;
+      padding-left: 1rem;
+      padding-bottom: 1rem;
     }
 
     .navbar-toggler {
@@ -82,6 +88,7 @@
 
     .nav-item a {
       margin-right: 0;
+
       &::after {
         content: " ";
         position: absolute;
@@ -103,33 +110,33 @@
   }
 }
 
-@media (max-width: 576px) {
+@media (max-width: 540px) {
   .sinai-site-navbar {
+    .navbar-logo-block {
+      flex: 0 0 83%;
+    }
     .sinai-navbar-logo a {
       font-size: 1.15rem;
-      font-weight: 600;
     }
-    .navbar-logo {
-      width: 250px !important;
+    .navbar-subtitle {
+      font-size: 0.9rem;
+    }
+    .nav-item a {
+      font-size: 1rem;
     }
   }
 }
 
 @media (max-width: 374px) {
   .sinai-site-navbar {
-    .navbar-logo-block {
-      padding: 0rem 1rem;
-    }
     .sinai-navbar-logo a {
-      font-size: 0.9rem;
-      font-weight: 600;
-      margin-top: 10px;
+      font-size: 1.05rem;
     }
-    .navbar-logo-block {
-      flex-direction: column;
-      justify-content: unset;
-      align-items: flex-start;
-      height: 50px;
+    .navbar-subtitle {
+      font-size: 0.8rem;
+    }
+    .nav-item a {
+      font-size: 0.9rem;
     }
     .navbar-nav.nav {
       padding: 0.85rem;

--- a/app/views/shared/_sinai_header.html.erb
+++ b/app/views/shared/_sinai_header.html.erb
@@ -1,7 +1,8 @@
-<nav class='navbar navbar-expand-lg navbar-dark sinai-site-navbar' role='navigation'>
-  <div class='container-fluid'>
-    <div class='navbar-logo-block sinai-navbar-logo'>
+<nav class='navbar navbar-expand-md navbar-dark sinai-site-navbar' role='navigation'>
+
+<div class='navbar-logo-block sinai-navbar-logo'>
       <%= link_to "Sinai Manuscripts Digital Library", root_path %>
+      <span class="navbar-subtitle">A publication of St. Catherine's Monastery of the Sinai, Egypt</span>
     </div>
 
     <button class='navbar-toggler custom-toggler' type='button' data-toggle='collapse' data-target='#user-util-collapse' aria-controls='user-util-collapse' aria-expanded='false' aria-label='Toggle navigation'>
@@ -13,5 +14,5 @@
         <li class='nav-item'><a href='http://sinaipalimpsests.org/' target='_blank' rel="noopener" >Sinai Palimpsests Project</a></li>
       </ul>
     </div>
-  </div>
+
 </nav>


### PR DESCRIPTION
[URS-677](https://jira.library.ucla.edu/browse/URS-677) Sinai: Add subtitle to home page
Added in Tinu updates:

[x] Add text: "A publication of St. Catherine's Monastery of the Sinai, Egypt"
![image](https://user-images.githubusercontent.com/2350153/75738050-1c7d5300-5cb6-11ea-8686-da089a4fb261.png)
----
![image](https://user-images.githubusercontent.com/2350153/75738140-58b0b380-5cb6-11ea-856e-cee17aba1578.png)
----
![image](https://user-images.githubusercontent.com/2350153/75738177-6c5c1a00-5cb6-11ea-92b9-ad610704b292.png)
----
![image](https://user-images.githubusercontent.com/2350153/75738200-8564cb00-5cb6-11ea-894b-2338b4431e2f.png)

[x] Update CSS for "Sinai Palimpsest Project"
    [x] font-size: 1rem
    [x] Remove letter-spacing property
    [x] In 991px and lower, remove nav-item's "padding-top: 20px" 

[x] Footer
![image](https://user-images.githubusercontent.com/2350153/75738308-cbba2a00-5cb6-11ea-8a94-763d2649af5f.png)
----
![image](https://user-images.githubusercontent.com/2350153/75738326-de346380-5cb6-11ea-9c9a-91d839d0e8a5.png)
