### PR TITLE
remove .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-default.env


### PR DESCRIPTION
.env was included as a symlink for default dev environments, but is getting picked up in prod.