### PR TITLE
Reset the Browse Facet labels in Ursus back to blue

### DIFF
--- a/app/assets/stylesheets/legacy/old_blacklight/_facets.scss
+++ b/app/assets/stylesheets/legacy/old_blacklight/_facets.scss
@@ -20,7 +20,6 @@
 
     &#{$infix} {
       @include media-breakpoint-up($next) {
-
         // scss-lint:disable ImportantRule
         .facets-collapse {
           display: block !important;
@@ -64,12 +63,10 @@
   margin-bottom: 0;
 
   li {
-
     display: table-row;
     .selected {
       @extend .text-success;
     }
-
   }
 
   .remove {
@@ -78,7 +75,7 @@
     padding-left: $spacer / 2;
 
     &:hover {
-      color: theme-color("danger");
+      color: theme-color('danger');
       text-decoration: none;
     }
   }
@@ -109,11 +106,11 @@
 
 .facet-extended-list {
   .sort-options {
-    text-align:right;
+    text-align: right;
   }
 
   .prev-next-links {
-    float:left;
+    float: left;
   }
 }
 
@@ -121,7 +118,7 @@
   @extend .h6;
 
   a {
-    color: inherit;
+    color: #005587;
   }
 }
 
@@ -136,14 +133,13 @@
   }
 }
 
-
-
 /* style for pivot facet's nested list */
 
 .pivot-facet {
   @extend .list-unstyled;
 
-  ul, .pivot-facet {
+  ul,
+  .pivot-facet {
     @extend .list-unstyled;
     @extend .py-1;
     @extend .px-3;


### PR DESCRIPTION
[URS-831](https://jira.library.ucla.edu/browse/URS-831)

Ursus: Browse facet labels in Ursus are no longer blue (they are black now)

*Acceptance criteria*

 - [x] Reset the Browse Facet labels in Ursus back to blue

*Files changed*
 - modified:   app/assets/stylesheets/legacy/old_blacklight/_facets.scss

*Screenshot*
![facet_labels_are_now_blue](https://user-images.githubusercontent.com/2350153/83198677-84e0a280-a0f4-11ea-9716-046d4e66c9fa.jpg)
