### PR TITLE
URS-814 & URS-861 Ursus footer & Privacy page updates

### DIFF
--- a/app/views/shared/footer/_ursus_footer.html.erb
+++ b/app/views/shared/footer/_ursus_footer.html.erb
@@ -23,7 +23,7 @@
 
   <div class='container-full site-footer__secondary site-footer__secondary--ursus'>
     <div class='site-footer__secondary-text'>
-      &#169; 2020 UC Regents. All rights reserved.
+      &#169; 2019-<%= Time.zone.now.year %> UC Regents. All rights reserved.
     </div>
   </div>
 </footer>

--- a/app/views/static/ursus_privacy.html.erb
+++ b/app/views/static/ursus_privacy.html.erb
@@ -12,7 +12,7 @@
     <br><br>
       Your privacy while using the UCLA Library and its website is an important element of your intellectual and academic freedom. In the course of providing services and circulating library materials, the Library acquires information about you such as your name, university ID, and the services and materials you use. When it is necessary to identify users, it is the Library's goal to gather only the minimum information necessary and to retain that information only as long as is needed to complete the transaction. The Library is supported in this goal by national and state laws as well as through UC and campus policies.
     <br><br>
-      In addition, the UCLA Library routinely collect information to help improve functionality and navigation and to monitor performance. Examples of such information collected by the UCLA Library we site include:
+      In addition, the UCLA Library routinely collects information to help improve functionality and navigation and to monitor performance. Examples of such information collected by the UCLA Library we site include:
 
       <ul class='static-page__list static-page__list--ursus'>
         <li>your Internet location (IP address)</li>


### PR DESCRIPTION
Connected to [URS-814](https://jira.library.ucla.edu/browse/URS-814) & [URS-861](https://jira.library.ucla.edu/browse/URS-861)

+ Revise-copyright-footer
    + The current year is now dynamic
    + © 2019-2020 UC Regents. All rights reserved.
![Screen Shot 2020-07-01 at 3 02 07 PM](https://user-images.githubusercontent.com/751697/86295616-dc6aa600-bbab-11ea-9bae-20feee41ed99.png)
+ Fix typo in the copy on the Ursus Privacy page

---

Changes to be committed:
+ modified:   app/views/shared/footer/_ursus_footer.html.erb
+ modified:   app/views/static/ursus_privacy.html.erb