### PR TITLE
Urs 739 allow google to index images in ursus3

### DIFF
--- a/app/views/catalog/_primary_metadata.html.erb
+++ b/app/views/catalog/_primary_metadata.html.erb
@@ -1,5 +1,5 @@
 <div class='primary-metadata'>
-  <div class="sr-only">
+  <div hidden>
     <% document_json = JSON.parse @document.to_json.gsub(/'/, '_') %>
     <% tn = "<img src=\""+document_json['thumbnail_url_ss']+"\" alt=\"Image for search engines to index.\" \>" if !document_json['thumbnail_url_ss'].blank? %>
     <%= tn.html_safe if !document_json['thumbnail_url_ss'].blank?%>

--- a/app/views/catalog/_primary_metadata.html.erb
+++ b/app/views/catalog/_primary_metadata.html.erb
@@ -1,9 +1,9 @@
 <div class='primary-metadata'>
   <div class="sr-only">
     <% document_json = JSON.parse @document.to_json.gsub(/'/, '_') %>
-    <% tn = "<img src=\""+document_json['thumbnail_url_ss']+"\" alt=\"Image for search engines to index.\" \>" %>
+    <% tn = "<img src=\""+document_json['thumbnail_url_ss']+"\" alt=\"Image for search engines to index.\" \>" if !document_json['thumbnail_url_ss'].blank? %>
     <%= tn.html_safe  %>
-  </div>
+    </div>
   <%= render 'item_overview_metadata', { document: document } %>
   <%= render 'note_metadata', { document: document } %>
   <%= render 'physical_description_metadata', { document: document } %>

--- a/app/views/catalog/_primary_metadata.html.erb
+++ b/app/views/catalog/_primary_metadata.html.erb
@@ -1,7 +1,7 @@
 <div class='primary-metadata'>
   <div hidden>
     <% document_json = JSON.parse @document.to_json.gsub(/'/, '_') %>
-    <% tn = "<img src=\""+document_json['thumbnail_url_ss']+"\" alt=\"Image for search engines to index.\" \>" if !document_json['thumbnail_url_ss'].blank? %>
+    <% tn = "<img src=\""+document_json['thumbnail_url_ss']+"\" alt=\"This image for search engines to index.\" \>" if !document_json['thumbnail_url_ss'].blank? %>
     <%= tn.html_safe if !document_json['thumbnail_url_ss'].blank?%>
     </div>
   <%= render 'item_overview_metadata', { document: document } %>

--- a/app/views/catalog/_primary_metadata.html.erb
+++ b/app/views/catalog/_primary_metadata.html.erb
@@ -2,7 +2,7 @@
   <div class="sr-only">
     <% document_json = JSON.parse @document.to_json.gsub(/'/, '_') %>
     <% tn = "<img src=\""+document_json['thumbnail_url_ss']+"\" alt=\"Image for search engines to index.\" \>" if !document_json['thumbnail_url_ss'].blank? %>
-    <%= tn.html_safe  %>
+    <%= tn.html_safe if !document_json['thumbnail_url_ss'].blank?%>
     </div>
   <%= render 'item_overview_metadata', { document: document } %>
   <%= render 'note_metadata', { document: document } %>

--- a/app/views/catalog/_primary_metadata.html.erb
+++ b/app/views/catalog/_primary_metadata.html.erb
@@ -1,4 +1,9 @@
 <div class='primary-metadata'>
+  <div class="sr-only">
+    <% document_json = JSON.parse @document.to_json.gsub(/'/, '_') %>
+    <% tn = "<img src=\""+document_json['thumbnail_url_ss']+"\" alt=\"Image for search engines to index.\" \>" %>
+    <%= tn.html_safe  %>
+  </div>
   <%= render 'item_overview_metadata', { document: document } %>
   <%= render 'note_metadata', { document: document } %>
   <%= render 'physical_description_metadata', { document: document } %>

--- a/spec/system/view_work_spec.rb
+++ b/spec/system/view_work_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe 'View a Work', type: :system, js: true do
     expect(page).to have_content 'Powell Library'
     expect(page).to have_content 'Film Still'
     expect(page).to have_content 'Mom & Dad'
+    expect(page.html).to match(/<img src="http/)
   end
 
   context 'license' do


### PR DESCRIPTION
[URS-739 - Allow Google to index Images in Ursus](https://jira.library.ucla.edu/browse/URS-739)

The main goal is to find a way to allow the Google crawler to index the Ursus images by embedding an image in the Show page that is not displayed by the web browser (the image is already displayed in the Universal Viewer player). Two common techniques, _display:none;_ and _visibility:hidden_ are problematic so a third alternative suggested by Tinu, Bootstrap's screen-reader selector class "sr-only", was employed.

Acceptance criteria:
 - [ ] - Ursus images appear in Google Images
 - [ ] - Google page formatting recommendations applied to Ursus where reasonable and possible