### PR TITLE
Urs 894 implement cyress tests for facets

### DIFF
--- a/e2e/cypress/integration/facets.js
+++ b/e2e/cypress/integration/facets.js
@@ -1,20 +1,25 @@
-describe('Ursus Homepage', () => {
-  it('Visits the Homepage, clicks on the Subject facet, clicks on more, clicks on A-Z Sort, clicks on next, clicks Academy Awards (Motion pictures) and verifies the page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
+describe('Facets', () => {
+  it('Subject', () => {
+    cy.visit('/');
     cy.contains('a', 'Subject').click({ force: true });
+    cy.percySnapshot('Subject facet open');
+
     cy.contains('a', 'more').click({ force: true });
+    cy.contains('Landmarks');
+
     cy.contains('a', 'A-Z Sort').click({ force: true });
+    cy.contains('Abbots--Japan');
     cy.contains('a', 'Next').click({ force: true });
-    cy.get(
-      '.modal-footer > .facet-pagination > .modal-pagination > :nth-child(2) > .modal-pagination__page-link'
-    ).click({ force: true });
-    cy.get('a[href*="Academy"]').click({ force: true });
+    cy.percySnapshot('Subject facet modal');
+    cy.contains('Academy Awards (Motion pictures)').click({ force: true });
+
     cy.get('.filter-label-key').contains('Subject');
     cy.get('.filter-label-value').contains('Academy Awards (Motion pictures)');
-    cy.percySnapshot();
+    cy.percySnapshot('Subject facet selected');
   });
-  it('Visits the Homepage, opens on the Resource Type facet, clicks on Cartographic, opens on the Language facet, clicks on English and verifies page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
+
+  it('Resource Type + Language', () => {
+    cy.visit('/');
     cy.contains('a', 'Resource Type').click();
     cy.contains('a', 'cartographic').click({ force: true });
     cy.get('[title="cartographic"]');
@@ -35,11 +40,12 @@ describe('Ursus Homepage', () => {
     ).contains('cartographic');
     cy.percySnapshot();
   });
-  it('Visits the Homepage, opens on the Genre facet, clicks on black-and-white photographs, opens on the Language facet, clicks on English and verifies page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
+
+  it('Genre + Language', () => {
+    cy.visit('/');
     cy.contains('a', 'Genre').click();
-    cy.contains('a', 'black-and-white photographs').click({ force: true });
-    cy.get('[title="black-and-white photographs"]');
+    cy.contains('a', 'Black-and-white photographs').click({ force: true });
+    cy.get('[title="Black-and-white photographs"]');
     cy.contains('a', 'Language').click();
     cy.contains('a', 'English').click({ force: true });
     cy.get('[title="English"]');
@@ -48,26 +54,24 @@ describe('Ursus Homepage', () => {
     ).contains('Genre');
     cy.get(
       '.filter-genre_sim > .filter-group__label > .filter-label-value'
-    ).contains('black-and-white photographs');
+    ).contains('Black-and-white photographs');
     cy.get(
       '.filter-human_readable_language_sim > .filter-group__label > .filter-label-key'
     ).contains('Language');
     cy.get(
       '.filter-human_readable_language_sim > .filter-group__label > .filter-label-value'
     ).contains('English');
-    cy.percySnapshot();
   });
-  it('Visits the Homepage, opens on the Genre facet, clicks on any link, clicks on Start Over and verifies page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
-    cy.contains('a', 'Genre').click();
-    cy.contains('a', 'black-and-white photographs').click({ force: true });
-    cy.get('[title="black-and-white photographs"]');
+
+  it('Start Over', () => {
+    cy.visit('/catalog?f[genre_sim][]=Black-and-white+photographs');
+    cy.get('[title="Black-and-white photographs"]');
     cy.contains('a', 'Start Over').click({ force: true });
-    cy.get('title').contains('UCLA Library Digital Collections Search Results');
-    cy.percySnapshot();
+    cy.get('.search-results-container').should('not.contain', 'You searched for');
   });
-  it('Visits the Homepage, opens on the Locations facet, clicks on Los Angeles (Calif.), opens on the Namse facet, clicks on Tournament of Roses and verifies page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
+
+  it('Names', () => {
+    cy.visit('/');
     cy.contains('a', 'Names').click();
     cy.contains('a', 'Tournament of Roses').click({ force: true });
     cy.get('[title="Tournament of Roses"]');
@@ -88,22 +92,20 @@ describe('Ursus Homepage', () => {
     ).contains('Tournament of Roses');
     cy.percySnapshot();
   });
-  it('Visits the Homepage, opens on the Dates facet, enters a Starting Date, enters an ending date and verifies page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
+
+  it('Dates', () => {
+    cy.visit('/');
     cy.contains('a', 'Date').click();
-    cy.get('#range_year_isim_begin').type(
-      '{end}{backspace}{backspace}{backspace}{backspace}1935'
-    );
-    cy.get('#range_year_isim_end').type(
-      '{end}{backspace}{backspace}{backspace}{backspace}1967'
-    );
+    cy.get('#range_year_isim_begin').clear().type('1935');
+    cy.get('#range_year_isim_end').clear().type('1967');
     cy.get('.submit').click();
     cy.get('.filter-label-key').contains('Date');
     cy.get('.filter-label-value').contains('1935 to 1967');
     cy.percySnapshot();
   });
-  it('Visits the Homepage, clicks on the Collection facet, clicks on more, clicks on next, clicks Ethiopic Manuscripts and verifies the page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
+
+  it('Collection', () => {
+    cy.visit('/');
     cy.contains('a', 'Collection').click({ force: true });
     cy.get(
       '#facet-member_of_collections_ssim > .facet-values > .more_facets > a'
@@ -114,8 +116,9 @@ describe('Ursus Homepage', () => {
     cy.get('.filter-label-value').contains('Ethiopic Manuscripts');
     cy.percySnapshot();
   });
-  it('Visits the Homepage, clicks on the Genre facet, clicks on more, clicks on next, clicks Architectural drawings and verifies the page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
+
+  it('Genre', () => {
+    cy.visit('/');
     cy.contains('a', 'Genre').click({ force: true });
     cy.get('#facet-genre_sim > .facet-values > .more_facets > a').click({
       force: true,
@@ -124,18 +127,6 @@ describe('Ursus Homepage', () => {
     cy.get('a[href*="Architectural+drawings"]').click({ force: true });
     cy.get('.filter-label-key').contains('Genre');
     cy.get('.filter-label-value').contains('Architectural drawings');
-    cy.percySnapshot();
-  });
-  it('Visits the Homepage, clicks on the Subject facet, clicks Landmarks and verifies the page load', () => {
-    cy.visit('https://digital.library.ucla.edu');
-    cy.contains('a', 'Subject').click({ force: true });
-    cy.get('#facet-subject_sim > .facet-values > .more_facets > a').click({
-      force: true,
-    });
-    ///cy.contains('a', 'A-Z Sort').click({ force: true });
-    cy.get('a[href*="Landmarks"]').click({ force: true });
-    cy.get('.filter-label-key').contains('Subject');
-    cy.get('.filter-label-value').contains('Landmarks');
     cy.percySnapshot();
   });
 });

--- a/e2e/cypress/integration/facets.js
+++ b/e2e/cypress/integration/facets.js
@@ -11,6 +11,7 @@ describe('Ursus Homepage', () => {
     cy.get('a[href*="Academy"]').click({ force: true });
     cy.get('.filter-label-key').contains('Subject');
     cy.get('.filter-label-value').contains('Academy Awards (Motion pictures)');
+    cy.percySnapshot();
   });
   it('Visits the Homepage, opens on the Resource Type facet, clicks on Cartographic, opens on the Language facet, clicks on English and verifies page load', () => {
     cy.visit('https://digital.library.ucla.edu');
@@ -85,6 +86,7 @@ describe('Ursus Homepage', () => {
     cy.get(
       '.filter-named_subject_sim > .filter-group__label > .filter-label-value'
     ).contains('Tournament of Roses');
+    cy.percySnapshot();
   });
   it('Visits the Homepage, opens on the Dates facet, enters a Starting Date, enters an ending date and verifies page load', () => {
     cy.visit('https://digital.library.ucla.edu');
@@ -110,6 +112,7 @@ describe('Ursus Homepage', () => {
     cy.get('a[href*="Ethiopic"]').click({ force: true });
     cy.get('.filter-label-key').contains('Collection');
     cy.get('.filter-label-value').contains('Ethiopic Manuscripts');
+    cy.percySnapshot();
   });
   it('Visits the Homepage, clicks on the Genre facet, clicks on more, clicks on next, clicks Architectural drawings and verifies the page load', () => {
     cy.visit('https://digital.library.ucla.edu');
@@ -121,6 +124,7 @@ describe('Ursus Homepage', () => {
     cy.get('a[href*="Architectural+drawings"]').click({ force: true });
     cy.get('.filter-label-key').contains('Genre');
     cy.get('.filter-label-value').contains('Architectural drawings');
+    cy.percySnapshot();
   });
   it('Visits the Homepage, clicks on the Subject facet, clicks Landmarks and verifies the page load', () => {
     cy.visit('https://digital.library.ucla.edu');
@@ -132,5 +136,6 @@ describe('Ursus Homepage', () => {
     cy.get('a[href*="Landmarks"]').click({ force: true });
     cy.get('.filter-label-key').contains('Subject');
     cy.get('.filter-label-value').contains('Landmarks');
+    cy.percySnapshot();
   });
 });

--- a/e2e/cypress/integration/facets.js
+++ b/e2e/cypress/integration/facets.js
@@ -1,0 +1,136 @@
+describe('Ursus Homepage', () => {
+  it('Visits the Homepage, clicks on the Subject facet, clicks on more, clicks on A-Z Sort, clicks on next, clicks Academy Awards (Motion pictures) and verifies the page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Subject').click({ force: true });
+    cy.contains('a', 'more').click({ force: true });
+    cy.contains('a', 'A-Z Sort').click({ force: true });
+    cy.contains('a', 'Next').click({ force: true });
+    cy.get(
+      '.modal-footer > .facet-pagination > .modal-pagination > :nth-child(2) > .modal-pagination__page-link'
+    ).click({ force: true });
+    cy.get('a[href*="Academy"]').click({ force: true });
+    cy.get('.filter-label-key').contains('Subject');
+    cy.get('.filter-label-value').contains('Academy Awards (Motion pictures)');
+  });
+  it('Visits the Homepage, opens on the Resource Type facet, clicks on Cartographic, opens on the Language facet, clicks on English and verifies page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Resource Type').click();
+    cy.contains('a', 'cartographic').click({ force: true });
+    cy.get('[title="cartographic"]');
+    cy.contains('a', 'Language').click();
+    cy.contains('a', 'English').click({ force: true });
+    cy.get('[title="English"]');
+    cy.get(
+      '.filter-human_readable_language_sim > .filter-group__label > .filter-label-key'
+    ).contains('Language');
+    cy.get(
+      '.filter-human_readable_language_sim > .filter-group__label > .filter-label-value'
+    ).contains('English');
+    cy.get(
+      '.filter-human_readable_resource_type_sim > .filter-group__label > .filter-label-key'
+    ).contains('Resource Type');
+    cy.get(
+      '.filter-human_readable_resource_type_sim > .filter-group__label > .filter-label-value'
+    ).contains('cartographic');
+    cy.percySnapshot();
+  });
+  it('Visits the Homepage, opens on the Genre facet, clicks on black-and-white photographs, opens on the Language facet, clicks on English and verifies page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Genre').click();
+    cy.contains('a', 'black-and-white photographs').click({ force: true });
+    cy.get('[title="black-and-white photographs"]');
+    cy.contains('a', 'Language').click();
+    cy.contains('a', 'English').click({ force: true });
+    cy.get('[title="English"]');
+    cy.get(
+      '.filter-genre_sim > .filter-group__label > .filter-label-key'
+    ).contains('Genre');
+    cy.get(
+      '.filter-genre_sim > .filter-group__label > .filter-label-value'
+    ).contains('black-and-white photographs');
+    cy.get(
+      '.filter-human_readable_language_sim > .filter-group__label > .filter-label-key'
+    ).contains('Language');
+    cy.get(
+      '.filter-human_readable_language_sim > .filter-group__label > .filter-label-value'
+    ).contains('English');
+    cy.percySnapshot();
+  });
+  it('Visits the Homepage, opens on the Genre facet, clicks on any link, clicks on Start Over and verifies page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Genre').click();
+    cy.contains('a', 'black-and-white photographs').click({ force: true });
+    cy.get('[title="black-and-white photographs"]');
+    cy.contains('a', 'Start Over').click({ force: true });
+    cy.get('title').contains('UCLA Library Digital Collections Search Results');
+    cy.percySnapshot();
+  });
+  it('Visits the Homepage, opens on the Locations facet, clicks on Los Angeles (Calif.), opens on the Namse facet, clicks on Tournament of Roses and verifies page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Names').click();
+    cy.contains('a', 'Tournament of Roses').click({ force: true });
+    cy.get('[title="Tournament of Roses"]');
+    cy.contains('a', 'Location').click();
+    cy.contains('a', 'Los Angeles (Calif.)').click({ force: true });
+    cy.get('[title="Los Angeles (Calif.)"]');
+    cy.get(
+      '.filter-location_sim > .filter-group__label > .filter-label-key'
+    ).contains('Location');
+    cy.get(
+      '.filter-location_sim > .filter-group__label > .filter-label-value'
+    ).contains('Los Angeles (Calif.)');
+    cy.get(
+      '.filter-named_subject_sim > .filter-group__label > .filter-label-key'
+    ).contains('Names');
+    cy.get(
+      '.filter-named_subject_sim > .filter-group__label > .filter-label-value'
+    ).contains('Tournament of Roses');
+  });
+  it('Visits the Homepage, opens on the Dates facet, enters a Starting Date, enters an ending date and verifies page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Date').click();
+    cy.get('#range_year_isim_begin').type(
+      '{end}{backspace}{backspace}{backspace}{backspace}1935'
+    );
+    cy.get('#range_year_isim_end').type(
+      '{end}{backspace}{backspace}{backspace}{backspace}1967'
+    );
+    cy.get('.submit').click();
+    cy.get('.filter-label-key').contains('Date');
+    cy.get('.filter-label-value').contains('1935 to 1967');
+    cy.percySnapshot();
+  });
+  it('Visits the Homepage, clicks on the Collection facet, clicks on more, clicks on next, clicks Ethiopic Manuscripts and verifies the page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Collection').click({ force: true });
+    cy.get(
+      '#facet-member_of_collections_ssim > .facet-values > .more_facets > a'
+    ).click({ force: true });
+    cy.contains('a', 'Next').click({ force: true });
+    cy.get('a[href*="Ethiopic"]').click({ force: true });
+    cy.get('.filter-label-key').contains('Collection');
+    cy.get('.filter-label-value').contains('Ethiopic Manuscripts');
+  });
+  it('Visits the Homepage, clicks on the Genre facet, clicks on more, clicks on next, clicks Architectural drawings and verifies the page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Genre').click({ force: true });
+    cy.get('#facet-genre_sim > .facet-values > .more_facets > a').click({
+      force: true,
+    });
+    cy.contains('a', 'A-Z Sort').click({ force: true });
+    cy.get('a[href*="Architectural+drawings"]').click({ force: true });
+    cy.get('.filter-label-key').contains('Genre');
+    cy.get('.filter-label-value').contains('Architectural drawings');
+  });
+  it('Visits the Homepage, clicks on the Subject facet, clicks Landmarks and verifies the page load', () => {
+    cy.visit('https://digital.library.ucla.edu');
+    cy.contains('a', 'Subject').click({ force: true });
+    cy.get('#facet-subject_sim > .facet-values > .more_facets > a').click({
+      force: true,
+    });
+    ///cy.contains('a', 'A-Z Sort').click({ force: true });
+    cy.get('a[href*="Landmarks"]').click({ force: true });
+    cy.get('.filter-label-key').contains('Subject');
+    cy.get('.filter-label-value').contains('Landmarks');
+  });
+});


### PR DESCRIPTION
Connected to [URS-894](https://jira.library.ucla.edu/browse/URS-894)

**implement Cyress tests for facets**
    Automate the testing for _Facets_ that is now done manually.

**Acceptance criteria:**
    
[x] each of the following is automated via our cypress suite:


- [Browse By Subject > Academy Awards (Motion pictures)](https://digital.library.ucla.edu/catalog?f%5Bsubject_sim%5D%5B%5D=Academy+Awards+%28Motion+pictures%29&search_field=subject_tesim)
- [Browse by Language > English and Resource Type > Cartographic](https://digital.library.ucla.edu/catalog?f%5Bhuman_readable_language_sim%5D%5B%5D=English&f%5Bhuman_readable_resource_type_sim%5D%5B%5D=cartographic&search_field=subject_tesim)
- [You searched for: Genre > black-and-white photographs and Language > English](https://digital.library.ucla.edu/catalog?f%5Bgenre_sim%5D%5B%5D=black-and-white+photographs&f%5Bhuman_readable_language_sim%5D%5B%5D=English&search_field=subject_tesim)
- [Start Over](https://digital.library.ucla.edu/catalog?utf8=%E2%9C%93&q=&search_field=all_fields)
- [You searched for: Location > Los Angeles (Calif.)and Names > Tournament of Roses](https://digital.library.ucla.edu/catalog?f%5Blocation_sim%5D%5B%5D=Los+Angeles+%28Calif.%29&f%5Bnamed_subject_sim%5D%5B%5D=Tournament+of+Roses&q=&search_field=all_fields)
- [Browse By Date > 1935 to 1967](https://digital.library.ucla.edu/catalog?utf8=%E2%9C%93&q=&search_field=all_fields&range%5Byear_isim%5D%5Bbegin%5D=1935&range%5Byear_isim%5D%5Bend%5D=1967&commit=Limit)
- [You searched for: Collection > Ethiopic Manuscripts](https://digital.library.ucla.edu/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=Ethiopic+Manuscripts&q=&search_field=all_fields)
- [GENRE Renderings Architectural drawings](https://digital.library.ucla.edu/catalog?f%5Bgenre_sim%5D%5B%5D=Architectural+drawings)
- [SUBJECTS Landmarks](https://digital.library.ucla.edu/catalog?f%5Bsubject_sim%5D%5B%5D=Landmarks)

[x] a percy.io screenshot is taken and submitted at each page
[x] tested
[x] linted

**Files**
e2e/cypress/integration/facets.js

