### PR TITLE
Use new solr image in standalone and ci docker

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -62,7 +62,7 @@ services:
       TRAVIS_PULL_REQUEST: $TRAVIS_PULL_REQUEST
 
   solr:
-    image: uclalibrary/solr-ursus
+    image: uclalibrary/solr-ursus:2020-07-15
 
   solr_test:
-    image: uclalibrary/solr-ursus
+    image: uclalibrary/solr-ursus:2020-07-15

--- a/docker-compose-standalone.yml
+++ b/docker-compose-standalone.yml
@@ -61,12 +61,12 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
 
   solr:
-    image: uclalibrary/solr-ursus
+    image: uclalibrary/solr-ursus:2020-07-15
     ports:
       - "127.0.0.1:8983:8983"
 
   solr_test:
-    image: uclalibrary/solr-ursus
+    image: uclalibrary/solr-ursus:2020-07-15
     ports:
       - "127.0.0.1:8985:8983"
 


### PR DESCRIPTION
(cloned from -stage servers 7/15/2020)