### PR TITLE
Set start-ursus[/sinai].sh to fail on errors

### DIFF
--- a/start-sinai.sh
+++ b/start-sinai.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+start -e
+
 bundle check || bundle install
 
 find . -name *.pid -delete

--- a/start-ursus.sh
+++ b/start-ursus.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 bundle check || bundle install
 
 find . -name *.pid -delete


### PR DESCRIPTION
sets the start scripts (start-ursus.sh and start-sinai.sh) to fail. This way the server doesn't start if e.g. `bundle install` or `yarn install` fails.