### PR TITLE
URS-775 Create body colors and reset scss partials

### DIFF
--- a/app/assets/stylesheets/base/global/_body.scss
+++ b/app/assets/stylesheets/base/global/_body.scss
@@ -1,0 +1,26 @@
+@import 'colors';
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  background-color: $gray-80;
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0 auto;
+  min-width: 320px;
+  max-width: 1920px;
+  min-height: 100vh;
+  background-color: $white;
+  color: $gray-80;
+  font-family: "Helvetica", sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+}

--- a/app/assets/stylesheets/base/global/_colors.scss
+++ b/app/assets/stylesheets/base/global/_colors.scss
@@ -1,0 +1,6 @@
+$white: #fff;
+$black: #000;
+$gray-10: #e5e5e5;
+$gray-40: #999;
+$gray-60: #666;
+$gray-80: #333;

--- a/app/assets/stylesheets/base/global/_resets.scss
+++ b/app/assets/stylesheets/base/global/_resets.scss
@@ -1,0 +1,22 @@
+html, 
+body, 
+div, 
+span,
+h1,
+h2,
+h3,
+h4,
+p,
+ul[class],
+ol[class],
+li {
+  margin: 0;
+  padding: 0;
+}
+
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}

--- a/app/assets/stylesheets/theme_sinai/elements/_si-colors.scss
+++ b/app/assets/stylesheets/theme_sinai/elements/_si-colors.scss
@@ -1,0 +1,5 @@
+$sinai-red: #800020;
+$sinai-red-lighter: rgba(128,0,32,.45);
+$sinai-orange: #cb3208;
+$sinai-beige: #f7f2ea;
+$sinai-beige-darker: #e2dbcf;

--- a/app/assets/stylesheets/theme_ursus/elements/_ur-colors.scss
+++ b/app/assets/stylesheets/theme_ursus/elements/_ur-colors.scss
@@ -1,0 +1,8 @@
+$ucla-blue: #2774ae;
+$ucla-blue-darker: #005587;
+$ucla-blue-darkest: #003b5c;
+$ucla-blue-lighter: #8bb8e8;
+$ucla-blue-lightest: #c3d7ee;
+$ucla-gold: #ffd100;
+$ucla-gold-darker: #ffc72c;
+$ucla-gold-darkest: #ffb81c;


### PR DESCRIPTION
Connected to [URS-775](https://jira.library.ucla.edu/browse/URS-775)

Yay, it is working...
![Screen Shot 2020-05-14 at 12 39 38 PM](https://user-images.githubusercontent.com/751697/81978453-63ee5c80-95e0-11ea-8a28-b4b8886c45ee.png)

- [x] Add CSS code for global (default) elements, colors and resets; ursus colors and sinai colors.

---

Changes to be committed:
Modified:
+ `app/assets/stylesheets/base/global/_body.scss`
+ `app/assets/stylesheets/base/global/_colors.scss`
+ `app/assets/stylesheets/base/global/_resets.scss`
+ `app/assets/stylesheets/theme_sinai/elements/_si-colors.scss`
+ `app/assets/stylesheets/theme_ursus/elements/_ur-colors.scss`