### PR TITLE
URS-912 Add IIIF manifest field (with drag and drop logo) to Collection pages

### DIFF
--- a/app/views/catalog/collection_record/_collection_record.html.erb
+++ b/app/views/catalog/collection_record/_collection_record.html.erb
@@ -11,6 +11,7 @@
   <%= render 'catalog/collection_record/keyword_metadata', document: document %>
 
   <div class='collection-page__btn-row'>
-  <a href="/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=<%= document[:title_tesim][0] %>" class="btn-base btn-base-lg btn-ursus--gold" role="button">Browse items in this collection</a>
+    <a href="/catalog?f%5Bmember_of_collections_ssim%5D%5B%5D=<%= document[:title_tesim][0] %>" class="btn-base btn-base-lg btn-ursus--gold" role="button">Browse items in this collection</a>
   </div>
+
 </div>

--- a/app/views/catalog/collection_record/_find_this_collection_metadata.html.erb
+++ b/app/views/catalog/collection_record/_find_this_collection_metadata.html.erb
@@ -4,16 +4,25 @@
 <% if find_collection.length > 0 %>
   <div class='metadata-block'>
     <h2 class='metadata-block__title'>Find this Collection</h2>
-    <% find_collection.each do |field_name, field| -%>
-      <div class='metadata-block__group--collection-pg'>
+    <div class='metadata-block__group--collection-pg'>
+      <% find_collection.each do |field_name, field| -%>
         <div class="blacklight-<%= field_name.parameterize %> metadata-block__label-key">
           <%= (render_document_show_field_label document, field: field_name).tr(':', '') %>
         </div>
         <div class="blacklight-<%= field_name.parameterize %> metadata-block__label-value">
           <%= doc_presenter.field_value field %>
         </div>
+      <% end %>
+
+      <div class="metadata-block__label-key">MANIFEST URL</div>
+      <div class="metadata-block__label-value">
+        <% collection_ark = @document[:ark_ssi] %>
+        <% link = "http://iiif.library.ucla.edu/collections/" + CGI.escape(collection_ark) %>
+
+        <a href="<%= link %>" target="_blank"><%= image_tag('iiif-logo.png', alt: 'IIIF Manifest') %></a>
       </div>
-    <% end %>
+    </div>
+
     <hr class='divider divider--ursus'>
   </div>
 <% end %>


### PR DESCRIPTION
Connected to [URS-912](https://jira.library.ucla.edu/browse/URS-912)

Acceptance criteria:

- [x] A IIIF logo displays in the "Find this Collection" section of Collection pages

- [x] The IIIF logo can be dragged and dropped onto another IIIF viewer to open the manifest (I'm not sure how this works with collection manifests, so not sure what the expected behavior should be)

- [x] The IIIF logo can be clicked to open the manifest in a new tab/window

<img width="864" alt="Screen Shot 2020-09-14 at 2 59 54 PM" src="https://user-images.githubusercontent.com/751697/93142674-57b40200-f69b-11ea-8a78-da3dc34ce4c2.png">

<img width="1225" alt="Screen Shot 2020-09-14 at 3 00 01 PM" src="https://user-images.githubusercontent.com/751697/93142681-5d114c80-f69b-11ea-8d14-ba89e5671b69.png">

---

#### Changes to be committed:
modified:
+ `app/assets/stylesheets/base/templates/_collection-page.scss
+ `app/views/catalog/collection_record/_collection_record.html.erb`