### PR TITLE
Fix CI suite in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - docker-compose run web bundle exec rails db:setup
   - docker-compose run sinai bundle exec rails db:setup
   - docker-compose up --detach
-  # - docker-compose run web sh start-ci.sh
+  - docker-compose run web sh start-ci.sh
   - docker-compose run e2e sh start-e2e.sh
 notifications:
   email: false


### PR DESCRIPTION
re-enables parts of the ci suite that were temporarily disabled for debugging but accidentally checked in to master.