### PR TITLE
URS-807 Revert blacklight to v. 7.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'blacklight', '~> 7.3.0'
+gem 'blacklight', '~> 7.0.1'
 gem 'blacklight-access_controls', '>= 6.0.0'
 gem 'blacklight_dynamic_sitemap', '~> 0.1.0'
 gem 'blacklight_range_limit', '~> 7.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,12 +77,13 @@ GEM
     bixby (1.0.0)
       rubocop (~> 0.50, <= 0.52.1)
       rubocop-rspec (~> 1.22, <= 1.22.2)
-    blacklight (7.3.0)
+    blacklight (7.0.1)
       deprecation
       globalid
       jbuilder (~> 2.7)
       kaminari (>= 0.15)
-      rails (>= 5.1, < 7)
+      nokogiri (~> 1.6)
+      rails (~> 5.1)
     blacklight-access_controls (6.0.0)
       blacklight (> 6.0, < 8)
       cancancan (~> 1.8)
@@ -203,18 +204,18 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.3.0)
-    kaminari (1.2.0)
+    kaminari (1.2.1)
       activesupport (>= 4.1.0)
-      kaminari-actionview (= 1.2.0)
-      kaminari-activerecord (= 1.2.0)
-      kaminari-core (= 1.2.0)
-    kaminari-actionview (1.2.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
       actionview
-      kaminari-core (= 1.2.0)
-    kaminari-activerecord (1.2.0)
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
       activerecord
-      kaminari-core (= 1.2.0)
-    kaminari-core (1.2.0)
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -445,7 +446,7 @@ PLATFORMS
 
 DEPENDENCIES
   bixby
-  blacklight (~> 7.3.0)
+  blacklight (~> 7.0.1)
   blacklight-access_controls (>= 6.0.0)
   blacklight-gallery!
   blacklight_dynamic_sitemap (~> 0.1.0)

--- a/spec/system/next_previous_on_show_spec.rb
+++ b/spec/system/next_previous_on_show_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'the result bar displays the correct links', :clean, type: :syste
     expect(page).to have_content 'You searched for: Person'
     expect(page).to have_content 'Start Over'
     click_link('Title One', match: :first)
-    # expect(page).to have_content '1 of 2 results' # Upgrade to v 7.2 breaks in the test, not in prod
+    expect(page).to have_content '1 of 2 results'
     expect(page).to have_content 'Back to Search Results'
     # expect(page).to have_content 'New Search'
     expect(page).not_to have_content 'Cite This Item'


### PR DESCRIPTION
Connected to [URS-807](https://jira.library.ucla.edu/browse/URS-807) Restore Pagination to the Item Page

The upgrade to blacklight 7.3 introduced changes to search history tracking which had the effect of breaking our custom pagination logic. Reverting should restore proper search result pagination.