### PR TITLE
URS-840 Update CSS styling/colors for Prev-Next links (item page)

### DIFF
--- a/app/assets/stylesheets/theme_sinai/pages/_si-item-page.scss
+++ b/app/assets/stylesheets/theme_sinai/pages/_si-item-page.scss
@@ -3,3 +3,25 @@
 
   background-color: $sinai-beige;
 }
+
+.item-page__pagination-widgets--sinai {
+  .previous {
+    color: $sinai-red;
+
+    &:hover {
+      color: $sinai-lighter-red;
+    }
+
+    &:not(a) {
+      color: $gray-60;
+    }
+  }
+
+  .next {
+    color: $sinai-red;
+
+    &:hover {
+      color: $sinai-lighter-red;
+    }
+  }
+}

--- a/app/assets/stylesheets/theme_ursus/pages/_ur-item-page.scss
+++ b/app/assets/stylesheets/theme_ursus/pages/_ur-item-page.scss
@@ -1,6 +1,27 @@
 .item-page__secondary-metadata--ursus {
-
   @extend .col-lg-5;
 
   background-color: $ucla-lightest-blue;
+}
+
+.item-page__pagination-widgets--ursus {
+  .previous {
+    color: $ucla-darker-blue;
+
+    &:hover {
+      color: $ucla-blue;
+    }
+
+    &:not(a) {
+      color: $gray-60;
+    }
+  }
+
+  .next {
+    color: $ucla-darker-blue;
+
+    &:hover {
+      color: $ucla-blue;
+    }
+  }
 }

--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -1,0 +1,21 @@
+<!-- Uses the Bootstrap Pagination class -->
+<!-- SINAI -->
+<% if Flipflop.sinai? %>
+  <div class='item-page__pagination-widgets item-page__pagination-widgets--sinai'>
+    <% if @search_context[:prev] || @search_context[:next] %>
+      <%= item_page_entry_info %> results &nbsp;
+      <%= link_to_previous_document @search_context[:prev] %> &nbsp; <%= link_to_next_document @search_context[:next] %>
+    <% end %>
+  </div>
+
+<!-- URSUS -->
+
+<% else %>
+  <%# -%>
+  <div class='item-page__pagination-widgets item-page__pagination-widgets--ursus'>
+    <% if @search_context[:prev] || @search_context[:next] %>
+      <%= item_page_entry_info %> results &nbsp;
+      <%= link_to_previous_document @search_context[:prev] %> &nbsp; <%= link_to_next_document @search_context[:next] %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views_legacy/catalog/_previous_next_doc.html.erb
+++ b/app/views_legacy/catalog/_previous_next_doc.html.erb
@@ -1,9 +1,0 @@
-<% # Using the Bootstrap Pagination class  -%>
-<div class='item-page__pagination-widgets'>
-  <% if @search_context[:prev] || @search_context[:next] %>
-    <!--<div class='total-results'>-->
-      <%= item_page_entry_info %> results &nbsp;
-      <%= link_to_previous_document @search_context[:prev] %> &nbsp; <%= link_to_next_document @search_context[:next] %>
-    <!--</div>-->
-  <% end %>
-</div>


### PR DESCRIPTION
Connected to [URS-840](https://jira.library.ucla.edu/browse/URS-840)

<img width="754" alt="Screen Shot 2020-06-03 at 11 56 08 AM" src="https://user-images.githubusercontent.com/751697/83677795-877a4680-a591-11ea-8fce-acfba64c441c.png">
<img width="341" alt="Screen Shot 2020-06-03 at 11 59 00 AM" src="https://user-images.githubusercontent.com/751697/83677842-a11b8e00-a591-11ea-8918-724bd8bf57bd.png">

---

Changes to be committed:
modified:   app/assets/stylesheets/theme_sinai/pages/_si-item-page.scss
modified:   app/assets/stylesheets/theme_ursus/pages/_ur-item-page.scss
new file:   app/views/catalog/_previous_next_doc.html.erb