### PR TITLE
Remove unneccessary scss @imports

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -88,6 +88,7 @@
       "transition"
     ],
     "property-no-vendor-prefix": null,
+    "selector-class-pattern": null,
     "selector-max-compound-selectors": null,
     "scss/at-extend-no-missing-placeholder": null,
     "scss/at-import-no-partial-leading-underscore": null,

--- a/app/assets/stylesheets/base/global/_buttons.scss
+++ b/app/assets/stylesheets/base/global/_buttons.scss
@@ -1,6 +1,3 @@
-@import 'bootstrap';
-@import 'colors';
-
 .btn-base {
   @extend .btn;
 

--- a/app/assets/stylesheets/base/global/_dividers.scss
+++ b/app/assets/stylesheets/base/global/_dividers.scss
@@ -1,5 +1,3 @@
-@import 'colors';
-
 .divider {
   height: 0;
 }

--- a/app/assets/stylesheets/base/global/_links.scss
+++ b/app/assets/stylesheets/base/global/_links.scss
@@ -1,5 +1,3 @@
-@import 'colors';
-
 a,
 a:active,
 a:visited {

--- a/app/assets/stylesheets/base/layout/body/_body.scss
+++ b/app/assets/stylesheets/base/layout/body/_body.scss
@@ -1,5 +1,3 @@
-@import 'bootstrap';
-
 .site-container {
   display: flex;
   flex-direction: column;

--- a/app/assets/stylesheets/base/layout/header/_navbar-alert.scss
+++ b/app/assets/stylesheets/base/layout/header/_navbar-alert.scss
@@ -1,20 +1,17 @@
-@import 'base/global/colors';
-@import 'base/global/typography';
-
 .alert-bar {
-  background-color: $gray-10;
   padding-top: 1rem;
   padding-bottom: 1rem;
+  background-color: $gray-10;
   @media (max-width: 575px) {
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
   }
 }
 
-.alert-bar__wrapper {
-  font-size: $text-14;
+.aleDLrt-bar__wrapper {
   display: flex;
   justify-content: space-between;
+  font-size: $text-14;
 }
 
 .alert-bar__text {
@@ -27,11 +24,13 @@
 
 .alert-bar__close {
   font-weight: 500;
+
   &:hover {
     text-decoration: underline;
   }
+
   .fa-close {
-    color: $gray-80;
     padding-left: 0.5rem;
+    color: $gray-80;
   }
 }

--- a/app/assets/stylesheets/base/utilities/old-css/_beta-bar.scss
+++ b/app/assets/stylesheets/base/utilities/old-css/_beta-bar.scss
@@ -1,9 +1,7 @@
-@import "colors";
-
 .beta-bar {
-  background-color: #ffd100;
-  font-weight: 700;
   font-size: 0.875rem;
+  font-weight: 700;
+  background-color: #ffd100;
 
   .beta-bar-wrapper {
     display: flex;
@@ -11,7 +9,7 @@
   }
 
   .beta-text {
-    padding: 2px 0px 2px 20px;
+    padding: 2px 0 2px 20px;
     flex-basis: 90%;
   }
 
@@ -24,8 +22,8 @@
   }
 
   .fa-close {
-    color: $black;
     padding-left: 0.5rem;
+    color: $black;
   }
 }
 

--- a/app/assets/stylesheets/theme_sinai/elements/_si-buttons.scss
+++ b/app/assets/stylesheets/theme_sinai/elements/_si-buttons.scss
@@ -1,6 +1,3 @@
-@import 'base/global/colors';
-@import 'si-colors';
-
 .btn-sinai--red {
   color: $white;
   background-color: $sinai-red;

--- a/app/assets/stylesheets/theme_sinai/elements/_si-dividers.scss
+++ b/app/assets/stylesheets/theme_sinai/elements/_si-dividers.scss
@@ -1,5 +1,3 @@
-@import 'si-colors';
-
 .divider--sinai {
   border-top: 1px solid $sinai-lighter-red;
 }

--- a/app/assets/stylesheets/theme_sinai/elements/_si-links.scss
+++ b/app/assets/stylesheets/theme_sinai/elements/_si-links.scss
@@ -1,6 +1,3 @@
-@import 'base/global/colors';
-@import 'si-colors';
-
 .si-link {
   color: $sinai-red;
 }

--- a/app/assets/stylesheets/theme_sinai/theme_sinai.scss
+++ b/app/assets/stylesheets/theme_sinai/theme_sinai.scss
@@ -1,3 +1,8 @@
+@import 'theme_sinai/elements/_si-colors';
+@import 'theme_sinai/elements/_si-buttons';
+@import 'theme_sinai/elements/_si-typography';
+@import 'theme_sinai/elements/_si-dividers';
+@import 'theme_sinai/elements/_si-links';
 @import 'theme_sinai/components/_si-results-block';
 @import 'theme_sinai/components/_si-facets';
 @import 'theme_sinai/components/_si-pagination-block';
@@ -9,11 +14,6 @@
 @import 'theme_sinai/header/_si-navbar';
 @import 'theme_sinai/footer/_si-secondary-footer';
 @import 'theme_sinai/footer/_si-primary-footer';
-@import 'theme_sinai/elements/_si-buttons';
-@import 'theme_sinai/elements/_si-colors';
-@import 'theme_sinai/elements/_si-typography';
-@import 'theme_sinai/elements/_si-dividers';
-@import 'theme_sinai/elements/_si-links';
 @import 'theme_sinai/pages/_si-item-page';
 @import 'theme_sinai/pages/_si-landing-page';
 @import 'theme_sinai/pages/_si-login-page';

--- a/app/assets/stylesheets/theme_ursus/elements/_ur-buttons.scss
+++ b/app/assets/stylesheets/theme_ursus/elements/_ur-buttons.scss
@@ -1,6 +1,3 @@
-@import 'base/global/colors';
-@import 'ur-colors';
-
 .btn-ursus--blue {
   color: $white;
   background-color: $ucla-darker-blue;

--- a/app/assets/stylesheets/theme_ursus/elements/_ur-dividers.scss
+++ b/app/assets/stylesheets/theme_ursus/elements/_ur-dividers.scss
@@ -1,5 +1,3 @@
-@import 'ur-colors';
-
 .divider--ursus {
   border-top: 1px solid $ucla-lighter-blue;
 }

--- a/app/assets/stylesheets/theme_ursus/elements/_ur-links.scss
+++ b/app/assets/stylesheets/theme_ursus/elements/_ur-links.scss
@@ -1,5 +1,3 @@
-@import 'ur-colors';
-
 .ur-link {
   color: $ucla-darker-blue;
 }

--- a/app/assets/stylesheets/theme_ursus/header/_ur-navbar-alert.scss
+++ b/app/assets/stylesheets/theme_ursus/header/_ur-navbar-alert.scss
@@ -1,5 +1,3 @@
-@import 'theme_ursus/elements/ur-colors';
-
 .alert-bar--ursus {
   background-color: $ucla-gold;
 }

--- a/app/assets/stylesheets/theme_ursus/theme_ursus.scss
+++ b/app/assets/stylesheets/theme_ursus/theme_ursus.scss
@@ -1,3 +1,8 @@
+@import 'theme_ursus/elements/_ur-colors';
+@import 'theme_ursus/elements/_ur-buttons';
+@import 'theme_ursus/elements/_ur-typography';
+@import 'theme_ursus/elements/_ur-dividers';
+@import 'theme_ursus/elements/_ur-links';
 @import 'theme_ursus/components/_ur-filter-chain-block';
 @import 'theme_ursus/components/_ur-facets';
 @import 'theme_ursus/components/_ur-featured-collections';
@@ -12,11 +17,6 @@
 @import 'theme_ursus/footer/_ur-secondary-footer';
 @import 'theme_ursus/footer/_ur-primary-footer';
 @import 'theme_ursus/canon-law/_cl-inner-navbar';
-@import 'theme_ursus/elements/_ur-typography';
-@import 'theme_ursus/elements/_ur-dividers';
-@import 'theme_ursus/elements/_ur-links';
-@import 'theme_ursus/elements/_ur-colors';
-@import 'theme_ursus/elements/_ur-buttons';
 @import 'theme_ursus/pages/_ur-static-page';
 @import 'theme_ursus/pages/_ur-item-page';
 @import 'theme_ursus/pages/_ur-landing-page';


### PR DESCRIPTION
Components such as bootstrap previously had to be imported directly into partials due to a bug in the scss/css build setup. This has been corrected, so each component can now be imported just once