### PR TITLE
fixed alignment of metadata

### DIFF
--- a/app/assets/stylesheets/base/components/index/_list-view.scss
+++ b/app/assets/stylesheets/base/components/index/_list-view.scss
@@ -39,6 +39,7 @@
 
   align-items: baseline;
   align-content: baseline;
+  width: 100%;
 }
 
 .document__list-metadata-key {


### PR DESCRIPTION
Connected to [CAL-925](https://jira.library.ucla.edu/browse/CAL-925)

Meta data on the Collection Search Results page does not always align properly. See [Collections](https://digital.library.ucla.edu/catalog?f%5Bhas_model_ssim%5D%5B%5D=Collection&view=list).

Please develop a means to ensure consistent metadata alignment.

**Acceptance criteria**

[x] - All metadata fields are aligned
[x] - No text overlaps with any other text (this may not be an issue anymore)
