### PR TITLE
URS-754 Add functionality to choose collection page banner image

### DIFF
--- a/app/helpers/home_page_helper.rb
+++ b/app/helpers/home_page_helper.rb
@@ -3,7 +3,7 @@
 module HomePageHelper
   # Use the ark to find the record, and then return a link to that record.
   def link_to_featured_work(link_text, ark)
-    # Use ssim, not tesim, for an exact match
+    # Use ssim, not tesim,  an exact match
     query = "identifier_ssim:#{ark}"
 
     solr = Blacklight.default_index.connection
@@ -17,5 +17,13 @@ module HomePageHelper
 
   def blank_search_path
     search_catalog_path(search_field: 'all_fields', q: '')
+  end
+
+  def create_representative_image(document)
+    if document['masthead_parameters_ssi'] && document['representative_image_ssi']
+      document['representative_image_ssi'] + document['masthead_parameters_ssi']
+    else
+      "ucla_powell_library.jpg"
+    end
   end
 end

--- a/app/views/catalog/_homepage_banner.html.erb
+++ b/app/views/catalog/_homepage_banner.html.erb
@@ -44,8 +44,8 @@
       to bottom,
       rgba(0, 0, 0, 0),
       rgba(0, 0, 0, 0.4)
-      ),url(<%= image_path "ucla_powell_library.jpg" %>);">
-      <%= render 'collection_masthead_overlay', document: @document, collection_count: @collection_count%>
+      ),url(<%= image_path create_representative_image(@document) %>);">
+      <%= render 'collection_masthead_overlay', document: @document, collection_count: @collection_count %>
     </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
Connected to [URS-754](https://jira.library.ucla.edu/browse/URS-754)

<img width="1127" alt="Screen Shot 2020-05-11 at 3 47 33 PM" src="https://user-images.githubusercontent.com/751697/81620247-4c289580-93a0-11ea-9822-c364eacff77e.png">

We changed the image **locally** so we could prove that the default image was working if there were no parameters for the masthead_parameters_ssi and the  representative_image_ssi
<img width="1250" alt="Screen Shot 2020-05-11 at 3 52 56 PM" src="https://user-images.githubusercontent.com/751697/81619983-a37a3600-939f-11ea-89e2-274977692e95.png">

---

Changes to be committed:
+ modified: `app/helpers/home_page_helper.rb`
+ modified: `app/views/catalog/_homepage_banner.html.erb`