### PR TITLE
URS-805 Change default sort order of search results to title a z when user is browsing

### DIFF
--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -27,4 +27,18 @@
       <%= render 'search_results' %>
     </div>
   <% end %>
+
+  <!-- if URL contains catalog with a sort option, remove sort option (illegal combination) -->
+  <!-- else if URL (contians an empty query OR empty square brackets) AND contains a sort term AND does not contain the Start Over string -->
+  <!--   add Title Sort string to URL -->
+  <!--   got to page -->
+  <script type="text/javascript">
+    var urlFacet = window.location.search;
+    if ( urlFacet.indexOf("catalog?sort=" ) !== -1){
+      window.history.replaceState('page2', 'Title', '/catalog');
+    } else if (( (urlFacet.indexOf("&q=&") !== -1) || (urlFacet.indexOf("%5B%5D=") !== -1) ) && (urlFacet.indexOf("&sort=") == -1) && (urlFacet != "?utf8=%E2%9C%93&q=&search_field=all_fields") ) {
+        var titleSortUrl = urlFacet+"&sort=title_alpha_numeric_ssort+asc";
+        window.location = titleSortUrl;
+    }
+  </script>
 <% end %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -29,7 +29,7 @@
   <% end %>
 
   <!-- if URL contains catalog with a sort option, remove sort option (illegal combination) -->
-  <!-- else if URL (contians an empty query OR empty square brackets) AND contains a sort term AND does not contain the Start Over string -->
+  <!-- else if URL (contians an empty query OR empty square brackets) AND ((contains "members of collections") OR (contains a sort term AND does not contain the Start Over string)) -->
   <!--   add Title Sort string to URL -->
   <!--   got to page -->
   <script type="text/javascript">
@@ -37,7 +37,7 @@
     console.log(urlFacet);
     if ( urlFacet.indexOf("catalog?sort=" ) !== -1){
       window.history.replaceState('page2', 'Title', '/catalog');
-    } else if ( ((urlFacet.indexOf("&q=&") !== -1) || (urlFacet.indexOf("%5B%5D=") !== -1)) && (    (urlFacet.indexOf("[member_of_collections_") !== -1)     || ((urlFacet.indexOf("&sort=") == -1) && (urlFacet != "?utf8=%E2%9C%93&q=&search_field=all_fields"))) ) {
+    } else if ( ((urlFacet.indexOf("&q=&") !== -1) || (urlFacet.indexOf("%5B%5D=") !== -1)) && ((urlFacet.indexOf("[member_of_collections_") !== -1) || ((urlFacet.indexOf("&sort=") == -1) && (urlFacet != "?utf8=%E2%9C%93&q=&search_field=all_fields"))) ) {
         var titleSortUrl = urlFacet+"&sort=title_alpha_numeric_ssort+asc";
         window.location = titleSortUrl;
     }

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -32,7 +32,6 @@
   <!-- else if URL (contians an empty query OR empty square brackets) AND ((contains "members of collections") OR (contains a sort term AND does not contain the Start Over string)) -->
   <!--   add Title Sort string to URL -->
   <!--   got to page -->
