### PR TITLE
URS-774 Fix viewer alignment.

### DIFF
--- a/app/assets/javascripts/media_viewer_width.js
+++ b/app/assets/javascripts/media_viewer_width.js
@@ -1,6 +1,0 @@
-resize_media_viewer = function () {
-  $('#media-viewer-iframe').width($('.media-viewer-container').width())
-}
-
-$(document).ready(resize_media_viewer)
-$(window).resize(resize_media_viewer)

--- a/app/assets/stylesheets/ursus.scss
+++ b/app/assets/stylesheets/ursus.scss
@@ -10,6 +10,7 @@
 @import "ursus/gallery";
 @import "ursus/header_image_block";
 @import "ursus/home";
+@import "ursus/media-viewer";
 @import "ursus/modal-header";
 @import "ursus/navbar";
 @import "ursus/search--filter";
@@ -21,7 +22,6 @@
 @import "ursus/sort-pagination";
 @import "ursus/static-pages";
 @import "ursus/title";
-@import "ursus/univ-viewr";
 @import "ursus/collection_box";
 @import "ursus/about";
 @import "ursus/facets";

--- a/app/assets/stylesheets/ursus/_media-viewer.scss
+++ b/app/assets/stylesheets/ursus/_media-viewer.scss
@@ -5,11 +5,16 @@
   //display: flex;
   //justify-content: center;
 }
+
 .media-viewer {
   margin-bottom: 25px;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+}
+
+#media-viewer-iframe {
+  width: 100%;
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
Removes javascript hooks that resized the media viewer iframe; sets the css width to 100% instead.

Addresses an issue that caused the media viewer to not occupy all available space.