### PR TITLE
Allow commands to run natively or in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+public/uv

--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+default.env

--- a/default.env
+++ b/default.env
@@ -7,9 +7,9 @@ DATABASE_ADAPTER=mysql2
 
 ADMIN_PASSWORD=password
 CABLE_CHANNEL_PREFIX=ursus_development
-DATABASE_HOST=localhost
-DATABASE_USERNAME=ursus
-DATABASE_PASSWORD=ursus
+DATABASE_HOST=127.0.0.1
+DATABASE_USERNAME=californica
+DATABASE_PASSWORD=californica
 DATABASE_POOL=25
 DATABASE_MIN_MESSAGES=warning
 RAILS_SERVE_STATIC_FILES=true
@@ -20,6 +20,11 @@ SINAI_ID_BYPASS=true
 
 # The solr for the Californica environment that this Ursus environment will use as its data source
 SOLR_URL=http://127.0.0.1:8983/solr/californica
+SOLR_TEST_URL=http://127.0.0.1:8985/solr/californica
+
+# old stuff, should be able to remove sometime
+IIIF_URL=https://californica-test.library.ucla.edu/concern/works
+THUMBNAIL_BASE_URL=http://californica-test.library.ucla.edu
 
 # Controls whether or not the login and bookmarks UI show up
 USER_ACCOUNT_UI_ENABLED=false

--- a/docker-compose-standalone.yml
+++ b/docker-compose-standalone.yml
@@ -9,18 +9,21 @@ services:
       - solr
       - dockerhost
     env_file:
-      - ./dotenv.sample
+      - ./default.env
+      - ./docker.env
     environment:
-      DATABASE_HOST: db
-      IIIF_URL: https://californica-test.library.ucla.edu/concern/works
-      THUMBNAIL_BASE_URL: http://californica-test.library.ucla.edu
-      SOLR_URL: http://solr:8983/solr/californica
-      SOLR_TEST_URL: http://solr_test:8983/solr/californica
+      SOLR_URL: http://solr:8983/solr/ursus
+      SOLR_TEST_URL: http://solr_test:8983/solr/ursus
+      DATABASE_USERNAME: ursus
+      DATABASE_PASSWORD: ursus
     ports:
       - "127.0.0.1:3003:3000"
     volumes:
       - .:/ursus
-      - bundle_dir:/usr/local/bundle
+      - ursus_bundle_dir:/usr/local/bundle
+      - ursus_node_modules:/ursus/node_modules
+      - ursus_public_uv:/ursus/public/uv
+      - ursus_tmp:/ursus/tmp
     working_dir: /ursus
   db:
     image: mysql:5.6
@@ -46,5 +49,8 @@ services:
     cap_add: [ 'NET_ADMIN', 'NET_RAW' ]
     restart: on-failure
 volumes:
-  bundle_dir:
   mysql_data:
+  ursus_bundle_dir:
+  ursus_node_modules:
+  ursus_public_uv:
+  ursus_tmp:

--- a/docker-compose-with-californica.yml
+++ b/docker-compose-with-californica.yml
@@ -5,21 +5,15 @@ services:
     image: uclalibrary/ursus
     hostname: ursus
     env_file:
-      - ./dotenv.sample
-    environment:
-      DATABASE_HOST: db
-      DATABASE_NAME: ursus
-      DATABASE_USERNAME: californica
-      DATABASE_PASSWORD: californica
-      IIIF_URL: http://localhost:3000/concern/works
-      THUMBNAIL_BASE_URL: http://localhost:3000
-      SOLR_URL: http://solr:8983/solr/californica
-      SOLR_TEST_URL: http://solr_test:8983/solr/californica
+      - ./default.env
+      - ./docker.env
     ports:
       - "127.0.0.1:3003:3000"
     volumes:
       - .:/ursus
-      - bundle_dir:/usr/local/bundle
+      - ursus_bundle_dir:/usr/local/bundle
+      - ursus_node_modules:/ursus/node_modules
+      - ursus_public_uv:/ursus/public/uv
       - ursus_tmp:/ursus/tmp
     working_dir: /ursus
     networks:
@@ -27,32 +21,34 @@ services:
 
   sinai:
     image: uclalibrary/ursus
+    hostname: sinai
     command: 'sh start-sinai.sh'
     env_file:
-      - ./dotenv.sample
+      - ./default.env
+      - ./docker.env
     environment:
-      DATABASE_HOST: db
       DATABASE_NAME: sinai
-      DATABASE_USERNAME: californica
-      DATABASE_PASSWORD: californica
-      IIIF_URL: http://localhost:3000/concern/works
-      THUMBNAIL_BASE_URL: http://localhost:3000
-      SOLR_URL: http://solr:8983/solr/californica
-      SOLR_TEST_URL: http://solr_test:8983/solr/californica
     ports:
       - "127.0.0.1:3004:3000"
     volumes:
       - .:/ursus
       - sinai_bundle_dir:/usr/local/bundle
+      - sinai_node_modules:/ursus/node_modules
+      - sinai_public_uv:/ursus/public/uv
       - sinai_tmp:/ursus/tmp
     working_dir: /ursus
     networks:
       - californica_default
+
 volumes:
-  bundle_dir:
-  ursus_tmp:
   sinai_bundle_dir:
+  sinai_node_modules:
+  sinai_public_uv:
   sinai_tmp:
+  ursus_bundle_dir:
+  ursus_node_modules:
+  ursus_public_uv:
+  ursus_tmp:
 networks:
   californica_default:
     external: true

--- a/docker.env
+++ b/docker.env
@@ -1,0 +1,3 @@
+DATABASE_HOST=db
+SOLR_URL=http://solr:8983/solr/californica
+SOLR_TEST_URL=http://solr_test:8983/solr/californica

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "scripts": {
     "lint": "stylelint app/assets/stylesheets/** --syntax scss",
     "lint:fix": "stylelint app/assets/stylesheets/** --syntax scss --fix",
-    "preinstall": "rm -rf ./public/uv",
+    "preinstall": "mkdir -p ./public/uv; rm -rf ./public/uv/*",
     "postinstall": "yarn run uv-install && yarn run uv-config",
-    "uv-install": "shx cp -r ./node_modules/universalviewer/uv ./public/",
+    "uv-install": "shx cp -r ./node_modules/universalviewer/uv/* ./public/uv/",
     "uv-config": "shx cp ./config/uv/uv.html ./public/uv/uv.html & shx cp ./config/uv/uv-config.json ./public/uv/"
   },
   "devDependencies": {


### PR DESCRIPTION
- Refactor dot.env files so that commands can be run natively as well as in docker
- Mount docker volumes to node_modules/ and public/uv/ to avoid conflicts between docker-installed and natively-installed javascript [docker-compose-with-californica.yml]