-  
   <script type="text/javascript">
     var urlFacet = window.location.search;
     if ( urlFacet.indexOf("catalog?sort=" ) !== -1){

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -33,11 +33,11 @@
   <!--   add Title Sort string to URL -->
   <!--   got to page -->
   <script type="text/javascript">
-    let urlFacet = window.location.search;
+    var urlFacet = window.location.search;
     if ( urlFacet.indexOf("catalog?sort=" ) !== -1){
       window.history.replaceState('page2', 'Title', '/catalog');
     } else if ( ((urlFacet.indexOf("&q=&") !== -1) || (urlFacet.indexOf("%5B%5D=") !== -1)) && ((urlFacet.indexOf("[member_of_collections_") !== -1) || ((urlFacet.indexOf("&sort=") == -1) && (urlFacet != "?utf8=%E2%9C%93&q=&search_field=all_fields"))) ) {
-        let titleSortUrl = urlFacet+"&sort=title_alpha_numeric_ssort+asc";
+        var titleSortUrl = urlFacet+"&sort=title_alpha_numeric_ssort+asc";
         window.location = titleSortUrl;
     }
   </script>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -33,11 +33,11 @@
   <!--   add Title Sort string to URL -->
   <!--   got to page -->
   <script type="text/javascript">
-    var urlFacet = window.location.search;
+    let urlFacet = window.location.search;
     if ( urlFacet.indexOf("catalog?sort=" ) !== -1){
       window.history.replaceState('page2', 'Title', '/catalog');
     } else if ( ((urlFacet.indexOf("&q=&") !== -1) || (urlFacet.indexOf("%5B%5D=") !== -1)) && ((urlFacet.indexOf("[member_of_collections_") !== -1) || ((urlFacet.indexOf("&sort=") == -1) && (urlFacet != "?utf8=%E2%9C%93&q=&search_field=all_fields"))) ) {
-        var titleSortUrl = urlFacet+"&sort=title_alpha_numeric_ssort+asc";
+        let titleSortUrl = urlFacet+"&sort=title_alpha_numeric_ssort+asc";
         window.location = titleSortUrl;
     }
   </script>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -28,10 +28,7 @@
     </div>
   <% end %>
 
-  <!-- if URL contains catalog with a sort option, remove sort option (illegal combination) -->
-  <!-- else if URL (contians an empty query OR empty square brackets) AND ((contains "members of collections") OR (contains a sort term AND does not contain the Start Over string)) -->
-  <!--   add Title Sort string to URL -->
-  <!--   got to page -->
+  <!-- add Title Sort -->
   <script type="text/javascript">
     var urlFacet = window.location.search;
     if ( urlFacet.indexOf("catalog?sort=" ) !== -1){

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -34,9 +34,10 @@
   <!--   got to page -->
   <script type="text/javascript">
     var urlFacet = window.location.search;
+    console.log(urlFacet);
     if ( urlFacet.indexOf("catalog?sort=" ) !== -1){
       window.history.replaceState('page2', 'Title', '/catalog');
-    } else if (( (urlFacet.indexOf("&q=&") !== -1) || (urlFacet.indexOf("%5B%5D=") !== -1) ) && (urlFacet.indexOf("&sort=") == -1) && (urlFacet != "?utf8=%E2%9C%93&q=&search_field=all_fields") ) {
+    } else if ( ((urlFacet.indexOf("&q=&") !== -1) || (urlFacet.indexOf("%5B%5D=") !== -1)) && (    (urlFacet.indexOf("[member_of_collections_") !== -1)     || ((urlFacet.indexOf("&sort=") == -1) && (urlFacet != "?utf8=%E2%9C%93&q=&search_field=all_fields"))) ) {
         var titleSortUrl = urlFacet+"&sort=title_alpha_numeric_ssort+asc";
         window.location = titleSortUrl;
     }

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -34,7 +34,6 @@
   <!--   got to page -->
   <script type="text/javascript">
     var urlFacet = window.location.search;
-    console.log(urlFacet);
     if ( urlFacet.indexOf("catalog?sort=" ) !== -1){
       window.history.replaceState('page2', 'Title', '/catalog');
     } else if ( ((urlFacet.indexOf("&q=&") !== -1) || (urlFacet.indexOf("%5B%5D=") !== -1)) && ((urlFacet.indexOf("[member_of_collections_") !== -1) || ((urlFacet.indexOf("&sort=") == -1) && (urlFacet != "?utf8=%E2%9C%93&q=&search_field=all_fields"))) ) {

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -29,11 +29,7 @@
   <% end %>
 
   <!-- if URL contains catalog with a sort option, remove sort option (illegal combination) -->
-<<<<<<< HEAD
   <!-- else if URL (contians an empty query OR empty square brackets) AND ((contains "members of collections") OR (contains a sort term AND does not contain the Start Over string)) -->
-=======
-  <!-- else if URL (contians an empty query OR empty square brackets) AND contains a sort term AND does not contain the Start Over string -->
->>>>>>> 4ed3cad61fbdfe0125d603c9d2620684b98e22d8
   <!--   add Title Sort string to URL -->
   <!--   got to page -->
   <script type="text/javascript">
@@ -41,11 +37,7 @@
     console.log(urlFacet);
     if ( urlFacet.indexOf("catalog?sort=" ) !== -1){
       window.history.replaceState('page2', 'Title', '/catalog');
-<<<<<<< HEAD
     } else if ( ((urlFacet.indexOf("&q=&") !== -1) || (urlFacet.indexOf("%5B%5D=") !== -1)) && ((urlFacet.indexOf("[member_of_collections_") !== -1) || ((urlFacet.indexOf("&sort=") == -1) && (urlFacet != "?utf8=%E2%9C%93&q=&search_field=all_fields"))) ) {
-=======
-    } else if ( ((urlFacet.indexOf("&q=&") !== -1) || (urlFacet.indexOf("%5B%5D=") !== -1)) && (    (urlFacet.indexOf("[member_of_collections_") !== -1)     || ((urlFacet.indexOf("&sort=") == -1) && (urlFacet != "?utf8=%E2%9C%93&q=&search_field=all_fields"))) ) {
->>>>>>> 4ed3cad61fbdfe0125d603c9d2620684b98e22d8
         var titleSortUrl = urlFacet+"&sort=title_alpha_numeric_ssort+asc";
         window.location = titleSortUrl;
     }

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -32,6 +32,7 @@
   <!-- else if URL (contians an empty query OR empty square brackets) AND ((contains "members of collections") OR (contains a sort term AND does not contain the Start Over string)) -->
   <!--   add Title Sort string to URL -->
   <!--   got to page -->
+  
   <script type="text/javascript">
     var urlFacet = window.location.search;
     if ( urlFacet.indexOf("catalog?sort=" ) !== -1){


### PR DESCRIPTION
Connected to [URS-805](https://jira.library.ucla.edu/browse/URS-805)

### Change default sort order of search results to Title (A-Z) when user is browsing.
See the ticket for details and trade offs.

#### Acceptance criteria:

- [x] If no search terms are provided, the default sort is by Title (A-Z)
- [x] Otherwise default sort is by relevance
- [x] Linted
- [x] Tested

---

#### Files
+ `app/views/catalog/index.html.erb`
