### PR TITLE
Update standalone solr image

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -62,7 +62,7 @@ services:
       TRAVIS_PULL_REQUEST: $TRAVIS_PULL_REQUEST
 
   solr:
-    image: uclalibrary/solr-ursus:2020-07-15
+    image: uclalibrary/solr-ursus:2020-07-22
 
   solr_test:
-    image: uclalibrary/solr-ursus:2020-07-15
+    image: uclalibrary/solr-ursus:2020-07-22

--- a/docker-compose-standalone.yml
+++ b/docker-compose-standalone.yml
@@ -61,12 +61,12 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
 
   solr:
-    image: uclalibrary/solr-ursus:2020-07-15
+    image: uclalibrary/solr-ursus:2020-07-22
     ports:
       - "127.0.0.1:8983:8983"
 
   solr_test:
-    image: uclalibrary/solr-ursus:2020-07-15
+    image: uclalibrary/solr-ursus:2020-07-22
     ports:
       - "127.0.0.1:8985:8983"
 


### PR DESCRIPTION
The old image did not include all facet fields, so only "Collection" and "Year" displayed. This updates the image to one where that issue has been fixed (cf. https://github.com/UCLALibrary/docker-solr-ursus/commit/febf98c5383073d913188c01856d1b77685d2104)