### PR TITLE
Don't check member_ids when forward canvas index

### DIFF
--- a/app/services/iiif_service.rb
+++ b/app/services/iiif_service.rb
@@ -5,7 +5,7 @@ class IiifService
     if Flipflop.sinai?
       "#{request&.base_url}/mirador.html#?manifest=#{CGI.escape(iiif_manifest_url(document))}"
     else
-      if request.query_parameters.include?('cv') && document[:member_ids_ssim].size >= request.query_parameters['cv'].to_i
+      if request.query_parameters.include?('cv')
         "#{request&.base_url}/uv/uv.html#?cv=#{request.query_parameters['cv']}&manifest=#{CGI.escape(iiif_manifest_url(document))}"
       else
         "#{request&.base_url}/uv/uv.html#?manifest=#{CGI.escape(iiif_manifest_url(document))}"

--- a/spec/services/iiif_service_spec.rb
+++ b/spec/services/iiif_service_spec.rb
@@ -76,12 +76,6 @@ RSpec.describe IiifService do
 
         expect(service.src(request, solr_document_with_cv)).to eq 'http://test.url/uv/uv.html#?cv=7&manifest=https%3A%2F%2Fmanifest.store%2Fark%253A%252Fabc%252F123%2Fmanifest'
       end
-
-      it 'returns page 1 if someone requests a page higher than the total page count' do
-        allow(request).to receive(:query_parameters).and_return('cv' => 9)
-
-        expect(service.src(request, solr_document_with_cv)).to eq 'http://test.url/uv/uv.html#?manifest=https%3A%2F%2Fmanifest.store%2Fark%253A%252Fabc%252F123%2Fmanifest'
-      end
     end
   end
 end


### PR DESCRIPTION
When forwarding a canvas ID from an item show page URL parameter to Universal Viewer, #698 checked to make sure that number was less than the total number of children in solr / hyrax.

We are currently importing many Manuscripts into californica without their ChildWork / page objects, since what matters is that they are in the manifest and we can import them to hyrax later. Thus, the check will not be accurate and in fact will result in a rails error when member_ids_ssim is nil.

Unfortunately, this will cause Universal Viewer to render a blank page if the `cv` parameter is invalid.