### PR TITLE
DO NOT MERGE: Refactor docker environments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+public/uv

--- a/.gitignore
+++ b/.gitignore
@@ -74,8 +74,6 @@ flycheck_*.el
 # directory configuration
 .dir-locals.el
 
-public/uv
-
 *.DS_Store
 app/assets/images/.DS_Store
 app/assets/.DS_Store

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,6 +1,5 @@
 {
     "urls": [
-        "http://dockerhost:3003"
     ],
     "defaults": {
         "chromeLaunchConfig": {

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,27 +5,20 @@ services:
   - docker
 env:
   global:
-    - DOCKER_COMPOSE_VERSION=1.23.2
     - JENKINS_HOST=jenkins-devsupport.library.ucla.edu
     - JENKINS_USER="${TRAVIS_JENKINS_USER}"
     - JENKINS_API_CALLISTO="${TRAVIS_JENKINS_API_CALLISTO}"
     - JENKINS_API_URSUS="${TRAVIS_JENKINS_API_URSUS}"
 before_install:
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
-script:
-  - docker-compose -f docker-compose-standalone.yml up -d
-  - docker-compose -f docker-compose-standalone.yml run web gem install bundler
-  - docker-compose -f docker-compose-standalone.yml run web bundle install
-  - docker-compose -f docker-compose-standalone.yml run web yarn install
-  - docker-compose -f docker-compose-standalone.yml run web bundle exec rubocop
-  - docker-compose -f docker-compose-standalone.yml run web bundle exec erblint --lint-all
-  - docker-compose -f docker-compose-standalone.yml run web yarn run lint
+  - docker-compose -f docker-compose-standalone.yml run web bundle check || bundle install
+  - docker-compose -f docker-compose-standalone.yml run sinai bundle check || bundle install
+  - docker-compose -f docker-compose-standalone.yml run yarn install
+  - docker-compose -f docker-compose-standalone.yml run yarn install
   - docker-compose -f docker-compose-standalone.yml run web bundle exec rake db:setup
-  - docker-compose -f docker-compose-standalone.yml run web yarn run pa11y-ci --threshold 10
-  - docker-compose -f docker-compose-standalone.yml run web bundle exec rspec
+  - docker-compose -f docker-compose-standalone.yml run sinai bundle exec rake db:setup
+  - docker-compose -f docker-compose-standalone.yml ps
+script:
+  - docker-compose -f docker-compose-standalone.yml run ci
 notifications:
   email: false
 after_success:

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,20 @@ RUN apt-get install mariadb-client build-essential libpq-dev yarn nodejs chromiu
 # Install Ruby Gems
 RUN gem install bundler
 ENV BUNDLE_PATH /usr/local/bundle
-WORKDIR /californica
-COPY Gemfile /californica/Gemfile
-COPY Gemfile.lock /californica/Gemfile.lock
+WORKDIR /ursus
+COPY Gemfile /ursus/Gemfile
+COPY Gemfile.lock /ursus/Gemfile.lock
 RUN bundle install
+
+# Install Node Packages
+COPY package.json /ursus/package.json
+COPY yarn.lock /ursus/yarn.lock
+RUN mkdir -p /ursus/public/uv
+RUN yarn install
 
 # Create a non-root user
 RUN useradd -ms /bin/bash  ursus
 
-# Add californica
+# Add ursus
 COPY / /ursus
 CMD ["sh", "/ursus/start-ursus.sh"]

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,10 @@ group :development, :test do
   gem 'rubocop'
   gem 'selenium-webdriver', '>= 3.142.3'
   gem 'solr_wrapper', '>= 2.1.0'
+  gem 'spring'
+  gem 'spring-commands-rspec'
+  gem 'spring-commands-rubocop'
+  gem 'spring-watcher-listen'
   gem 'webmock'
 end
 
@@ -70,9 +74,6 @@ group :development do
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
   gem 'capistrano-sidekiq', '~> 0.20.0'
-  gem 'spring'
-  gem 'spring-commands-rspec'
-  gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'xray-rails', '>= 0.3.2'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,6 +383,8 @@ GEM
     spring (2.1.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
+    spring-commands-rubocop (0.2.0)
+      spring (>= 1.0, < 3.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -492,7 +494,8 @@ DEPENDENCIES
   solrizer (>= 4.1.0)
   spring
   spring-commands-rspec
-  spring-watcher-listen (~> 2.0.0)
+  spring-commands-rubocop
+  spring-watcher-listen
   sprockets (< 4)
   turbolinks (~> 5)
   tzinfo-data

--- a/default.env
+++ b/default.env
@@ -7,7 +7,7 @@ DATABASE_ADAPTER=mysql2
 
 ADMIN_PASSWORD=password
 CABLE_CHANNEL_PREFIX=ursus_development
-DATABASE_HOST=localhost
+DATABASE_HOST=127.0.0.1
 DATABASE_USERNAME=ursus
 DATABASE_PASSWORD=ursus
 DATABASE_POOL=25
@@ -19,7 +19,12 @@ RAILS_HOST=localhost
 SINAI_ID_BYPASS=true
 
 # The solr for the Californica environment that this Ursus environment will use as its data source
-SOLR_URL=http://127.0.0.1:8983/solr/californica
+SOLR_URL=http://127.0.0.1:8983/solr/ursus
+SOLR_TEST_URL=http://127.0.0.1:8985/solr/ursus
+
+# old stuff, should be able to remove sometime
+IIIF_URL=https://californica-test.library.ucla.edu/concern/works
+THUMBNAIL_BASE_URL=http://californica-test.library.ucla.edu
 
 # Controls whether or not the login and bookmarks UI show up
 USER_ACCOUNT_UI_ENABLED=false

--- a/docker-compose-standalone.yml
+++ b/docker-compose-standalone.yml
@@ -7,21 +7,56 @@ services:
     depends_on:
       - db
       - solr
-      - dockerhost
     env_file:
-      - ./dotenv.sample
-    environment:
-      DATABASE_HOST: db
-      IIIF_URL: https://californica-test.library.ucla.edu/concern/works
-      THUMBNAIL_BASE_URL: http://californica-test.library.ucla.edu
-      SOLR_URL: http://solr:8983/solr/californica
-      SOLR_TEST_URL: http://solr_test:8983/solr/californica
+      - ./default.env
+      - ./docker.env
     ports:
       - "127.0.0.1:3003:3000"
     volumes:
       - .:/ursus
-      - bundle_dir:/usr/local/bundle
+      - ursus_bundle_dir:/usr/local/bundle
+      - ursus_node_modules:/ursus/node_modules
+      - ursus_public_uv:/ursus/public/uv
+      - ursus_tmp:/ursus/tmp
     working_dir: /ursus
+  
+  sinai:
+    image: uclalibrary/ursus
+    command: 'sh start-sinai.sh'
+    depends_on:
+      - db
+      - solr
+    env_file:
+      - ./default.env
+      - ./docker.env
+    environment:
+      DATABASE_NAME: sinai
+      SOLR_URL: http://solr:8983/solr/sinai
+      SOLR_TEST_URL: http://solr_test:8983/slumes:
+      - .:/ursus
+      - ursus_bundle_dir:/usr/local/bundle
+      - ursus_node_modules:/ursus/node_modules
+      - ursus_public_uv:/ursus/public/uv
+      - ur
+    depends_on:
+      - db
+      - sinai
+      - solr_test
+      - web
+    env_file:
+      - ./default.env
+      - ./docker.env
+    environment:
+      SOLR_TEST_URL: http://solr_test:8983/solr/ursus
+    volumes:
+      - .:/ursus
+      - ci_bundle_dir:/usr/local/bundle
+      - ci_node_modules:/ursus/node_modules
+      - ci_public_uv:/ursus/public/uv
+      - ci_tmp:/ursus/tmp
+    working_dir: /ursus
+
+
   db:
     image: mysql:5.6
     volumes:
@@ -37,14 +72,25 @@ services:
     ports:
       - "127.0.0.1:8983:8983"
 
-  solr_test:
-    image: uclalibrary/solr-ursus
-    ports:
+  solr_test:lumes:
+      - .:/ursus
+      - ursus_bundle_dir:/usr/local/bundle
+      - ursus_node_modules:/ursus/node_modules
+      - ursus_public_uv:/ursus/public/uv
+      - ur
       - "127.0.0.1:8985:8983"
-  dockerhost:
-    image: qoomon/docker-host
-    cap_add: [ 'NET_ADMIN', 'NET_RAW' ]
-    restart: on-failure
+
 volumes:
-  bundle_dir:
+  ci_bundle_dir:
+  ci_node_modules:
+  ci_public_uv:
+  ci_tmp:
   mysql_data:
+  sinai_bundle_dir:
+  sinai_node_modules:
+  sinai_public_uv:
+  sinai_tmp:
+  ursus_bundle_dir:
+  ursus_node_modules:
+  ursus_public_uv:
+  ursus_tmp:

--- a/docker-compose-with-californica.yml
+++ b/docker-compose-with-californica.yml
@@ -5,21 +5,20 @@ services:
     image: uclalibrary/ursus
     hostname: ursus
     env_file:
-      - ./dotenv.sample
+      - ./default.env
+      - ./docker.env
     environment:
-      DATABASE_HOST: db
-      DATABASE_NAME: ursus
       DATABASE_USERNAME: californica
       DATABASE_PASSWORD: californica
-      IIIF_URL: http://localhost:3000/concern/works
-      THUMBNAIL_BASE_URL: http://localhost:3000
       SOLR_URL: http://solr:8983/solr/californica
       SOLR_TEST_URL: http://solr_test:8983/solr/californica
     ports:
       - "127.0.0.1:3003:3000"
     volumes:
       - .:/ursus
-      - bundle_dir:/usr/local/bundle
+      - ursus_bundle_dir:/usr/local/bundle
+      - ursus_node_modules:/ursus/node_modules
+      - ursus_public_uv:/ursus/public/uv
       - ursus_tmp:/ursus/tmp
     working_dir: /ursus
     networks:
@@ -27,16 +26,15 @@ services:
 
   sinai:
     image: uclalibrary/ursus
+    hostname: sinai
     command: 'sh start-sinai.sh'
     env_file:
-      - ./dotenv.sample
+      - ./default.env
+      - ./docker.env
     environment:
-      DATABASE_HOST: db
       DATABASE_NAME: sinai
       DATABASE_USERNAME: californica
       DATABASE_PASSWORD: californica
-      IIIF_URL: http://localhost:3000/concern/works
-      THUMBNAIL_BASE_URL: http://localhost:3000
       SOLR_URL: http://solr:8983/solr/californica
       SOLR_TEST_URL: http://solr_test:8983/solr/californica
     ports:
@@ -44,15 +42,22 @@ services:
     volumes:
       - .:/ursus
       - sinai_bundle_dir:/usr/local/bundle
+      - sinai_node_modules:/ursus/node_modules
+      - sinai_public_uv:/ursus/public/uv
       - sinai_tmp:/ursus/tmp
     working_dir: /ursus
     networks:
       - californica_default
+
 volumes:
-  bundle_dir:
-  ursus_tmp:
   sinai_bundle_dir:
+  sinai_node_modules:
+  sinai_public_uv:
   sinai_tmp:
+  ursus_bundle_dir:
+  ursus_node_modules:
+  ursus_public_uv:
+  ursus_tmp:
 networks:
   californica_default:
     external: true

--- a/docker.env
+++ b/docker.env
@@ -1,0 +1,3 @@
+DATABASE_HOST=db
+SOLR_URL=http://solr:8983/solr/ursus
+SOLR_TEST_URL=http://solr_test:8983/solr/ursus

--- a/package.json
+++ b/package.json
@@ -6,11 +6,7 @@
   },
   "scripts": {
     "lint": "stylelint app/assets/stylesheets/** --syntax scss",
-    "lint:fix": "stylelint app/assets/stylesheets/** --syntax scss --fix",
-    "preinstall": "rm -rf ./public/uv",
-    "postinstall": "yarn run uv-install && yarn run uv-config",
-    "uv-install": "shx cp -r ./node_modules/universalviewer/uv ./public/",
-    "uv-config": "shx cp ./config/uv/uv.html ./public/uv/uv.html & shx cp ./config/uv/uv-config.json ./public/uv/"
+    "lint:fix": "stylelint app/assets/stylesheets/** --syntax scss --fix"
   },
   "devDependencies": {
     "pa11y-ci": "^2.2.0",

--- a/public/uv/build.js.map
+++ b/public/uv/build.js.map
@@ -1,0 +1,1 @@
+../../node_modules/universalviewer/uv/build.js.map

--- a/public/uv/favicon.ico
+++ b/public/uv/favicon.ico
@@ -1,0 +1,1 @@
+../../node_modules/universalviewer/uv/favicon.ico

--- a/public/uv/helpers.js
+++ b/public/uv/helpers.js
@@ -1,0 +1,1 @@
+../../node_modules/universalviewer/uv/helpers.js

--- a/public/uv/img
+++ b/public/uv/img
@@ -1,0 +1,1 @@
+../../node_modules/universalviewer/uv/img

--- a/public/uv/info.json
+++ b/public/uv/info.json
@@ -1,0 +1,1 @@
+../../node_modules/universalviewer/uv/info.json

--- a/public/uv/lib
+++ b/public/uv/lib
@@ -1,0 +1,1 @@
+../../node_modules/universalviewer/uv/lib

--- a/public/uv/schema
+++ b/public/uv/schema
@@ -1,0 +1,1 @@
+../../node_modules/universalviewer/uv/schema

--- a/public/uv/themes
+++ b/public/uv/themes
@@ -1,0 +1,1 @@
+../../node_modules/universalviewer/uv/themes

--- a/public/uv/uv-config.json
+++ b/public/uv/uv-config.json
@@ -1,0 +1,1 @@
+../../config/uv/uv-config.json

--- a/public/uv/uv.css
+++ b/public/uv/uv.css
@@ -1,0 +1,1 @@
+../../node_modules/universalviewer/uv/uv.css

--- a/public/uv/uv.html
+++ b/public/uv/uv.html
@@ -1,0 +1,1 @@
+../../config/uv/uv.html

--- a/public/uv/uv.js
+++ b/public/uv/uv.js
@@ -1,0 +1,1 @@
+../../node_modules/universalviewer/uv/uv.js

--- a/start-ci.sh
+++ b/start-ci.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+bundle check || bundle install
+spring rubocop
+bundle exec erblint --lint-all
+
+yarn install
+yarn run lint
+
+spring rspec spec
+
+yarn run pa11y-ci --threshold 10

--- a/start-sinai.sh
+++ b/start-sinai.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+start -e
+
 bundle check || bundle install
 
 find . -name *.pid -delete

--- a/start-ursus.sh
+++ b/start-ursus.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 bundle check || bundle install
 
 find . -name *.pid -delete


### PR DESCRIPTION
- Refactor dot.env files so that commands can be run natively as well as in docker
- Mount docker volumes to node_modules/ and public/uv/ to avoid conflicts between docker-installed and natively-installed javascript
- add a 'sinai' container to docker-compose-standalone.yml
- add a 'ci' container to run ci suite in docker-compose-standalone.yml; this can be invoked with `docker-compose -f docker-compose-standalone.yml run ci`
- remove `dockerhost` container; pa11y can point directly at `web` and `sinai` containers