### PR TITLE
Downgrade stylelint

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "pa11y-ci": "^2.2.0",
     "shx": "^0.3.2",
-    "stylelint": "^13.5.0",
+    "stylelint": "^12.0.1",
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-sass-guidelines": "^7.0.0",
     "stylelint-config-standard": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "shx": "^0.3.2",
     "stylelint": "^12.0.1",
     "stylelint-config-prettier": "^8.0.1",
-    "stylelint-config-sass-guidelines": "^7.0.0",
+    "stylelint-config-sass-guidelines": "^6.2.0",
     "stylelint-config-standard": "^20.0.0",
     "stylelint-order": "^4.0.0",
     "stylelint-scss": "^3.17.2"


### PR DESCRIPTION
Last version of stylint to support Node 8 is 12.0.1