### PR TITLE
URS-866 Sinai: Add "Manuscript Descriptions" static page & update navbar

### DIFF
--- a/app/assets/stylesheets/theme_sinai/footer/_si-secondary-footer.scss
+++ b/app/assets/stylesheets/theme_sinai/footer/_si-secondary-footer.scss
@@ -10,7 +10,8 @@
 .site-footer__list-item--sinai {
   display: inline;
 
-  &:nth-child(1)::after {
+  &:nth-child(1)::after,
+  &:nth-child(2)::after {
     position: relative;
     top: -3px;
     left: -15px;

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -13,4 +13,8 @@ class StaticController < ApplicationController
 
   # Sinai static pages
   def sinai_terms_of_use; end
+
+  def sinai_about; end
+
+  def sinai_manuscript_descriptions; end
 end

--- a/app/views/shared/footer/_sinai_footer.html.erb
+++ b/app/views/shared/footer/_sinai_footer.html.erb
@@ -23,7 +23,8 @@
     <div class='site-footer__secondary-wrapper--sinai'>
         <ul class='site-footer__list'>
           <li class='site-footer__list-item site-footer__list-item--sinai'><%= link_to 'Contact Us', '/contact', class: 'site-footer__link site-footer__link--sinai' %></li>
-          <li class='site-footer__list-item site-footer__list-item--sinai'><%= link_to 'Terms of Use ', '/terms-of-use', class: 'site-footer__link site-footer__link--sinai' %></li>
+          <li class='site-footer__list-item site-footer__list-item--sinai'><%= link_to 'Terms of Use', '/terms-of-use', class: 'site-footer__link site-footer__link--sinai' %></li>
+          <li class='site-footer__list-item site-footer__list-item--sinai'><%= link_to 'Sinai Palimpsests Project', 'http://sinaipalimpsests.org/', class: 'site-footer__link site-footer__link--sinai', target: '_blank', rel: 'noopener' %></li>
         </ul>
     </div>
   </div>

--- a/app/views/shared/header/_sinai_header.html.erb
+++ b/app/views/shared/header/_sinai_header.html.erb
@@ -12,8 +12,11 @@
     <div class='collapse navbar-collapse' id='user-util-collapse'>
       <ul class='navbar-nav nav ml-auto'>
         <li class='site-navbar__item site-navbar__item--sinai'>
-          <a class='site-navbar__item-link site-navbar__item-link--sinai' href='http://sinaipalimpsests.org/' target='_blank' rel="noopener">Sinai Palimpsests Project</a>
-          </li>
+          <a class='site-navbar__item-link site-navbar__item-link--sinai' href='/sinai_about'>About</a>
+        </li>
+        <li class='site-navbar__item site-navbar__item--sinai'>
+          <a class='site-navbar__item-link site-navbar__item-link--sinai' href='/manuscript_descriptions'>Manuscript Descriptions</a>
+        </li>
       </ul>
     </div>
   </nav>

--- a/app/views/shared/header/_ursus_header.html.erb
+++ b/app/views/shared/header/_ursus_header.html.erb
@@ -21,7 +21,7 @@
     <div class="collapse navbar-collapse" id="user-util-collapse">
       <ul class="navbar-nav nav ml-auto">
         <li class="site-navbar__item site-navbar__item--ursus">
-          <a class='site-navbar__item-link site-navbar__item-link--ursus' href="/about">About</a>
+          <a class='site-navbar__item-link site-navbar__item-link--ursus' href="/ursus_about">About</a>
         </li>
         <li class="site-navbar__item site-navbar__item--ursus">
           <a class='site-navbar__item-link site-navbar__item-link--ursus site-navbar__item-link-feedback'
@@ -33,5 +33,5 @@
         </li>
       </ul>
     </div>
-</nav>
+  </nav>
 </div>

--- a/app/views/static/sinai_about.html.erb
+++ b/app/views/static/sinai_about.html.erb
@@ -1,0 +1,3 @@
+<% if Flipflop.sinai? %>
+  <h1>About the Project</h1>
+<% end %>

--- a/app/views/static/sinai_manuscript_descriptions.html.erb
+++ b/app/views/static/sinai_manuscript_descriptions.html.erb
@@ -1,0 +1,75 @@
+<% if Flipflop.sinai? %>
+<div class='content-container--static-page'>
+  <div class='static-page__title-row'>
+    <h1 class='static-page__title static-page__title--sinai bordered-title bordered-title--sinai'>Manuscript Descriptions</h1></div>
+    <div class='static-page__row'>
+      <p class='static-page__text static-page__text--sinai'>
+      During this phase of the Sinai Manuscripts Digital Library website, our primary focus is on providing access to the Arabic and Syriac manuscripts of St. Catherine’s Monastery. Our goal is to make the approximately 1000 manuscripts accessible and discoverable through our beta web portal by Fall 2021. To this end, we are focusing  our efforts on processing and publishing the over 400,000 page images, providing basic manuscript descriptions compiled primarily from existing catalogues and handlists, as well as from data collected onsite during digitization. The supplied descriptions provide information on both the codicological and textual aspects of the manuscripts, and have been enhanced and standardized where feasible to increase discoverability within the  collection. Since our manuscript data originates from several sources, we outline a few of the fields and their sources below.
+      </p>
+    </div>
+
+    <hr class='divider divider--sinai'>
+
+    <div class='static-page__row'>
+      <h3 class='static-page__subtitle static-page__subtitle--sinai'>DATA COLLECTED ONSITE IN SINAI</h3>
+      <p class='static-page__text static-page__text--sinai'>
+        During preparation for imaging, the Monastery Librarian, onsite consulting conservators and imaging specialists review manuscripts for their condition and record data for each manuscript, including the date created, language(s), object dimensions, weight, support, and any relevant notes on the physical condition. This data is incorporated into the manuscript descriptions and provides the most up-to-date measurements and assessments of the Sinai manuscripts.
+      </p>
+      </div>
+
+    <div class='static-page__row'>
+      <h3 class='static-page__subtitle static-page__subtitle--sinai'>TITLE</h2>
+      <p class='static-page__text static-page__text--sinai'>
+        Currently, the Title field comprises several components beginning with the Monastery’s shelf mark, followed by a general title and the date of the manuscript. The general titles are compiled from Murad Kamil’s <i>Catalogue of all Manuscripts in the Monastery of St. Catharine</i>. We recognize that there are more up-to-date and detailed catalogues available by respected scholars in this area; however, Kamil was chosen for its comprehensiveness as it includes all but a few of the manuscripts in the Monastery’s Old Collection. It is also important to note that Kamil’s numbering system differs from the Monastery’s shelf marks, although Kamil references the Monastery’s shelf marks in square brackets next to his numbers.
+      </p>
+
+      <p class='static-page__text static-page__text--sinai'>
+        In many cases, especially where there are multiple works within a single bound manuscript object, Kamil’s entries provide more of a description than a title. In these cases, we use in the “Title” field what appears to be the primary work (or works) within Kamil’s entry. We then add Kamil’s longer description to the “Contents note” field. When primary works cannot be identified, or where there are too many to include in the Title field, we opt for the general title, <i>Varia</i>, following Kamil’s practice, leaving Kamil’s full description in “Contents note.”
+      </p>
+      </div>
+
+    <div class='static-page__row'>
+      <h3 class='static-page__subtitle static-page__subtitle--sinai'>UNIFORM TITLE</h2>
+      <p class='static-page__text static-page__text--sinai'>
+        In addition to the Title and Contents note, we also supply uniform titles where feasible. Providing an authoritative form for titles allows a user to collocate all versions for a given work, especially where the title or spelling might differ between versions. Our sources for uniform titles are the Library of Congress Name Authority File (LCNAF) and the Virtual International Authority File (VIAF). In some cases, we have established project-specific uniform titles. To date, we have supplied uniform titles for all biblical and liturgical texts. The work on uniform titles for theological, historical, and other texts is ongoing and these are applied only where feasible and where uniform titles are already established. The uniform titles applied during this phase of the project will lay the foundation for a comprehensive title index that we plan to implement during a scholarly cataloguing project.
+      </p>
+    </div>
+
+    <div class='static-page__row'>
+      <h3 class='static-page__subtitle static-page__subtitle--sinai'>GENRE</h3>
+      <p class='static-page__text static-page__text--sinai'>
+        The genre terms used are based on the categories in Kamil’s handlist. Kamil groups the manuscripts into five distinct categories, some with subcategories: <i>Biblia</i>, <i>Liturgica</i>, <i>Theologica</i>, <i>Historical Accounts</i>, <i>Canons</i>, and <i>Varia</i>. Each of these categories and their subcategories have been mapped to authoritative genre terms from the Getty’s Art & Architecture Thesaurus (AAT) and are applied to the manuscript descriptions according to their placement in one of the categories in Kamil.
+      </p>
+
+      <p class='static-page__text static-page__text--sinai'>
+        Since many of the manuscripts contain multiple works and these often fall outside of Kamil’s assigned category, we apply additional genre terms from our list where appropriate and where the works are sufficiently identified. We have also added a few additional genre terms to our list to supplement Kamil’s categories where these might be beneficial. For example, we apply the genre term “gospel books” to all manuscripts containing any of the four Gospels, whether categorized as biblical or liturgical by Kamil. The primary goal of the genre terms is to allow for more faceted browsing within the collection.
+      </p>
+    </div>
+
+    <div class='static-page__row'>
+      <h3 class='static-page__subtitle static-page__subtitle--sinai'>NAMES</h3>
+      <p class='static-page__text static-page__text--sinai'>
+        Currently, we record names of authors and other associated names where they are supplied in Kamil or in the catalogue records of the LoC and National Library of Israel (NLI) microform collections of Sinai manuscripts. When an author or other associated name is noted, we source authoritative name forms from LCNAF and VIAF. The authoritative form is supplied in the appropriate field, such as the “Author” or the “Scribe” field. For associated names where the role is unclear or no authority exists, we attempt to record the name in a notes field where appropriate and feasible. The work to supply authoritative name forms is ongoing and only a subset of the manuscripts have been enhanced thus far.
+      </p>
+    </div>
+
+    <div class='static-page__row'>
+      <h3 class='static-page__subtitle static-page__subtitle--sinai'>FEATURES</h3>
+      <p class='static-page__text static-page__text--sinai'>
+        To facilitate browsing by manuscript features, such as decoration and illustrations, colophons, headpieces, and marginalia, we are piloting a “Features” descriptive field. The list of features and their definitions are based on Adam Gacek’s <i>Arabic Manuscripts: A Vademecum for Readers</i> and have been added to the descriptions for a subset of manuscripts in the collection.
+      </p>
+      </div>
+
+    <hr class='divider divider--sinai'>
+
+     <div class='static-page__row'>
+      <p class='static-page__text static-page__text--sinai'>
+      In the current phase, manuscript descriptions are more bibliographic in nature, providing basic enumeration of titles where they are identified in Kamil. In cooperation with the Monastery, we plan to organize scholarly cataloging projects to provide more complete descriptions of the imaged manuscripts, where our goal will be to catalogue and describe each work within a bound manuscript to meet contemporary manuscript cataloguing standards.
+      </p>
+
+      <p class='static-page__text static-page__text--sinai'>
+        We welcome suggestions and feedback from the community, so please feel free to reach out to the project team at dlp@library.ucla.edu.
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/static/ursus_about.html.erb
+++ b/app/views/static/ursus_about.html.erb
@@ -1,17 +1,19 @@
-<div class='content-container--static-page'>
-  <div class='static-page__title-row'>
-    <h1 class='static-page__title bordered-title bordered-title--ursus'><%= t('static_pages.about.page_title') %></h1>
-  </div>
-
-<!-- OUR MISSION -->
-  <div class='static-page__row static-page__row--ursus'>
-    <div class='static-page__subtitle static-page__subtitle--ursus'>
-      <%= t('static_pages.about.mission').upcase %>
+<% if !Flipflop.sinai? %>
+  <div class='content-container--static-page'>
+    <div class='static-page__title-row'>
+      <h1 class='static-page__title bordered-title bordered-title--ursus'><%= t('static_pages.about.page_title') %></h1>
     </div>
-    <div class='static-page__text static-page__text--ursus'>
-      The UCLA Digital Library Program (DLP) serves as the catalyst for the creation, management, and delivery of digital content in support of the UCLA Library mission and goals. The Program provides for the storage and dissemination of digital objects, including text, images, audio, and video in their various digital manifestations and combinations. The UCLA Library provides a web presence for digital collections, and provides storage, backup and digital preservation support for all digital content accepted into, or developed by, the Library.
-    </div>
-  </div>
 
-  <hr class='divider divider--ursus'>
-</div>
+  <!-- OUR MISSION -->
+    <div class='static-page__row static-page__row--ursus'>
+      <div class='static-page__subtitle static-page__subtitle--ursus'>
+        <%= t('static_pages.about.mission').upcase %>
+      </div>
+      <div class='static-page__text static-page__text--ursus'>
+        The UCLA Digital Library Program (DLP) serves as the catalyst for the creation, management, and delivery of digital content in support of the UCLA Library mission and goals. The Program provides for the storage and dissemination of digital objects, including text, images, audio, and video in their various digital manifestations and combinations. The UCLA Library provides a web presence for digital collections, and provides storage, backup and digital preservation support for all digital content accepted into, or developed by, the Library.
+      </div>
+    </div>
+
+    <hr class='divider divider--ursus'>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,11 +7,13 @@ Rails.application.routes.draw do
   # Ursus static pages
   get '/copyrights_and_collections', to: 'static#ursus_copyright'
   get '/privacy_policy', to: 'static#ursus_privacy'
-  get '/about', to: 'static#ursus_about'
+  get '/ursus_about', to: 'static#ursus_about'
 
   # Sinai static pages
   get '/login', to: 'login#new', as: 'login'
   get '/terms-of-use', to: 'static#sinai_terms_of_use'
+  get '/sinai_about', to: 'static#sinai_about'
+  get '/manuscript_descriptions', to: 'static#sinai_manuscript_descriptions'
 
   # Canon Law
   get '/canonlaw', to: 'canon_law#index'


### PR DESCRIPTION
Connected to [URS-866](https://jira.library.ucla.edu/browse/URS-866)

This also sets up the structure for the Sinai About page ticket [URS-865](https://jira.library.ucla.edu/browse/URS-865)

- [x] A new static page with the "Manuscript Description" copy

- [x] Sinai has a new "About & Manuscript Description" feature in the top nav banner

- [x] Sinai Palimsests Project Link is in the Footer after the Terms of Use

- [x] Work has been previewed and approved by Dawn on Callisto-stage


<img width="1347" alt="Screen Shot 2020-07-23 at 3 57 42 PM" src="https://user-images.githubusercontent.com/751697/88347420-7e8b3300-ccff-11ea-9f71-609520e57725.png">

<img width="1345" alt="Screen Shot 2020-07-23 at 3 57 32 PM" src="https://user-images.githubusercontent.com/751697/88347442-8a76f500-ccff-11ea-9bc3-9ab111b68f6f.png">

<img width="491" alt="Screen Shot 2020-07-23 at 4 28 39 PM" src="https://user-images.githubusercontent.com/751697/88348195-9ebbf180-cd01-11ea-8c29-6645943c4595.png">

---

Changes to be committed:
modified:   app/assets/stylesheets/theme_sinai/footer/_si-secondary-footer.scss
modified:   app/controllers/static_controller.rb
modified:   app/views/shared/footer/_sinai_footer.html.erb
modified:   app/views/shared/header/_sinai_header.html.erb
modified:   app/views/shared/header/_ursus_header.html.erb
new file:   app/views/static/sinai_about.html.erb
new file:   app/views/static/sinai_manuscript_descriptions.html.erb
modified:   app/views/static/ursus_about.html.erb
modified:   config/routes.rb