### PR TITLE
Urs 893 implement cyress tests for collection pages

### DIFF
--- a/e2e/cypress/integration/collections.js
+++ b/e2e/cypress/integration/collections.js
@@ -1,136 +1,32 @@
-describe('Ursus Homepage', () => {
-  it('Visits the Homepage, clicks on the Subject facet, clicks on more, clicks on A-Z Sort, clicks on next, clicks Academy Awards (Motion pictures) and verifies the page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
-    cy.contains('a', 'Subject').click({ force: true });
-    cy.contains('a', 'more').click({ force: true });
-    cy.contains('a', 'A-Z Sort').click({ force: true });
-    cy.contains('a', 'Next').click({ force: true });
-    cy.get(
-      '.modal-footer > .facet-pagination > .modal-pagination > :nth-child(2) > .modal-pagination__page-link'
-    ).click({ force: true });
-    cy.get('a[href*="Academy"]').click({ force: true });
-    cy.get('.filter-label-key').contains('Subject');
-    cy.get('.filter-label-value').contains('Academy Awards (Motion pictures)');
-  });
-  it('Visits the Homepage, opens on the Resource Type facet, clicks on Cartographic, opens on the Language facet, clicks on English and verifies page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
-    cy.contains('a', 'Resource Type').click();
-    cy.contains('a', 'cartographic').click({ force: true });
-    cy.get('[title="cartographic"]');
-    cy.contains('a', 'Language').click();
-    cy.contains('a', 'English').click({ force: true });
-    cy.get('[title="English"]');
-    cy.get(
-      '.filter-human_readable_language_sim > .filter-group__label > .filter-label-key'
-    ).contains('Language');
-    cy.get(
-      '.filter-human_readable_language_sim > .filter-group__label > .filter-label-value'
-    ).contains('English');
-    cy.get(
-      '.filter-human_readable_resource_type_sim > .filter-group__label > .filter-label-key'
-    ).contains('Resource Type');
-    cy.get(
-      '.filter-human_readable_resource_type_sim > .filter-group__label > .filter-label-value'
-    ).contains('cartographic');
-    cy.percySnapshot();
-  });
-  it('Visits the Homepage, opens on the Genre facet, clicks on black-and-white photographs, opens on the Language facet, clicks on English and verifies page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
-    cy.contains('a', 'Genre').click();
-    cy.contains('a', 'black-and-white photographs').click({ force: true });
-    cy.get('[title="black-and-white photographs"]');
-    cy.contains('a', 'Language').click();
-    cy.contains('a', 'English').click({ force: true });
-    cy.get('[title="English"]');
-    cy.get(
-      '.filter-genre_sim > .filter-group__label > .filter-label-key'
-    ).contains('Genre');
-    cy.get(
-      '.filter-genre_sim > .filter-group__label > .filter-label-value'
-    ).contains('black-and-white photographs');
-    cy.get(
-      '.filter-human_readable_language_sim > .filter-group__label > .filter-label-key'
-    ).contains('Language');
-    cy.get(
-      '.filter-human_readable_language_sim > .filter-group__label > .filter-label-value'
-    ).contains('English');
-    cy.percySnapshot();
-  });
-  it('Visits the Homepage, opens on the Genre facet, clicks on any link, clicks on Start Over and verifies page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
-    cy.contains('a', 'Genre').click();
-    cy.contains('a', 'black-and-white photographs').click({ force: true });
-    cy.get('[title="black-and-white photographs"]');
-    cy.contains('a', 'Start Over').click({ force: true });
-    cy.get('title').contains('UCLA Library Digital Collections Search Results');
-    cy.percySnapshot();
-  });
-  it('Visits the Homepage, opens on the Locations facet, clicks on Los Angeles (Calif.), opens on the Namse facet, clicks on Tournament of Roses and verifies page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
-    cy.contains('a', 'Names').click();
-    cy.contains('a', 'Tournament of Roses').click({ force: true });
-    cy.get('[title="Tournament of Roses"]');
-    cy.contains('a', 'Location').click();
-    cy.contains('a', 'Los Angeles (Calif.)').click({ force: true });
-    cy.get('[title="Los Angeles (Calif.)"]');
-    cy.get(
-      '.filter-location_sim > .filter-group__label > .filter-label-key'
-    ).contains('Location');
-    cy.get(
-      '.filter-location_sim > .filter-group__label > .filter-label-value'
-    ).contains('Los Angeles (Calif.)');
-    cy.get(
-      '.filter-named_subject_sim > .filter-group__label > .filter-label-key'
-    ).contains('Names');
-    cy.get(
-      '.filter-named_subject_sim > .filter-group__label > .filter-label-value'
-    ).contains('Tournament of Roses');
-  });
-  it('Visits the Homepage, opens on the Dates facet, enters a Starting Date, enters an ending date and verifies page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
-    cy.contains('a', 'Date').click();
-    cy.get('#range_year_isim_begin').type(
-      '{end}{backspace}{backspace}{backspace}{backspace}1935'
-    );
-    cy.get('#range_year_isim_end').type(
-      '{end}{backspace}{backspace}{backspace}{backspace}1967'
-    );
-    cy.get('.submit').click();
-    cy.get('.filter-label-key').contains('Date');
-    cy.get('.filter-label-value').contains('1935 to 1967');
-    cy.percySnapshot();
-  });
-  it('Visits the Homepage, clicks on the Collection facet, clicks on more, clicks on next, clicks Ethiopic Manuscripts and verifies the page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
-    cy.contains('a', 'Collection').click({ force: true });
-    cy.get(
-      '#facet-member_of_collections_ssim > .facet-values > .more_facets > a'
-    ).click({ force: true });
-    cy.contains('a', 'Next').click({ force: true });
-    cy.get('a[href*="Ethiopic"]').click({ force: true });
-    cy.get('.filter-label-key').contains('Collection');
-    cy.get('.filter-label-value').contains('Ethiopic Manuscripts');
-  });
-  it('Visits the Homepage, clicks on the Genre facet, clicks on more, clicks on next, clicks Architectural drawings and verifies the page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
-    cy.contains('a', 'Genre').click({ force: true });
-    cy.get('#facet-genre_sim > .facet-values > .more_facets > a').click({
-      force: true,
-    });
-    cy.contains('a', 'A-Z Sort').click({ force: true });
-    cy.get('a[href*="Architectural+drawings"]').click({ force: true });
-    cy.get('.filter-label-key').contains('Genre');
-    cy.get('.filter-label-value').contains('Architectural drawings');
-  });
-  it('Visits the Homepage, clicks on the Subject facet, clicks Landmarks and verifies the page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
-    cy.contains('a', 'Subject').click({ force: true });
-    cy.get('#facet-subject_sim > .facet-values > .more_facets > a').click({
-      force: true,
-    });
-    ///cy.contains('a', 'A-Z Sort').click({ force: true });
-    cy.get('a[href*="Landmarks"]').click({ force: true });
-    cy.get('.filter-label-key').contains('Subject');
-    cy.get('.filter-label-value').contains('Landmarks');
-  });
+it('Visits the Homepage and clicks through to Los Angeles Daily News Negatives', () => {
+  cy.visit('https://digital.library.ucla.edu');
+  cy.contains('h3', 'Los Angeles Daily News Negatives').click();
+  cy.get('[class=banner__title--collection]').contains(
+    'Los Angeles Daily News Negatives'
+  );
+  cy.percySnapshot();
+});
+it('Visits the Homepage and clicks through to Walter E. Bennett Photographic Collection, 1937-1983', () => {
+  cy.visit('https://digital.library.ucla.edu');
+  cy.contains(
+    'h3',
+    'Walter E. Bennett Photographic Collection, 1937-1983'
+  ).click();
+  cy.get('[class=banner__title--collection]').contains(
+    'Bennett (Walter E.) Photographic Collection, 1937-1983 (bulk 1952-1982)'
+  );
+  cy.percySnapshot();
+});
+it('Visits the Homepage and clicks through to Will Connell Papers', () => {
+  cy.visit('https://digital.library.ucla.edu');
+  cy.contains('h3', 'Will Connell Papers').click();
+  cy.get('[class=banner__title--collection]').contains('Connell (Will) Papers');
+  cy.percySnapshot();
+});
+it('Visits the Homepage and clicks the More about this collection link of a collection', () => {
+  cy.visit('https://digital.library.ucla.edu');
+  cy.get(
+    '[href="/catalog/37sh8000zz-89112"] > .collection-grid__item-content > .collection-grid__item-link'
+  ).click();
+  cy.percySnapshot();
 });

