### PR TITLE
URS-725  Display multiple uniform_titles should on new lines

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -204,7 +204,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'support_tesim', label: 'Support'
     config.add_show_field 'title_tesim'
     config.add_show_field 'toc_tesim', label: 'Table of Contents'
-    config.add_show_field 'uniform_title_tesim'
+    config.add_show_field 'uniform_title_tesim', separator_options: BREAKS
     config.add_show_field 'writing_and_hands_tesim', label: 'Writing and hands'
     config.add_show_field 'writing_system_tesim', label: 'Writing system'
 


### PR DESCRIPTION
Connected to [URS-725](https://jira.library.ucla.edu/browse/URS-725)

Added code to insert line breaks instead of comma or and in the case… of multiple uniform titles

[x] - Ursus displays multiple uniform titles on separate lines, one title per line

![multi-unform_titles](https://user-images.githubusercontent.com/2350153/79891347-b8bdff00-83b5-11ea-9ba9-d4cc2b6cb3a3.png)

---

+ modified: `app/controllers/catalog_controller.rb`