### PR TITLE
URS-817 Remove "flash message" row

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -52,7 +52,6 @@
 
       <main class="main-content-container container-constrained">
         <%= content_for(:container_header) %>
-        <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
         <div class="row">
           <%= content_for?(:content) ? yield(:content) : yield %>
         </div>


### PR DESCRIPTION
[URS-817](https://jira.library.ucla.edu/browse/URS-817)

*Acceptance Criteria:*
In app/views/layouts/blacklight/base.html.erb:

 - [x] Remove the flash message markup since it's not in use

Fine(s) changed:
 - modified:   app/views/layouts/blacklight/base.html.erb