### PR TITLE
URS-580 Implement Cypress tests for Search related pages

### DIFF
--- a/e2e/cypress/integration/search.js
+++ b/e2e/cypress/integration/search.js
@@ -10,7 +10,7 @@ describe('Search', () => {
   });
 
   it('Search Not Found', () => {
-    cy.get('[id=q]').type('unicorn');
+    cy.get('[id=q]').type('unicornasdasd');
     cy.get('[id=search]').click();
     cy.contains('h2', '0 Catalog Results').should('exist');
     cy.percySnapshot();
@@ -64,7 +64,7 @@ describe('Search', () => {
       '.document-position-0 > .document__list-header > .document__list-title > a'
     ).click({ force: true });
     cy.get(
-      '.blacklight-photographer_tesim.metadata-block__label-value > a'
+      '.blacklight-photographer_tesim.metadata-block__label-value.metadata-block__label-value--ursus > a'
     ).click();
     cy.contains('span', 'Photographer Sim');
     cy.percySnapshot();

--- a/e2e/cypress/integration/search.js
+++ b/e2e/cypress/integration/search.js
@@ -10,7 +10,7 @@ describe('Search', () => {
   });
 
   it('Search Not Found', () => {
-    cy.get('[id=q]').type('unicornasdasd');
+    cy.get('[id=q]').type('unicorn');
     cy.get('[id=search]').click();
     cy.contains('h2', '0 Catalog Results').should('exist');
     cy.percySnapshot();
@@ -63,6 +63,9 @@ describe('Search', () => {
     cy.get(
       '.document-position-0 > .document__list-header > .document__list-title > a'
     ).click({ force: true });
-    cy.get('.blacklight-photographer_tesim.metadata-block__label-key');
+    cy.contains('dt', 'Photographer');
+    cy.get('a[href*="photographer_sim"]').click();
+    cy.contains('span', 'Photographer Sim');
+    cy.percySnapshot();
   });
 });

--- a/e2e/cypress/integration/search.js
+++ b/e2e/cypress/integration/search.js
@@ -63,13 +63,6 @@ describe('Search', () => {
     cy.get(
       '.document-position-0 > .document__list-header > .document__list-title > a'
     ).click({ force: true });
-
     cy.get('.blacklight-photographer_tesim.metadata-block__label-key');
-
-    ///cy.get(
-    ///'.blacklight-photographer_tesim.metadata-block__label-value.metadata-block__label-value--ursus'
-    ///)
-    ///.children()
-    ///.click();
   });
 });

--- a/e2e/cypress/integration/search.js
+++ b/e2e/cypress/integration/search.js
@@ -3,70 +3,79 @@ beforeEach(() => {
   cy.visit('/');
 });
 describe('Search', () => {
-  it('Search Blank', () => {
-    cy.get('[id=search]').click();
-    cy.contains('span', 'You searched for:').should('not.exist');
-    cy.percySnapshot();
-  });
-
-  it('Search Not Found', () => {
-    cy.get('[id=q]').type('unicorn');
-    cy.get('[id=search]').click();
-    cy.contains('h2', '0 Catalog Results').should('exist');
-    cy.percySnapshot();
-  });
-
-  it('Search Title Found', () => {
-    cy.get('[id=q]').type('postcards');
-    cy.get('select').select('Title').should('have.value', 'title_tesim');
-    cy.get('[id=search]').click();
-    cy.get('.search-count__heading').contains('Catalog Results');
-    cy.percySnapshot();
-  });
-
-  it('Search Subject Found', () => {
-    cy.get('[id=q]').type('engineer');
-    cy.get('select').select('Subject').should('have.value', 'subject_tesim');
-    cy.get('[id=search]').click();
-    cy.get('.search-count__heading').contains('Catalog Results');
-    cy.percySnapshot();
-  });
-
-  it('Metadata Text', () => {
-    cy.contains('a', 'Resource Type').click();
-    cy.contains('a', 'text').click({ force: true });
-    cy.get('[title="text"]');
-    cy.get(
-      '.document-position-0 > .document__list-header > .document__list-title > a'
-    ).click({ force: true });
-    cy.contains('a', 'text').click();
-    cy.contains('span', 'Resource Type');
-    cy.get('[title=text]').contains('text');
-    cy.percySnapshot();
-  });
-
-  it('Metadata Still Image', () => {
-    cy.get('[id=q]').type('still image');
-    cy.get('[id=search]').click();
-    cy.get(
-      '.document-position-0 > .document__list-header > .document__list-title > a'
-    ).click({ force: true });
-    cy.contains('a', 'still image').click();
-    cy.contains('span', 'Genre');
-    cy.contains('span', 'still image');
-    cy.percySnapshot();
-  });
-
+  ///  it('Search Blank', () => {
+  ///    cy.get('[id=search]').click();
+  ///    cy.contains('span', 'You searched for:').should('not.exist');
+  ///    cy.percySnapshot();
+  ///  });
+  ///
+  ///  it('Search Not Found', () => {
+  ///    cy.get('[id=q]').type('unicorn');
+  ///    cy.get('[id=search]').click();
+  ///    cy.contains('h2', '0 Catalog Results').should('exist');
+  ///    cy.percySnapshot();
+  ///  });
+  ///
+  ///  it('Search Title Found', () => {
+  ///    cy.get('[id=q]').type('postcards');
+  ///    cy.get('select').select('Title').should('have.value', 'title_tesim');
+  ///    cy.get('[id=search]').click();
+  ///    cy.get('.search-count__heading').contains('Catalog Results');
+  ///    cy.percySnapshot();
+  ///  });
+  ///
+  ///  it('Search Subject Found', () => {
+  ///    cy.get('[id=q]').type('engineer');
+  ///    cy.get('select').select('Subject').should('have.value', ///'subject_tesim');
+  ///    cy.get('[id=search]').click();
+  ///    cy.get('.search-count__heading').contains('Catalog Results');
+  ///    cy.percySnapshot();
+  ///  });
+  ///
+  ///  it('Metadata Text', () => {
+  ///    cy.contains('a', 'Resource Type').click();
+  ///    cy.contains('a', 'text').click({ force: true });
+  ///    cy.get('[title="text"]');
+  ///    cy.get(
+  ///      '.document-position-0 > .document__list-header > .///document__list-title > a'
+  ///    ).click({ force: true });
+  ///    cy.contains('a', 'text').click();
+  ///    cy.contains('span', 'Resource Type');
+  ///    cy.get('[title=text]').contains('text');
+  ///    cy.percySnapshot();
+  ///  });
+  ///
+  ///  it('Metadata Still Image', () => {
+  ///    cy.get('[id=q]').type('still image');
+  ///    cy.get('[id=search]').click();
+  ///    cy.get(
+  ///      '.document-position-0 > .document__list-header > .///document__list-title > a'
+  ///    ).click({ force: true });
+  ///    cy.contains('a', 'still image').click();
+  ///    cy.contains('span', 'Genre');
+  ///    cy.contains('span', 'still image');
+  ///    cy.percySnapshot();
+  ///  });
+  ///
   it('Metadata Artistic Photo', () => {
-    cy.get('[id=q]').type('photographer');
-    cy.get('[id=search]').click();
-    cy.get(
-      '.document-position-0 > .document__list-header > .document__list-title > a'
-    )
-      .click({ force: true })
-      .wait(5000);
-    cy.contains('dt', 'Photographer');
-    cy.get('a[href*="photographer_sim"]').click();
+    ///cy.server();
+    ///cy.route('GET', '/catalog').as('todos');
+    ///cy.visit('/');
+    ///cy.wait('@todos');
+    ///// cy.get() will run AFTER cy.wait() finishescy.
+    ///post('li.todo').should('have.length', 0);
+    ///
+    cy.visit(
+      'https://ursus-dev.library.ucla.edu/catalog?utf8=%E2%9C%93&q=photographer&search_field=all_fields'
+    );
+    ///    cy.get('[id=q]').type('photographer');
+    ///    cy.get('[id=search]').click();
+    ///    cy.get(
+    ///      '.document-position-0 > .document__list-header > .///document__list-title > a'
+    ///    ).click({ force: true });
+    ///cy.contains('dt', 'Photographer');
+    ///cy.get('.blacklight-photographer_tesim.metadata-block__label-key');
+    cy.get('a[href*="photographer_sim"]').eq(0).click();
     cy.contains('span', 'Photographer Sim');
     cy.percySnapshot();
   });

--- a/e2e/cypress/integration/search.js
+++ b/e2e/cypress/integration/search.js
@@ -64,9 +64,9 @@ describe('Search', () => {
       '.document-position-0 > .document__list-header > .document__list-title > a'
     ).click({ force: true });
     cy.get(
-      '.blacklight-photographer_tesim.metadata-block__label-value.metadata-block__label-value--ursus > a'
-    ).click();
-    cy.contains('span', 'Photographer Sim');
-    cy.percySnapshot();
+      '.blacklight-photographer_tesim.metadata-block__label-value.metadata-block__label-value--ursus'
+    )
+      .children()
+      .click();
   });
 });

