### PR TITLE
URS870-Fix missing UCLA footer logo

### DIFF
--- a/app/assets/stylesheets/theme_ursus/footer/_ur-primary-footer.scss
+++ b/app/assets/stylesheets/theme_ursus/footer/_ur-primary-footer.scss
@@ -20,10 +20,11 @@
 .site-footer__block--ursus {
   &:nth-child(1) {
     align-self: center;
+    width: 12.5rem;
   }
 
   &:nth-child(2) {
-    @media (max-width: 767px) {
+    @media (max-width: 850px) {
       margin-top: 1.5rem;
     }
   }


### PR DESCRIPTION
Display UCLA logo in Ursus's footer in Firefox wide resolution

modified:   app/assets/stylesheets/theme_ursus/footer/_ur-primary-footer.scss

<img width="375" alt="Screen Shot 2020-06-19 at 12 53 40 PM" src="https://user-images.githubusercontent.com/24995224/85175479-5f931000-b22c-11ea-8d5f-cc0c56fb10b8.png">