--- a/e2e/cypress/integration/collections.js
+++ b/e2e/cypress/integration/collections.js
@@ -1,0 +1,136 @@
+describe('Ursus Homepage', () => {
+  it('Visits the Homepage, clicks on the Subject facet, clicks on more, clicks on A-Z Sort, clicks on next, clicks Academy Awards (Motion pictures) and verifies the page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Subject').click({ force: true });
+    cy.contains('a', 'more').click({ force: true });
+    cy.contains('a', 'A-Z Sort').click({ force: true });
+    cy.contains('a', 'Next').click({ force: true });
+    cy.get(
+      '.modal-footer > .facet-pagination > .modal-pagination > :nth-child(2) > .modal-pagination__page-link'
+    ).click({ force: true });
+    cy.get('a[href*="Academy"]').click({ force: true });
+    cy.get('.filter-label-key').contains('Subject');
+    cy.get('.filter-label-value').contains('Academy Awards (Motion pictures)');
+  });
+  it('Visits the Homepage, opens on the Resource Type facet, clicks on Cartographic, opens on the Language facet, clicks on English and verifies page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Resource Type').click();
+    cy.contains('a', 'cartographic').click({ force: true });
+    cy.get('[title="cartographic"]');
+    cy.contains('a', 'Language').click();
+    cy.contains('a', 'English').click({ force: true });
+    cy.get('[title="English"]');
+    cy.get(
+      '.filter-human_readable_language_sim > .filter-group__label > .filter-label-key'
+    ).contains('Language');
+    cy.get(
+      '.filter-human_readable_language_sim > .filter-group__label > .filter-label-value'
+    ).contains('English');
+    cy.get(
+      '.filter-human_readable_resource_type_sim > .filter-group__label > .filter-label-key'
+    ).contains('Resource Type');
+    cy.get(
+      '.filter-human_readable_resource_type_sim > .filter-group__label > .filter-label-value'
+    ).contains('cartographic');
+    cy.percySnapshot();
+  });
+  it('Visits the Homepage, opens on the Genre facet, clicks on black-and-white photographs, opens on the Language facet, clicks on English and verifies page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Genre').click();
+    cy.contains('a', 'black-and-white photographs').click({ force: true });
+    cy.get('[title="black-and-white photographs"]');
+    cy.contains('a', 'Language').click();
+    cy.contains('a', 'English').click({ force: true });
+    cy.get('[title="English"]');
+    cy.get(
+      '.filter-genre_sim > .filter-group__label > .filter-label-key'
+    ).contains('Genre');
+    cy.get(
+      '.filter-genre_sim > .filter-group__label > .filter-label-value'
+    ).contains('black-and-white photographs');
+    cy.get(
+      '.filter-human_readable_language_sim > .filter-group__label > .filter-label-key'
+    ).contains('Language');
+    cy.get(
+      '.filter-human_readable_language_sim > .filter-group__label > .filter-label-value'
+    ).contains('English');
+    cy.percySnapshot();
+  });
+  it('Visits the Homepage, opens on the Genre facet, clicks on any link, clicks on Start Over and verifies page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Genre').click();
+    cy.contains('a', 'black-and-white photographs').click({ force: true });
+    cy.get('[title="black-and-white photographs"]');
+    cy.contains('a', 'Start Over').click({ force: true });
+    cy.get('title').contains('UCLA Library Digital Collections Search Results');
+    cy.percySnapshot();
+  });
+  it('Visits the Homepage, opens on the Locations facet, clicks on Los Angeles (Calif.), opens on the Namse facet, clicks on Tournament of Roses and verifies page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Names').click();
+    cy.contains('a', 'Tournament of Roses').click({ force: true });
+    cy.get('[title="Tournament of Roses"]');
+    cy.contains('a', 'Location').click();
+    cy.contains('a', 'Los Angeles (Calif.)').click({ force: true });
+    cy.get('[title="Los Angeles (Calif.)"]');
+    cy.get(
+      '.filter-location_sim > .filter-group__label > .filter-label-key'
+    ).contains('Location');
+    cy.get(
+      '.filter-location_sim > .filter-group__label > .filter-label-value'
+    ).contains('Los Angeles (Calif.)');
+    cy.get(
+      '.filter-named_subject_sim > .filter-group__label > .filter-label-key'
+    ).contains('Names');
+    cy.get(
+      '.filter-named_subject_sim > .filter-group__label > .filter-label-value'
+    ).contains('Tournament of Roses');
+  });
+  it('Visits the Homepage, opens on the Dates facet, enters a Starting Date, enters an ending date and verifies page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Date').click();
+    cy.get('#range_year_isim_begin').type(
+      '{end}{backspace}{backspace}{backspace}{backspace}1935'
+    );
+    cy.get('#range_year_isim_end').type(
+      '{end}{backspace}{backspace}{backspace}{backspace}1967'
+    );
+    cy.get('.submit').click();
+    cy.get('.filter-label-key').contains('Date');
+    cy.get('.filter-label-value').contains('1935 to 1967');
+    cy.percySnapshot();
+  });
+  it('Visits the Homepage, clicks on the Collection facet, clicks on more, clicks on next, clicks Ethiopic Manuscripts and verifies the page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Collection').click({ force: true });
+    cy.get(
+      '#facet-member_of_collections_ssim > .facet-values > .more_facets > a'
+    ).click({ force: true });
+    cy.contains('a', 'Next').click({ force: true });
+    cy.get('a[href*="Ethiopic"]').click({ force: true });
+    cy.get('.filter-label-key').contains('Collection');
+    cy.get('.filter-label-value').contains('Ethiopic Manuscripts');
+  });
+  it('Visits the Homepage, clicks on the Genre facet, clicks on more, clicks on next, clicks Architectural drawings and verifies the page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Genre').click({ force: true });
+    cy.get('#facet-genre_sim > .facet-values > .more_facets > a').click({
+      force: true,
+    });
+    cy.contains('a', 'A-Z Sort').click({ force: true });
+    cy.get('a[href*="Architectural+drawings"]').click({ force: true });
+    cy.get('.filter-label-key').contains('Genre');
+    cy.get('.filter-label-value').contains('Architectural drawings');
+  });
+  it('Visits the Homepage, clicks on the Subject facet, clicks Landmarks and verifies the page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Subject').click({ force: true });
+    cy.get('#facet-subject_sim > .facet-values > .more_facets > a').click({
+      force: true,
+    });
+    ///cy.contains('a', 'A-Z Sort').click({ force: true });
+    cy.get('a[href*="Landmarks"]').click({ force: true });
+    cy.get('.filter-label-key').contains('Subject');
+    cy.get('.filter-label-value').contains('Landmarks');
+  });
+});