--- a/e2e/cypress/integration/search.js
+++ b/e2e/cypress/integration/search.js
@@ -1,0 +1,72 @@
+/// <reference types="Cypress" />
+beforeEach(() => {
+  cy.visit('/');
+});
+describe('Search', () => {
+  it('Search Blank', () => {
+    cy.get('[id=search]').click();
+    cy.contains('span', 'You searched for:').should('not.exist');
+    cy.percySnapshot();
+  });
+
+  it('Search Not Found', () => {
+    cy.get('[id=q]').type('unicorn');
+    cy.get('[id=search]').click();
+    cy.contains('h2', '0 Catalog Results').should('exist');
+    cy.percySnapshot();
+  });
+
+  it('Search Title Found', () => {
+    cy.get('[id=q]').type('postcards');
+    cy.get('select').select('Title').should('have.value', 'title_tesim');
+    cy.get('[id=search]').click();
+    cy.get('.search-count__heading').contains('Catalog Results');
+    cy.percySnapshot();
+  });
+
+  it('Search Subject Found', () => {
+    cy.get('[id=q]').type('engineer');
+    cy.get('select').select('Subject').should('have.value', 'subject_tesim');
+    cy.get('[id=search]').click();
+    cy.get('.search-count__heading').contains('Catalog Results');
+    cy.percySnapshot();
+  });
+
+  it('Metadata Text', () => {
+    cy.contains('a', 'Resource Type').click();
+    cy.contains('a', 'text').click({ force: true });
+    cy.get('[title="text"]');
+    cy.get(
+      '.document-position-0 > .document__list-header > .document__list-title > a'
+    ).click({ force: true });
+    cy.contains('a', 'text').click();
+    cy.contains('span', 'Resource Type');
+    cy.get('[title=text]').contains('text');
+    cy.percySnapshot();
+  });
+
+  it('Metadata Still Image', () => {
+    cy.get('[id=q]').type('still image');
+    cy.get('[id=search]').click();
+    cy.get(
+      '.document-position-0 > .document__list-header > .document__list-title > a'
+    ).click({ force: true });
+    cy.contains('a', 'still image').click();
+    cy.contains('span', 'Genre');
+    cy.contains('span', 'still image');
+    cy.percySnapshot();
+  });
+
+  it('Metadata Artistic Photo', () => {
+    cy.get('[id=q]').type('photographer');
+    cy.get('[id=search]').click();
+    cy.get(
+      '.document-position-0 > .document__list-header > .document__list-title > a'
+    ).click({ force: true });
+    cy.get(
+      '.blacklight-photographer_tesim.metadata-block__label-value > a'
+    ).click();
+    cy.contains('span', 'Photographer Sim');
+    cy.percySnapshot();
+  });
+});

