### PR TITLE
URS-875 Use ursus core in the docker environment to support forward arks for Ursus

### DIFF
--- a/default.env
+++ b/default.env
@@ -19,8 +19,8 @@ RAILS_HOST=localhost
 SINAI_ID_BYPASS=true
 
 # The solr for the Californica environment that this Ursus environment will use as its data source
-SOLR_URL=http://127.0.0.1:8983/solr/californica
-SOLR_TEST_URL=http://127.0.0.1:8985/solr/californica
+SOLR_URL=http://127.0.0.1:8983/solr/ursus
+SOLR_TEST_URL=http://127.0.0.1:8985/solr/ursus
 
 # old stuff, should be able to remove sometime
 IIIF_URL=https://californica-test.library.ucla.edu/concern/works

--- a/docker.env
+++ b/docker.env
@@ -1,4 +1,4 @@
 CYPRESS_BASE_URL=http://web:3000
 DATABASE_HOST=db
-SOLR_URL=http://solr:8983/solr/californica
-SOLR_TEST_URL=http://solr_test:8983/solr/californica
+SOLR_URL=http://solr:8983/solr/ursus
+SOLR_TEST_URL=http://solr_test:8983/solr/ursusd

--- a/docker.env
+++ b/docker.env
@@ -1,4 +1,4 @@
 CYPRESS_BASE_URL=http://web:3000
 DATABASE_HOST=db
 SOLR_URL=http://solr:8983/solr/ursus
-SOLR_TEST_URL=http://solr_test:8983/solr/ursusd
+SOLR_TEST_URL=http://solr_test:8983/solr/ursus

--- a/ursus.dab
+++ b/ursus.dab
@@ -13,11 +13,11 @@
         "DATABASE_MIN_MESSAGES=warning",
         "RAILS_SERVE_STATIC_FILES=true",
         "RAILS_HOST=localhost",
-        "SOLR_URL=http://solr:8983/solr/californica",
+        "SOLR_URL=http://solr:8983/solr/ursus",
         "USER_ACCOUNT_UI_ENABLED=false",
         "THUMBNAIL_BASE_URL=http://localhost:3000",
         "IIIF_URL=http://localhost:3000/concern/works",
-        "SOLR_TEST_URL=http://solr_test:8983/solr/californica"
+        "SOLR_TEST_URL=http://solr_test:8983/solr/ursus"
       ],
       "Image": "uclalibrary/ursus@sha256:d0e74fffb59516f39baedd4927045c666ae96c9727a364a598610f4fbc06c309",
       "Networks": [


### PR DESCRIPTION
Connected to [URS-875 ](https://jira.library.ucla.edu/browse/URS-875)

This will update only the local dev environment.
There is another ticket for DevOps to update other environments.