### PR TITLE
APPS-445 Enable OAI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ git_source(:github) do |repo_name|
 end
 
 gem 'blacklight-gallery', github: 'projectblacklight/blacklight-gallery'
+gem 'blacklight_oai_provider', github: 'projectblacklight/blacklight_oai_provider'
 gem 'dotenv-rails', '>= 2.7.5'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,14 @@ GIT
       openseadragon (>= 0.2.0)
       rails (~> 5.1)
 
+GIT
+  remote: https://github.com/projectblacklight/blacklight_oai_provider.git
+  revision: 6f45e2d4a4cfc9eb46d61f97b5b12202641a3d03
+  specs:
+    blacklight_oai_provider (7.0.0)
+      blacklight (~> 7.0)
+      oai (~> 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -155,6 +163,8 @@ GEM
       railties (>= 4.2.0)
     faraday (0.17.1)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.14.0)
+      faraday (>= 0.7.4, < 1.0)
     ffi (1.12.2)
     flipflop (2.6.0)
       activesupport (>= 4.0)
@@ -227,6 +237,10 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     ntlm-http (0.1.1)
+    oai (1.1.0)
+      builder (>= 3.1.0)
+      faraday
+      faraday_middleware
     openseadragon (0.5.0)
       rails (> 3.2.0)
     orm_adapter (0.5.0)
@@ -418,6 +432,7 @@ DEPENDENCIES
   blacklight-access_controls (>= 6.0.0)
   blacklight-gallery!
   blacklight_dynamic_sitemap (~> 0.1.0)
+  blacklight_oai_provider!
   blacklight_range_limit (~> 7.0.0)
   bootstrap (~> 4.4, >= 4.4.1)
   byebug

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -6,6 +6,8 @@ require 'solrizer'
 class CatalogController < ApplicationController
   include BlacklightRangeLimit::ControllerOverride
   include Blacklight::Catalog
+  include BlacklightOaiProvider::Controller
+
   include Blacklight::AccessControls::Catalog
 
   # Apply the blacklight-access_controls

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class SolrDocument
   include Blacklight::Solr::Document
+  include BlacklightOaiProvider::SolrDocument
+
   include Blacklight::Gallery::OpenseadragonSolrDocument
 
   # self.unique_key = 'id'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
+  concern :oai_provider, BlacklightOaiProvider::Routes.new
+
   get '/login', to: 'login#new', as: 'login'
   mount Flipflop::Engine => "/flipflop"
   get '/about', to: 'static#about'
@@ -15,6 +17,8 @@ Rails.application.routes.draw do
   concern :searchable, Blacklight::Routes::Searchable.new
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
+    concerns :oai_provider
+
     concerns :searchable
     concerns :range_searchable
   end


### PR DESCRIPTION
Connected to [APPS-445](https://jira.library.ucla.edu/browse/APPS-445)

1. Adds the Gem blacklight_oai_provider 
    + https://rubygems.org/gems/blacklight_oai_provider/versions/6.0.0
2. Got the OAI home page working

$ `rails generate blacklight_oai_provider:install`
```
Running via Spring preloader in process 201
      insert  app/models/solr_document.rb
      insert  app/controllers/catalog_controller.rb
      insert  config/routes.rb
      insert  config/routes.rb
```

---

Changes to be committed:
+ modified:   `Gemfile`
+ modified:   `Gemfile.lock`
+ modified:   `config/routes.rb`
+ modified: `app/models/solr_document.rb`
+ modified: `app/models/solr_document.rb`