--- a/e2e/cypress/integration/search.js
+++ b/e2e/cypress/integration/search.js
@@ -63,7 +63,7 @@ describe('Search', () => {
     cy.get(
       '.document-position-0 > .document__list-header > .document__list-title > a'
     ).click({ force: true });
-    cy.contains('dt', 'Photographer');
+    cy.contains('dt', 'Photographer').wait(5000);
     cy.get('a[href*="photographer_sim"]').click();
     cy.contains('span', 'Photographer Sim');
     cy.percySnapshot();

--- a/e2e/cypress/integration/search.js
+++ b/e2e/cypress/integration/search.js
@@ -65,9 +65,7 @@ describe('Search', () => {
     ///// cy.get() will run AFTER cy.wait() finishescy.
     ///post('li.todo').should('have.length', 0);
     ///
-    cy.visit(
-      'https://ursus-dev.library.ucla.edu/catalog?utf8=%E2%9C%93&q=photographer&search_field=all_fields'
-    );
+    cy.visit('/catalog?utf8=%E2%9C%93&q=photographer&search_field=all_fields');
     ///    cy.get('[id=q]').type('photographer');
     ///    cy.get('[id=search]').click();
     ///    cy.get(

--- a/e2e/cypress/integration/search.js
+++ b/e2e/cypress/integration/search.js
@@ -1,6 +1,6 @@
 /// <reference types="Cypress" />
 beforeEach(() => {
-  cy.visit('https://ursus-dev.library.ucla.edu');
+  cy.visit('/');
 });
 describe('Search', () => {
   it('Search Blank', () => {

--- a/e2e/cypress/integration/search.js
+++ b/e2e/cypress/integration/search.js
@@ -1,6 +1,6 @@
 /// <reference types="Cypress" />
 beforeEach(() => {
-  cy.visit('/');
+  cy.visit('https://ursus-dev.library.ucla.edu');
 });
 describe('Search', () => {
   it('Search Blank', () => {
@@ -63,10 +63,13 @@ describe('Search', () => {
     cy.get(
       '.document-position-0 > .document__list-header > .document__list-title > a'
     ).click({ force: true });
-    cy.get(
-      '.blacklight-photographer_tesim.metadata-block__label-value.metadata-block__label-value--ursus'
-    )
-      .children()
-      .click();
+
+    cy.get('.blacklight-photographer_tesim.metadata-block__label-key');
+
+    ///cy.get(
+    ///'.blacklight-photographer_tesim.metadata-block__label-value.metadata-block__label-value--ursus'
+    ///)
+    ///.children()
+    ///.click();
   });
 });

--- a/e2e/cypress/integration/search.js
+++ b/e2e/cypress/integration/search.js
@@ -3,76 +3,56 @@ beforeEach(() => {
   cy.visit('/');
 });
 describe('Search', () => {
-  ///  it('Search Blank', () => {
-  ///    cy.get('[id=search]').click();
-  ///    cy.contains('span', 'You searched for:').should('not.exist');
-  ///    cy.percySnapshot();
-  ///  });
-  ///
-  ///  it('Search Not Found', () => {
-  ///    cy.get('[id=q]').type('unicorn');
-  ///    cy.get('[id=search]').click();
-  ///    cy.contains('h2', '0 Catalog Results').should('exist');
-  ///    cy.percySnapshot();
-  ///  });
-  ///
-  ///  it('Search Title Found', () => {
-  ///    cy.get('[id=q]').type('postcards');
-  ///    cy.get('select').select('Title').should('have.value', 'title_tesim');
-  ///    cy.get('[id=search]').click();
-  ///    cy.get('.search-count__heading').contains('Catalog Results');
-  ///    cy.percySnapshot();
-  ///  });
-  ///
-  ///  it('Search Subject Found', () => {
-  ///    cy.get('[id=q]').type('engineer');
-  ///    cy.get('select').select('Subject').should('have.value', ///'subject_tesim');
-  ///    cy.get('[id=search]').click();
-  ///    cy.get('.search-count__heading').contains('Catalog Results');
-  ///    cy.percySnapshot();
-  ///  });
-  ///
-  ///  it('Metadata Text', () => {
-  ///    cy.contains('a', 'Resource Type').click();
-  ///    cy.contains('a', 'text').click({ force: true });
-  ///    cy.get('[title="text"]');
-  ///    cy.get(
-  ///      '.document-position-0 > .document__list-header > .///document__list-title > a'
-  ///    ).click({ force: true });
-  ///    cy.contains('a', 'text').click();
-  ///    cy.contains('span', 'Resource Type');
-  ///    cy.get('[title=text]').contains('text');
-  ///    cy.percySnapshot();
-  ///  });
-  ///
-  ///  it('Metadata Still Image', () => {
-  ///    cy.get('[id=q]').type('still image');
-  ///    cy.get('[id=search]').click();
-  ///    cy.get(
-  ///      '.document-position-0 > .document__list-header > .///document__list-title > a'
-  ///    ).click({ force: true });
-  ///    cy.contains('a', 'still image').click();
-  ///    cy.contains('span', 'Genre');
-  ///    cy.contains('span', 'still image');
-  ///    cy.percySnapshot();
-  ///  });
-  ///
+  it('Search Blank', () => {
+    cy.get('[id=search]').click();
+    cy.contains('span', 'You searched for:').should('not.exist');
+    cy.percySnapshot();
+  });
+  it('Search Not Found', () => {
+    cy.get('[id=q]').type('unicorn');
+    cy.get('[id=search]').click();
+    cy.contains('h2', '0 Catalog Results').should('exist');
+    cy.percySnapshot();
+  });
+  it('Search Title Found', () => {
+    cy.get('[id=q]').type('postcards');
+    cy.get('select').select('Title').should('have.value', 'title_tesim');
+    cy.get('[id=search]').click();
+    cy.get('.search-count__heading').contains('Catalog Results');
+    cy.percySnapshot();
+  });
+  it('Search Subject Found', () => {
+    cy.get('[id=q]').type('engineer');
+    cy.get('select').select('Subject').should('have.value', 'subject_tesim');
+    cy.get('[id=search]').click();
+    cy.get('.search-count__heading').contains('Catalog Results');
+    cy.percySnapshot();
+  });
+  it('Metadata Text', () => {
+    cy.contains('a', 'Resource Type').click();
+    cy.contains('a', 'text').click({ force: true });
+    cy.get('[title="text"]');
+    cy.get(
+      '.document-position-0 > .document__list-header > .document__list-title > a'
+    ).click({ force: true });
+    cy.contains('a', 'text').click();
+    cy.contains('span', 'Resource Type');
+    cy.get('[title=text]').contains('text');
+    cy.percySnapshot();
+  });
+  it('Metadata Still Image', () => {
+    cy.get('[id=q]').type('still image');
+    cy.get('[id=search]').click();
+    cy.get(
+      '.document-position-0 > .document__list-header > .document__list-title > a'
+    ).click({ force: true });
+    cy.contains('a', 'still image').click();
+    cy.contains('span', 'Genre');
+    cy.contains('span', 'still image');
+    cy.percySnapshot();
+  });
   it('Metadata Artistic Photo', () => {
-    ///cy.server();
-    ///cy.route('GET', '/catalog').as('todos');
-    ///cy.visit('/');
-    ///cy.wait('@todos');
-    ///// cy.get() will run AFTER cy.wait() finishescy.
-    ///post('li.todo').should('have.length', 0);
-    ///
     cy.visit('/catalog?utf8=%E2%9C%93&q=photographer&search_field=all_fields');
-    ///    cy.get('[id=q]').type('photographer');
-    ///    cy.get('[id=search]').click();
-    ///    cy.get(
-    ///      '.document-position-0 > .document__list-header > .///document__list-title > a'
-    ///    ).click({ force: true });
-    ///cy.contains('dt', 'Photographer');
-    ///cy.get('.blacklight-photographer_tesim.metadata-block__label-key');
     cy.get('a[href*="photographer_sim"]').eq(0).click();
     cy.contains('span', 'Photographer Sim');
     cy.percySnapshot();

--- a/e2e/cypress/integration/search.js
+++ b/e2e/cypress/integration/search.js
@@ -62,8 +62,10 @@ describe('Search', () => {
     cy.get('[id=search]').click();
     cy.get(
       '.document-position-0 > .document__list-header > .document__list-title > a'
-    ).click({ force: true });
-    cy.contains('dt', 'Photographer').wait(5000);
+    )
+      .click({ force: true })
+      .wait(5000);
+    cy.contains('dt', 'Photographer');
     cy.get('a[href*="photographer_sim"]').click();
     cy.contains('span', 'Photographer Sim');
     cy.percySnapshot();


### PR DESCRIPTION
Connected to [URS-580](https://jira.library.ucla.edu/browse/URS-580)

### Create e2e test using Cypress as described in the ticket.

#### Acceptance criteria:

- [x] Each of the following is automated via our cypress suite:

    - [x] Search with blank keyword
    - [x] Search Unicorn under all fields
    - [x] Search postcards in titles
    - [x] Search keyword Engineer under subjects field
    - [x] Back to search Results
        - [x] Click the "text" on search results block
            - [x] *This test is done on the Facets ticket*
        - [x] Click on "Armenian Manuscripts" on search results block
        - [x] Click on "Still Image" on search results page
        - [x] Click on Photographer: Artistic Photo on search results block

- [x] A `percy.io` screenshot is taken and submitted at each page
- [x] Linted
- [x] Tested

**Files*

---

+ `e2e/cypress/integration/homepage.js`
+ `e2e/cypress/integration/search.js`
+ `e2e/cypress/support/index.js`
+ `e2e/package-lock.json`
+ `e2e/package.json`