--- a/e2e/cypress/integration/collections.js
+++ b/e2e/cypress/integration/collections.js
@@ -1,32 +1,38 @@
-it('Visits the Homepage and clicks through to Los Angeles Daily News Negatives', () => {
-  cy.visit('https://digital.library.ucla.edu');
-  cy.contains('h3', 'Los Angeles Daily News Negatives').click();
-  cy.get('[class=banner__title--collection]').contains(
-    'Los Angeles Daily News Negatives'
-  );
-  cy.percySnapshot();
-});
-it('Visits the Homepage and clicks through to Walter E. Bennett Photographic Collection, 1937-1983', () => {
-  cy.visit('https://digital.library.ucla.edu');
-  cy.contains(
-    'h3',
-    'Walter E. Bennett Photographic Collection, 1937-1983'
-  ).click();
-  cy.get('[class=banner__title--collection]').contains(
-    'Bennett (Walter E.) Photographic Collection, 1937-1983 (bulk 1952-1982)'
-  );
-  cy.percySnapshot();
-});
-it('Visits the Homepage and clicks through to Will Connell Papers', () => {
-  cy.visit('https://digital.library.ucla.edu');
-  cy.contains('h3', 'Will Connell Papers').click();
-  cy.get('[class=banner__title--collection]').contains('Connell (Will) Papers');
-  cy.percySnapshot();
-});
-it('Visits the Homepage and clicks the More about this collection link of a collection', () => {
-  cy.visit('https://digital.library.ucla.edu');
-  cy.get(
-    '[href="/catalog/37sh8000zz-89112"] > .collection-grid__item-content > .collection-grid__item-link'
-  ).click();
-  cy.percySnapshot();
+describe('Collection pages', () => {
+  it('Los Angeles Daily News Negatives', () => {
+    cy.visit('/');
+    cy.contains('h3', 'Los Angeles Daily News Negatives').click();
+    cy.get('[class=banner__title--collection]').contains(
+      'Los Angeles Daily News Negatives'
+    );
+    cy.percySnapshot();
+  });
+
+  it('Walter E. Bennett Photographic Collection, 1937-1983', () => {
+    cy.visit('/');
+    cy.contains(
+      'h3',
+      'Walter E. Bennett Photographic Collection, 1937-1983'
+    ).click();
+    cy.get('[class=banner__title--collection]').contains(
+      'Bennett (Walter E.) Photographic Collection, 1937-1983 (bulk 1952-1982)'
+    );
+    cy.percySnapshot();
+  });
+
+  it('Will Connell Papers', () => {
+    cy.visit('/');
+    cy.contains('h3', 'Will Connell Papers').click();
+    cy.get('[class=banner__title--collection]').contains('Connell (Will) Papers');
+    cy.percySnapshot();
+  });
+
+  it('California Postcards - Collection Record', () => {
+    cy.visit('/');
+    cy.get(
+      '[href="/catalog/37sh8000zz-89112"] > .collection-grid__item-content > .collection-grid__item-link'
+    ).click();
+    cy.contains('.metadata-block__title', 'Collection Overview')
+    cy.percySnapshot();
+  });
 });


### PR DESCRIPTION
Connected to [URS-893](https://jira.library.ucla.edu/browse/URS-893)

**implement cyress tests for collection pages**
    Automate the testing for Collection pages that is now done manually.

Acceptance criteria:
    
[x] each of the following is automated via our cypress suite:

-   [Los Angeles Daily News Negatives](https://digital.library.ucla.edu/catalog/8zn49200zz-89112)
-   [Bennett (Walter E.) Photographic Collection, 1937-1983 (bulk 1952-1982)](https://digital.library.ucla.edu/catalog/m8f11000zz-89112)
-   [Connell (Will) Papers](https://digital.library.ucla.edu/catalog/tpf2h200zz-89112)
-   [More about this collection](https://digital.library.ucla.edu/catalog/37sh8000zz-89112)

[x] a percy.io screenshot is taken and submitted at each page
[x] tested
[x] linted

**Files**
 e2e/cypress/integration/collections.js

