### PR TITLE
URS-688 Add schema.org values to catalog show pages

### DIFF
--- a/app/views/catalog/_collection_masthead_overlay.html.erb
+++ b/app/views/catalog/_collection_masthead_overlay.html.erb
@@ -2,7 +2,7 @@
   <h1><%= document[:title_tesim][0] %></h1>
   <div class='item-info'>
     <% if collection_count %>
-    <div class='collection-count'><%= collection_count %> items</div>
+    <div class='collection-count' itemprop="collectionSize"><%= collection_count %> items</div>
     <% end %>
     <%= link_to  'Browse items in this collection', "/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=#{document[:title_tesim][0]}", class:'btn btn-lg btn-browse' %>
   </div>

--- a/app/views/catalog/_collection_record.html.erb
+++ b/app/views/catalog/_collection_record.html.erb
@@ -1,7 +1,7 @@
 <div class='collection-record-container'>
   <% if document[:summary_tesim] %>
     <h2>About this Collection</h2>
-    <p> 
+    <p itemprop="abstract"> 
       <%= document[:summary_tesim][0] %> 
     </p>
     <hr>

--- a/app/views/catalog/_homepage_banner.html.erb
+++ b/app/views/catalog/_homepage_banner.html.erb
@@ -26,20 +26,6 @@
   <% end %>
 
   <% if controller.controller_name == 'catalog' && @document && @document[:has_model_ssim] && @document[:has_model_ssim][0] == 'Collection' %>
-
-    <!--<div style="display:none">
-      <%#= @pagination_collection.total_count %>
-    </div>
-    <div style="display:none">
-      <%#= @display_facet.items %>
-    </div>
-    <div style="display:none;">
-      <%#= @pagination_collection.items %>
-    </div>
-    <div style="display:none;">
-      <%#= @response_collection %>
-    </div> -->
-
     <div class="collection-masthead" style="background-image: linear-gradient(
       to bottom,
       rgba(0, 0, 0, 0),

--- a/app/views/catalog/_keyword_metadata.html.erb
+++ b/app/views/catalog/_keyword_metadata.html.erb
@@ -12,10 +12,17 @@
       <% keyword.each do |field_name, field| -%>
         <dt class="blacklight-<%= field_name.parameterize %> col-12 col-sm-4 item-label">
           <%= (render_document_show_field_label document, field: field_name).tr(':','') %>
+          <% if field_name.include? "genre" %>
+          <dd itemprop="genre" class="blacklight-<%= field_name.parameterize %> col-12 col-sm-8 item-value">
+            <%= doc_presenter.field_value field %>
+          </dd>
+          <% else %>
           <dd class="blacklight-<%= field_name.parameterize %> col-12 col-sm-8 item-value">
             <%= doc_presenter.field_value field %>
           </dd>
+        <% end %>
         </dt>
+        
       <% end %>
     </dl>
 <% end %>

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,10 +1,21 @@
 <% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name).html_safe %>
 <% content_for(:head) { render_link_rel_alternates } %>
-
-<div id='document' class="document <%= render_document_class %>" itemscope  itemtype="<%= @document.itemtype %>">
+<!--
+  <div id='document' class="document blacklight-work" itemscope  itemtype="http://schema.org/CreativeWork" itemid="https://digital.library.ucla.edu/catalog/5rsn2000zz-89112">
+  <link itemprop="isPartOf" itemscope itemtype="http://schema.org/Collection" itemid="https://digital.library.ucla.edu/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Los+Angeles+Daily+News+Negatives" />
+  
+</div>
+-->
+<div id='document' class="document <%= render_document_class %>">
+  
   <div id="doc_<%= @document.id.to_s.parameterize %>">
     <%= render_document_partials @document, blacklight_config.view_config(:show).partials %>
   </div>
+  <% if @document[:member_of_collections_ssim] && @document[:member_of_collection_ids_ssim] %>
+    <% @document[:member_of_collections_ssim].each_with_index do | member, index | %>
+      <link itemprop="isPartOf" itemscope itemtype="http://schema.org/Collection" itemid="<%=request.base_url+solr_document_path(@document[:member_of_collection_ids_ssim][index])%>" />
+    <% end %>
+  <% end %>
 </div>
 
 <% if @document.respond_to?(:export_as_openurl_ctx_kev) %>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -46,8 +46,17 @@
       <noscript id='analytics-noscript'><iframe src="https://www.googletagmanager.com/ns.html?id=<%= ENV["GOOGLE_TAG_MGR_ID"] %>"
         height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <% end %>
