### PR TITLE
URS-702 Sinai: Set Mirador to open to collection manifest when user adds item

### DIFF
--- a/public/mirador.html
+++ b/public/mirador.html
@@ -14,7 +14,6 @@
 </head>
 
 <body>
-
   <div id="viewer"></div>
   <script type="text/javascript">
     $(function () {
@@ -29,10 +28,10 @@
         "id": "viewer",
         "layout": "1",
         "buildPath": "https://unpkg.com/mirador@2.6.0/dist/",
-        "data": [{
-          "manifestUri": manifestURL,
-          "location": "UCLA"
-        }],
+        "data": [
+          { "collectionUri": "https://iiif.library.ucla.edu/collections/ark%3A%2F21198%2Fz1bk2gmg"},
+          { "manifestUri": manifestURL, location: "UCLA Library"}
+        ],
         "windowObjects": [{
           loadedManifest: manifestURL,
           viewType: "ImageView",


### PR DESCRIPTION
Changes to be committed:
modified:   public/mirador.html

```
        "data": [
          { "collectionUri": "https://iiif.library.ucla.edu/collections/ark%3A%2F21198%2Fz1bk2gmg"},
          { "manifestUri": manifestURL, location: "UCLA Library"}
        ],
```