### PR TITLE
URS-726 Expand width of Item page title to match viewer

### DIFF
--- a/app/assets/stylesheets/ursus/_show.scss
+++ b/app/assets/stylesheets/ursus/_show.scss
@@ -60,7 +60,7 @@
 
 .item-title h1 {
   margin: 0 auto 10px auto;
-  max-width: 900px;
+  max-width: 1275px;
   font-size: 2rem;
 }
 


### PR DESCRIPTION
Connected to [URS-726](https://jira.library.ucla.edu/browse/URS-726)

<img width="1080" alt="Screen Shot 2020-05-11 at 12 29 02 PM" src="https://user-images.githubusercontent.com/751697/81603763-baab2a80-9383-11ea-8414-2e7bb5de3c24.png">

---

Changes to be committed:
+ modified: `app/assets/stylesheets/ursus/_show.scss`