-
-    <div class="d-flex flex-column" style="min-height: 100vh">
+    
+    <div class="d-flex flex-column" style="min-height: 100vh"    
+    <% if controller.controller_name == 'catalog' && @document && @document[:has_model_ssim] %>
+    itemscope itemid="<%=request.base_url+solr_document_path(@document.id.to_s.parameterize)%>"
+      <% if @document[:has_model_ssim][0] == 'Collection'%>
+        itemtype="http://schema.org/Collection"
+      <% elsif @document[:has_model_ssim][0] == 'Work' %>
+        itemtype="http://schema.org/CreativeWork"
+      <% end %>
+    <% end %>
+    >
       <%= render partial: 'shared/header_navbar' %>
       <%= render 'catalog/homepage_banner' %>
 

--- a/spec/support/works.rb
+++ b/spec/support/works.rb
@@ -117,3 +117,98 @@ FOURTH_WORK = {
   thumbnail_url_ss: ["http://thumbnail/work4.jpg"],
   visibility_ssi: ['open']
 }.freeze
+
+WORK_A = {
+  id: 'id456a',
+  has_model_ssim: ['Work'],
+  title_tesim: ['Title Three'],
+  sort_title_ssort: 'Title Three',
+  title_alpha_numeric_ssort: 'The Title 100 of my Work',
+  identifier_tesim: ['ark 456'],
+  description_tesim: ['Description 3', 'Description 4', 'another desc'],
+  date_created_tesim: ["Date 1"],
+  sort_year_isi: 1929,
+  human_readable_resource_type_tesim: ['still image'],
+  photographer_tesim: ['Person 1'],
+  location_tesim: ['search_results_spec'], # to control what displays
+  member_of_collections_ssim: ['Bennett (Walter E.) Photographic Collection, 1937-1983 (bulk 1952-1982)'],
+  member_of_collection_ids_ssim: ['m8f11000zz-89112'],
+  thumbnail_url_ss: ["http://thumbnail/work4.jpg"],
+  visibility_ssi: ['open']
+}.freeze
+
+WORK_B = {
+  id: 'id456b',
+  has_model_ssim: ['Work'],
+  title_tesim: ['Title Three'],
+  sort_title_ssort: 'Title Three',
+  title_alpha_numeric_ssort: 'The Title 100 of my Work',
+  identifier_tesim: ['ark 456'],
+  description_tesim: ['Description 3', 'Description 4', 'another desc'],
+  date_created_tesim: ["Date 1"],
+  sort_year_isi: 1929,
+  human_readable_resource_type_tesim: ['still image'],
+  photographer_tesim: ['Person 1'],
+  location_tesim: ['search_results_spec'], # to control what displays
+  member_of_collections_ssim: ['Bennett (Walter E.) Photographic Collection, 1937-1983 (bulk 1952-1982)'],
+  member_of_collection_ids_ssim: ['m8f11000zz-89112'],
+  thumbnail_url_ss: ["http://thumbnail/work4.jpg"],
+  visibility_ssi: ['open']
+}.freeze
+
+WORK_C = {
+  id: 'id456c',
+  has_model_ssim: ['Work'],
+  title_tesim: ['Title Three'],
+  sort_title_ssort: 'Title Three',
+  title_alpha_numeric_ssort: 'The Title 100 of my Work',
+  identifier_tesim: ['ark 456'],
+  description_tesim: ['Description 3', 'Description 4', 'another desc'],
+  date_created_tesim: ["Date 1"],
+  sort_year_isi: 1929,
+  human_readable_resource_type_tesim: ['still image'],
+  photographer_tesim: ['Person 1'],
+  location_tesim: ['search_results_spec'], # to control what displays
+  member_of_collections_ssim: ['Bennett (Walter E.) Photographic Collection, 1937-1983 (bulk 1952-1982)'],
+  member_of_collection_ids_ssim: ['m8f11000zz-89112'],
+  thumbnail_url_ss: ["http://thumbnail/work4.jpg"],
+  visibility_ssi: ['open']
+}.freeze
+
+WORK_D = {
+  id: 'id456d',
+  has_model_ssim: ['Work'],
+  title_tesim: ['Title Three'],
+  sort_title_ssort: 'Title Three',
+  title_alpha_numeric_ssort: 'The Title 100 of my Work',
+  identifier_tesim: ['ark 456'],
+  description_tesim: ['Description 3', 'Description 4', 'another desc'],
+  date_created_tesim: ["Date 1"],
+  sort_year_isi: 1929,
+  human_readable_resource_type_tesim: ['still image'],
+  photographer_tesim: ['Person 1'],
+  location_tesim: ['search_results_spec'], # to control what displays
+  member_of_collections_ssim: ['Bennett (Walter E.) Photographic Collection, 1937-1983 (bulk 1952-1982)'],
+  member_of_collection_ids_ssim: ['m8f11000zz-89112'],
+  thumbnail_url_ss: ["http://thumbnail/work4.jpg"],
+  visibility_ssi: ['open']
+}.freeze
+
+WORK_E = {
+  id: 'id456e',
+  has_model_ssim: ['Work'],
+  title_tesim: ['Title Three'],
+  sort_title_ssort: 'Title Three',
+  title_alpha_numeric_ssort: 'The Title 100 of my Work',
+  identifier_tesim: ['ark 456'],
+  description_tesim: ['Description 3', 'Description 4', 'another desc'],
+  date_created_tesim: ["Date 1"],
+  sort_year_isi: 1929,
+  human_readable_resource_type_tesim: ['still image'],
+  photographer_tesim: ['Person 1'],
+  location_tesim: ['search_results_spec'], # to control what displays
+  member_of_collections_ssim: ['Bennett (Walter E.) Photographic Collection, 1937-1983 (bulk 1952-1982)'],
+  member_of_collection_ids_ssim: ['m8f11000zz-89112'],
+  thumbnail_url_ss: ["http://thumbnail/work4.jpg"],
+  visibility_ssi: ['open']
+}.freeze

