### PR TITLE
APPS-456 Fix - Firefox cannot log into Sinai Manuscripts on Stage

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
   end
 
   def sinai_authn_check
-    ###return true if ENV['SINAI_ID_BYPASS'] # skip auth in development
+    return true if ENV['SINAI_ID_BYPASS'] # skip auth in development
     return true if !Flipflop.sinai? || [login_path, version_path].include?(request.path) || sinai_authenticated?
     if ucla_token?
       set_auth_cookies

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
   end
 
   def sinai_authn_check
-    return true if ENV['SINAI_ID_BYPASS'] # skip auth in development
+    ###return true if ENV['SINAI_ID_BYPASS'] # skip auth in development
     return true if !Flipflop.sinai? || [login_path, version_path].include?(request.path) || sinai_authenticated?
     if ucla_token?
       set_auth_cookies

--- a/app/views/login/new.html.erb
+++ b/app/views/login/new.html.erb
@@ -10,7 +10,7 @@
     <p class='si-auth-page__sub-title'>A Publication of St. Catherine's Monastery of the Sinai, Egypt</p>
 
     <% requested_path_url = #{@requested_path} %>
-    <%= button_to 'Access the Sinai Collection', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: requested_path_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--white si-auth-page__btn wiggle' %>
+    <%= button_to 'Access the Sinai Collection', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: @requested_path.to_s, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--white si-auth-page__btn wiggle' %>
   </div>
 
   <div class="si-auth-page__lede">


### PR DESCRIPTION
Connected to [APPS-456](https://jira.library.ucla.edu/browse/APPS-456)

Sinai login fix for linter and turned off bypass for testing on dev/s

Updated setting of the `callback_url` to avoid changes by the linter.

**Acceptance criteria**

- [x] The login proceeds normally on https://sinaimanuscripts-stage.library.ucla.edu/
- [x] Linted
- [x] Tested

---

**Files modified**

`app/controllers/application_controller.rb`
`app/views/login/new.html.erb`