### PR TITLE
Travis CI refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,26 +5,14 @@ services:
   - docker
 env:
   global:
-    - DOCKER_COMPOSE_VERSION=1.23.2
+    - COMPOSE_FILE=docker-compose-ci.yml
     - JENKINS_HOST=jenkins-devsupport.library.ucla.edu
     - JENKINS_USER="${TRAVIS_JENKINS_USER}"
     - JENKINS_API_CALLISTO="${TRAVIS_JENKINS_API_CALLISTO}"
     - JENKINS_API_URSUS="${TRAVIS_JENKINS_API_URSUS}"
-before_install:
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
 script:
-  - docker-compose -f docker-compose-standalone.yml up -d
-  - docker-compose -f docker-compose-standalone.yml run web gem install bundler
-  - docker-compose -f docker-compose-standalone.yml run web bundle install
-  - docker-compose -f docker-compose-standalone.yml run web yarn install --frozen-lockfile
-  - docker-compose -f docker-compose-standalone.yml run web bundle exec rubocop
-  - docker-compose -f docker-compose-standalone.yml run web bundle exec erblint --lint-all
-  - docker-compose -f docker-compose-standalone.yml run web yarn run lint
-  - docker-compose -f docker-compose-standalone.yml run web bundle exec rake db:setup
-  - docker-compose -f docker-compose-standalone.yml run web bundle exec rspec
+  - docker-compose up --detach --build
+  - docker-compose run web sh start-ci.sh
 notifications:
   email: false
 after_success:

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,16 @@
+FROM uclalibrary/ursus
+
+WORKDIR /ursus
+
+# Install Ruby Gems
+COPY Gemfile /ursus/Gemfile
+COPY Gemfile.lock /ursus/Gemfile.lock
+RUN bundle install
+
+# Install node packages
+COPY package.json /ursus/package.json
+COPY yarn.lock /ursus/yarn.lock
+RUN yarn install --frozen-lockfile
+
+# Add ursus
+COPY / /ursus

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,0 +1,54 @@
+version: "3.6"
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.ci
+    hostname: ursus
+    depends_on:
+      - db
+      - solr
+    env_file:
+      - ./default.env
+      - ./docker.env
+    environment:
+      SOLR_URL: http://solr:8983/solr/ursus
+      SOLR_TEST_URL: http://solr_test:8983/solr/ursus
+      DATABASE_USERNAME: ursus
+      DATABASE_PASSWORD: ursus
+  
+  sinai:
+    build:
+      context: .
+      dockerfile: Dockerfile.ci
+    command: 'sh start-sinai.sh'
+    depends_on:
+      - db
+      - solr
+    env_file:
+      - ./default.env
+      - ./docker.env
+    environment:
+      DATABASE_NAME: sinai
+      SOLR_URL: http://solr:8983/solr/sinai
+      SOLR_TEST_URL: http://solr_test:8983/solr/sinai
+
+  db:
+    image: mysql:5.6
+    volumes:
+      - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+    ports:
+      - "127.0.0.1:3306:3306"
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+
+  solr:
+    image: uclalibrary/solr-ursus
+    ports:
+      - "127.0.0.1:8983:8983"
+
+  solr_test:
+    image: uclalibrary/solr-ursus
+    ports:
+      - "127.0.0.1:8985:8983"

--- a/start-ci.sh
+++ b/start-ci.sh
@@ -1,0 +1,7 @@
+set -e
+
+bundle exec rubocop
+bundle exec erblint --lint-all
+yarn run lint
+spring rails db:setup
+spring rspec


### PR DESCRIPTION
- use new docker-compose-ci.yml file in travis
-- doesn't publicly expose ports (everything done w/in docker)
-- doesn't mount docker volumes; everything just runs off container
- use new Dockerfile.ci in travis
-- extends uclalibrary/ursus image (based on original Dockerfile)
-- updates gems and node dependencies, copies in current code
- moves suite of CI tests to start-ci.sh script, instead of burying them in .travis.yml