### PR TITLE
URS-701 Change color of the Sinai Date slider

### DIFF
--- a/app/assets/stylesheets/sinai/_facets.scss
+++ b/app/assets/stylesheets/sinai/_facets.scss
@@ -11,6 +11,16 @@
     border-bottom: 1px solid $gray-10;
   }
 
+  // date-range slider
+  .slider_js .slider-selection {
+    background: $callisto-drk-beige;
+  }
+
+  .range_limit .slider-handle {
+    background-color: $callisto-drk-red !important;
+    background-image: none;
+}
+
   .facets-heading {
     color: $gray-80 !important;
   }


### PR DESCRIPTION
Changes the color of the Sinai date slider from blue to red for Sinai/Callisto

<img width="304" alt="Screen Shot 2020-03-09 at 2 54 37 PM" src="https://user-images.githubusercontent.com/751697/76261351-0d972300-6217-11ea-9605-703a72707d72.png">
<img width="322" alt="Screen Shot 2020-03-09 at 3 01 19 PM" src="https://user-images.githubusercontent.com/751697/76261354-0ec85000-6217-11ea-9a4a-ea96e35631b4.png">


---

Changes to be committed:
+ modified:   app/assets/stylesheets/sinai/_facets.scss