### PR TITLE
URS-845 Reduce top-bottom padding on navbars and site container

### DIFF
--- a/app/assets/stylesheets/base/components/banner/_collection-banner.scss
+++ b/app/assets/stylesheets/base/components/banner/_collection-banner.scss
@@ -1,7 +1,10 @@
 .banner--collection-page {
   @include banner;
 
-  height: 450px;
+  height: 400px;
+  @media (max-width: 576px) {
+    height: 450px;
+  }
 }
 
 .banner__overlay--collection {

--- a/app/assets/stylesheets/base/layout/body/_body.scss
+++ b/app/assets/stylesheets/base/layout/body/_body.scss
@@ -27,8 +27,8 @@
 }
 
 .main-content-container {
-  margin-top: 6.25rem;
-  margin-bottom: 6.25rem;
+  margin-top: 5.25rem;
+  margin-bottom: 5.25rem;
 
   @media (max-width: 768px) {
     margin-top: 4.25rem;

--- a/app/assets/stylesheets/base/layout/header/_navbar-alert.scss
+++ b/app/assets/stylesheets/base/layout/header/_navbar-alert.scss
@@ -1,6 +1,6 @@
 .alert-bar {
-  padding-top: 1rem;
-  padding-bottom: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
   background-color: $gray-10;
   @media (max-width: 575px) {
     padding-top: 0.5rem;

--- a/app/assets/stylesheets/base/layout/header/_navbar.scss
+++ b/app/assets/stylesheets/base/layout/header/_navbar.scss
@@ -6,7 +6,7 @@
 }
 
 .site-navbar__wrapper {
-  padding: 1rem 0;
+  padding: 0.75rem 0;
   @media (max-width: 991px) {
     padding-bottom: 0;
   }


### PR DESCRIPTION
Connected to [URS-845](https://jira.library.ucla.edu/browse/URS-845)

### Reduce top-bottom padding on navbars and site container

- [x] Update .alert-bar top and bottom padding to .5rem
- [x] Update .site-navbarwrapper top and bottom padding to .75rem
- [x] Update .main-content-container top and bottom margin to 5.25rem
- [x] Update .banner--collection-page height to 400px
    - [x] Add media query of (max-width: 576px), increase height to 450px

---

#### Changes to be committed:
##### Modified:   
1. `app/assets/stylesheets/base/components/banner/_collection-banner.scss`
1. ` app/assets/stylesheets/base/layout/body/_body.scss`
1. ` app/assets/stylesheets/base/layout/header/_navbar-alert.scss`
1. ` app/assets/stylesheets/base/layout/header/_navbar.scss`