### PR TITLE
Fix the constraints section on the results page

### DIFF
--- a/app/views/catalog/_browse_results.html.erb
+++ b/app/views/catalog/_browse_results.html.erb
@@ -1,6 +1,5 @@
- <%= render 'catalog/constraints' %>
-
 <div class='search-results-container col-md-12 col-lg-9'>
+ <%= render 'catalog/constraints' %>
   <% url = request.original_url %>
   <% if url.include?('has_model_ssim') && url.include?('Collection') %>
     <div class='search-count-wrapper'><h2 class='search-count__heading'><%= @response['response'].dig(:numFound) %> Collections</h2> <%= render_results_collection_tools wrapping_class: "search-widgets search-widgets-wrapper" %></div>


### PR DESCRIPTION
<img width="1164" alt="Screen Shot 2020-06-05 at 2 18 24 PM" src="https://user-images.githubusercontent.com/751697/83923631-7f5c0b80-a737-11ea-81a8-5cbb89acbe76.png">

---

+ modified: `app/views/catalog/_browse_results.html.erb`