--- a/spec/system/show_collection_spec.rb
+++ b/spec/system/show_collection_spec.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 
 require 'rails_helper'
@@ -39,9 +40,24 @@ RSpec.describe 'View a Collection', type: :system, js: true do
     }
   end
 
+  let(:work_1_attributes) { WORK_A }
+
+  let(:work_2_attributes) { WORK_B }
+
+  let(:work_3_attributes) { WORK_C }
+
+  let(:work_4_attributes) { WORK_D }
+
+  let(:work_5_attributes) { WORK_E }
+
   before do
     solr = Blacklight.default_index.connection
     solr.add(collection_attributes)
+    solr.add(work_1_attributes)
+    solr.add(work_2_attributes)
+    solr.add(work_3_attributes)
+    solr.add(work_4_attributes)
+    solr.add(work_5_attributes)
     solr.commit
     # allow(Rails.application.config).to receive(:iiif_url).and_return('https://example.com')
     # allow_any_instance_of(IiifService).to receive(:src).and_return('/uv/uv.html#?manifest=/manifest.json')
@@ -57,6 +73,13 @@ RSpec.describe 'View a Collection', type: :system, js: true do
 
     expect(page).to have_content 'Bennett (Walter E.) Photographic Collection, 1937-1983 (bulk 1952-1982)'
     expect(page).to have_content 'LOCAL IDENTIFIER  Collection 686'
+  end
+
+  it 'displays the schema.org values' do
+    visit solr_document_path(id)
+    expect(page.find('div[itemtype = "http://schema.org/Collection"]')['itemid']).to have_content '/catalog/m8f11000zz-89112'
+    expect(page.find('div > p[itemprop]')['itemprop']).to have_content 'abstract'
+    expect(page.find('div[itemprop]')['itemprop']).to have_content 'collectionSize'
   end
 
   it 'displays headings' do

--- a/spec/system/view_work_spec.rb
+++ b/spec/system/view_work_spec.rb
@@ -89,6 +89,14 @@ RSpec.describe 'View a Work', type: :system, js: true do
     expect(page.html).to match(/member_of_collections_ssim/)
   end
 
+  it 'displays the schema.org values' do
+    visit solr_document_path(id)
+    expect(page.find('div[itemtype = "http://schema.org/CreativeWork"]')['itemid']).to have_content '/catalog/123'
+    expect(page.find('dd.blacklight-genre_tesim')['itemprop']).to have_content 'genre'
+    # Capybara cannot find schema.org link tag
+    # expect(page.find('link[itemid$="/catalog/9qsg9000zz-89112"')['itemtype']).to have_content 'http://schema.org/Collection'
+  end
+
   it 'only displays the tools we want to support' do
     visit solr_document_path(id)
 


### PR DESCRIPTION
Connected to [URS-688](https://jira.library.ucla.edu/browse/URS-688)

See this link for an example of how Google is parsing our schema.org tags: https://search.google.com/structured-data/testing-tool/u/0/#url=https%3A%2F%2Fdigital.library.ucla.edu%2Fcatalog%2F5rsn2000zz-89112

The `itemtype` is a generic "Thing" and the id is a generic "document" URL.

Acceptance Criteria:
- [x] itemtype for a Hyrax collection is "Collection" ( https://schema.org/Collection)
- [x] itemtype for a Hyrax work is "CreativeWork" (https://schema.org/CreativeWork) 
- [x] itemprop for Hyrax Genre is "genre" (https://schema.org/genre)
- [x] id is not a generic document, but is the actual item URI

---

Modified:
+ `app/views/catalog/_collection_masthead_overlay.html.erb`
+ `app/views/catalog/_collection_record.html.erb`
+ `app/views/catalog/_homepage_banner.html.erb`
+ `app/views/catalog/_keyword_metadata.html.erb`
+ `app/views/catalog/_show_main_content.html.erb`
+ `app/views/layouts/blacklight/base.html.erb`
+ `spec/support/works.rb`
+ `spec/system/show_collection_spec.rb`
+ `spec/system/view_work_spec.rb`