### PR TITLE
APPS-465 Final Fixes

### DIFF
--- a/app/assets/stylesheets/theme_sinai/components/_si-facets.scss
+++ b/app/assets/stylesheets/theme_sinai/components/_si-facets.scss
@@ -5,7 +5,9 @@
 }
 
 .facets__navbar-heading--sinai {
-  color: $white;
+  @media (max-width: 991px) {
+    color: $white;
+  }
 }
 
 @media (max-width: 991px) {
@@ -32,10 +34,16 @@
   }
 
   &.collapse-toggle[aria-expanded='true'] {
-    color: $white;
     background-color: $sinai-red;
     border: 1px solid $sinai-red;
     border-radius: 0;
+
+    a,
+    a:active,
+    a:visited,
+    a:hover {
+      color: $white;
+    }
   }
 }
 
@@ -48,7 +56,6 @@
     color: $white;
   }
 }
-
 
 .facet-limit-active {
   .facet-field__heading--sinai {
@@ -88,6 +95,6 @@
   a,
   a:active,
   a:visited {
-    color: $ucla-darker-blue;
+    color: $sinai-red;
   }
 }

--- a/app/views/catalog/collection_record/_collection_record.html.erb
+++ b/app/views/catalog/collection_record/_collection_record.html.erb
@@ -10,7 +10,7 @@
   <%= render 'catalog/collection_record/physical_description_metadata', document: document %>
   <%= render 'catalog/collection_record/keyword_metadata', document: document %>
 
-  <div class='collection-page__btn-row>
+  <div class='collection-page__btn-row'>
   <a href="/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=<%= document[:title_tesim][0] %>" class="btn-base btn-base-lg btn-ursus--gold" role="button">Browse items in this collection</a>
   </div>
 </div>


### PR DESCRIPTION
Connected to: [APP-465](https://jira.library.ucla.edu/browse/APPS-465)

### Sinai

- [x] FIXED: Facets: facet label disappears when facet is expanded (text is red, then facet label background becomes red on expand) - screenshot attached
- [x] FIXED: "Browse Items" facets heading is missing

### Ursus

- [x] FIXED: Footer does not span main content div on collection page (see screenshot)

---

Changes to be committed:
modified:   app/assets/stylesheets/theme_sinai/components/_si-facets.scss
modified:   app/views/catalog/collection_record/_collection_record.html.erb