### PR TITLE
URS-731 Canon Law: Open UV to the page referenced in the param

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -134,6 +134,7 @@ Style/GuardClause:
 Style/IfInsideElse:
   Exclude:
      - app/controllers/application_controller.rb
+     - app/services/iiif_service.rb
 
 Lint/UselessAssignment:
   Exclude:

--- a/app/services/iiif_service.rb
+++ b/app/services/iiif_service.rb
@@ -5,7 +5,11 @@ class IiifService
     if Flipflop.sinai?
       "#{request&.base_url}/mirador.html#?manifest=#{CGI.escape(iiif_manifest_url(document))}"
     else
-      "#{request&.base_url}/uv/uv.html#?manifest=#{CGI.escape(iiif_manifest_url(document))}"
+      if request.query_parameters.include?('cv') && document[:member_ids_ssim].size >= request.query_parameters['cv'].to_i
+        "#{request&.base_url}/uv/uv.html#?cv=#{request.query_parameters['cv']}&manifest=#{CGI.escape(iiif_manifest_url(document))}"
+      else
+        "#{request&.base_url}/uv/uv.html#?manifest=#{CGI.escape(iiif_manifest_url(document))}"
+      end
     end
   end
 

--- a/spec/services/iiif_service_spec.rb
+++ b/spec/services/iiif_service_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe IiifService do
     SolrDocument.new(id: 'abc123',
                      iiif_manifest_url_ssi: 'https://manifest.store/ark%3A%2Fabc%2F123/manifest')
   end
+  let(:solr_document_with_cv) do
+    SolrDocument.new(id: 'cde123',
+                     iiif_manifest_url_ssi: 'https://manifest.store/ark%3A%2Fabc%2F123/manifest',
+                     member_ids_ssim: 7)
+  end
 
   before do
     allow(Rails.application.config).to receive(:iiif_url).and_return('https://californica.url/concern/works')
@@ -17,6 +22,7 @@ RSpec.describe IiifService do
     context 'when a url is stored and feature enabled' do
       it 'uses that url' do
         allow(Flipflop).to receive(:use_manifest_store?).and_return(true)
+
         expect(service.iiif_manifest_url(solr_document)).to eq 'https://manifest.store/ark%3A%2Fabc%2F123/manifest'
       end
     end
@@ -24,6 +30,7 @@ RSpec.describe IiifService do
     context 'when a url is stored but feature is disabled' do
       it 'builds a local url' do
         allow(Flipflop).to receive(:use_manifest_store?).and_return(false)
+
         expect(service.iiif_manifest_url(solr_document)).to eq 'https://californica.url/concern/works/abc123/manifest'
       end
     end
@@ -33,6 +40,7 @@ RSpec.describe IiifService do
 
       it 'builds a local url' do
         allow(Flipflop).to receive(:use_manifest_store?).and_return(true)
+
         expect(service.iiif_manifest_url(solr_document)).to eq 'https://californica.url/concern/works/abc123/manifest'
       end
     end
@@ -41,6 +49,7 @@ RSpec.describe IiifService do
   describe '#src' do
     before do
       allow(Flipflop).to receive(:use_manifest_store?).and_return(true)
+      allow(request).to receive(:query_parameters).and_return({})
     end
 
     let(:request) { instance_double('ActionDispatch::Request', base_url: 'http://test.url') }
@@ -48,6 +57,7 @@ RSpec.describe IiifService do
     context 'by default' do
       it 'links to universal viewer' do
         allow(Flipflop).to receive(:sinai?).and_return(false)
+
         expect(service.src(request, solr_document)).to eq 'http://test.url/uv/uv.html#?manifest=https%3A%2F%2Fmanifest.store%2Fark%253A%252Fabc%252F123%2Fmanifest'
       end
     end
@@ -55,7 +65,22 @@ RSpec.describe IiifService do
     context 'when the sinai feature flag is set' do
       it 'links to mirador' do
         allow(Flipflop).to receive(:sinai?).and_return(true)
+
         expect(service.src(request, solr_document)).to eq 'http://test.url/mirador.html#?manifest=https%3A%2F%2Fmanifest.store%2Fark%253A%252Fabc%252F123%2Fmanifest'
+      end
+    end
+
+    context 'when the link parameter "cv" exists' do
+      it 'links to the corresponding Work page in the universal viewer' do
+        allow(request).to receive(:query_parameters).and_return('cv' => 7)
+
+        expect(service.src(request, solr_document_with_cv)).to eq 'http://test.url/uv/uv.html#?cv=7&manifest=https%3A%2F%2Fmanifest.store%2Fark%253A%252Fabc%252F123%2Fmanifest'
+      end
+
+      it 'returns page 1 if someone requests a page higher than the total page count' do
+        allow(request).to receive(:query_parameters).and_return('cv' => 9)
+
+        expect(service.src(request, solr_document_with_cv)).to eq 'http://test.url/uv/uv.html#?manifest=https%3A%2F%2Fmanifest.store%2Fark%253A%252Fabc%252F123%2Fmanifest'
       end
     end
   end


### PR DESCRIPTION
Connected to [URS-731](https://jira.library.ucla.edu/browse/URS-731)

Read the Canvas ID from URL and link to the corresponding page in the Universal Viewer

---

Changes to be committed:
+ modified: `app/services/iiif_service.rb`
+ modified: `spec/services/iiif_service_spec.rb`
+ modified: `.rubocop.yml`