### PR TITLE
URS-885 Add metadata to the thumbnails embedded for Google Images

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -238,8 +238,7 @@ module Blacklight::BlacklightHelperBehavior
 
   ##
   # Render the document's title in the embedded thumbnail alt tag
-    def render_document_alttag(*args)
-    options = args.extract_options!
+  def render_document_alttag(*args)
     document = args.first
     document ||= @document
     presenter(document).heading

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -237,6 +237,15 @@ module Blacklight::BlacklightHelperBehavior
   end
 
   ##
+  # Render the document's title in the embedded thumbnail alt tag
+    def render_document_alttag(*args)
+    options = args.extract_options!
+    document = args.first
+    document ||= @document
+    presenter(document).heading
+  end
+
+  ##
   # Get the current "view type" (and ensure it is a valid type)
   #
   # @param [Hash] query_params the query parameters to check

--- a/app/views/catalog/work_record/_primary_metadata.html.erb
+++ b/app/views/catalog/work_record/_primary_metadata.html.erb
@@ -1,7 +1,7 @@
 <div class='item-page__primary-metadata'>
   <div hidden>
-    <% document_json = JSON.parse @document.to_json.tr("'", '_') %>
-    <% tn = "<img src=\"" + document_json['thumbnail_url_ss'] + "\" alt=\"This image for search engines to index.\" \>" unless document_json['thumbnail_url_ss'].blank? %>
+  <% document_json = JSON.parse @document.to_json.tr("'", '_') %>
+  <% tn = "<img src=\"" + document_json['thumbnail_url_ss'] + "\" alt=\"" + render_document_alttag(document) + "\" \>" unless document_json['thumbnail_url_ss'].blank? %>
     <%= tn.html_safe unless document_json['thumbnail_url_ss'].blank? %>
     </div>
   <%= render 'catalog/work_record/item_overview_metadata', document: document %>


### PR DESCRIPTION
Connected to: [URS-885](https://jira.library.ucla.edu/browse/URS-885)

### Add metadata to the thumbnails embedded for Google Images

Acceptance criteria:

- [x] Added the document's Heading to the alt tag of the embedded thumbnail
- [x] linted
- [x] tested