### PR TITLE
Urs 908 refactor new lines for multi valued fields

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -108,6 +108,7 @@ Rails/OutputSafety:
   Exclude:
     - app/helpers/blacklight/url_helper_behavior.rb
     - app/helpers/blacklight_helper.rb
+    - app/processors/custom_join.rb
 
 Style/BlockComments:
   Exclude:

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -15,12 +15,6 @@ class CatalogController < ApplicationController
 
   include BlacklightHelper
 
-  BREAKS = {
-    words_connector: '<br/>',
-    two_words_connector: '<br/>',
-    last_word_connector: '<br/>'
-  }.freeze
-
   configure_blacklight do |config|
     config.view.gallery.partials = [:gallery]
     # config.view.masonry.partials = [:index]
@@ -147,86 +141,92 @@ class CatalogController < ApplicationController
     # link_to_facet: 'fieldname_sim' (refer to editor on line 162)
     # and in Californica add :facetable to its predicate in app/models/ucla_metadata.rb
     # https://docs.google.com/spreadsheets/d/1Ult1ZpMuyKd92lZ5ODmBA6c7hO1pZGjXHTzN0_BOjeA/edit#gid=0
+    #
+    # Line breaks (separator_options: BREAKS) are set globally in two files:
+    #   config/initializers/blacklight.rb
+    #   app/processors/custom_join.rb
+    #
+    # More details: https://github.com/projectblacklight/blacklight/wiki/value-rendering
 
     # PRIMARY
     # Item Overview
-    config.add_show_field 'title_tesim', label: 'Title', separator_options: BREAKS
-    config.add_show_field 'alternative_title_tesim', label: 'Alternative title', separator_options: BREAKS
-    config.add_show_field 'uniform_title_tesim', label: 'Uniform title', link_to_facet: 'uniform_title_sim', separator_options: BREAKS
-    config.add_show_field 'photographer_tesim', label: 'Photographer', link_to_facet: 'photographer_sim', separator_options: BREAKS
-    config.add_show_field 'architect_tesim', label: 'Architect', link_to_facet: 'architect_sim', separator_options: BREAKS
-    config.add_show_field 'author_tesim', label: 'Author', link_to_facet: 'author_sim', separator_options: BREAKS
-    config.add_show_field 'illuminator_tesim', label: 'Illuminator', link_to_facet: 'illuminator_sim', separator_options: BREAKS
-    config.add_show_field 'scribe_tesim', label: 'Scribe', link_to_facet: 'scribe_sim', separator_options: BREAKS
-    config.add_show_field 'rubricator_tesim', label: 'Rubricator', link_to_facet: 'rubricator_sim', separator_options: BREAKS
-    config.add_show_field 'commentator_tesim', label: 'Commentator', link_to_facet: 'commentator_sim', separator_options: BREAKS
-    config.add_show_field 'translator_tesim', label: 'Translator', link_to_facet: 'translator_sim', separator_options: BREAKS
-    config.add_show_field 'lyricist_tesim', label: 'Lyricist', link_to_facet: 'lyricist_sim', separator_options: BREAKS
-    config.add_show_field 'composer_tesim', label: 'Composer', link_to_facet: 'composer_sim', separator_options: BREAKS
-    config.add_show_field 'illustrator_tesim', label: 'Illustrator', link_to_facet: 'illustrator_sim', separator_options: BREAKS
-    config.add_show_field 'editor_tesim', label: 'Editor', link_to_facet: 'editor_sim', separator_options: BREAKS
-    config.add_show_field 'calligrapher_tesim', label: 'Calligrapher', link_to_facet: 'calligrapher_sim', separator_options: BREAKS
-    config.add_show_field 'engraver_tesim', label: 'Engraver', link_to_facet: 'engraver_sim', separator_options: BREAKS
-    config.add_show_field 'printmaker_tesim', label: 'Printmaker', link_to_facet: 'printmaker_sim', separator_options: BREAKS
-    config.add_show_field 'date_created_tesim', label: 'Date created', separator_options: BREAKS
-    config.add_show_field 'normalized_date_sim', label: 'Date'
+    config.add_show_field 'title_tesim', label: 'Title'
+    config.add_show_field 'alternative_title_tesim', label: 'Alternative title'
+    config.add_show_field 'uniform_title_tesim', label: 'Uniform title', link_to_facet: 'uniform_title_sim'
+    config.add_show_field 'photographer_tesim', label: 'Photographer', link_to_facet: 'photographer_sim'
+    config.add_show_field 'architect_tesim', label: 'Architect', link_to_facet: 'architect_sim'
+    config.add_show_field 'author_tesim', label: 'Author', link_to_facet: 'author_sim'
+    config.add_show_field 'illuminator_tesim', label: 'Illuminator', link_to_facet: 'illuminator_sim'
+    config.add_show_field 'scribe_tesim', label: 'Scribe', link_to_facet: 'scribe_sim'
+    config.add_show_field 'rubricator_tesim', label: 'Rubricator', link_to_facet: 'rubricator_sim'
+    config.add_show_field 'commentator_tesim', label: 'Commentator', link_to_facet: 'commentator_sim'
+    config.add_show_field 'translator_tesim', label: 'Translator', link_to_facet: 'translator_sim'
+    config.add_show_field 'lyricist_tesim', label: 'Lyricist', link_to_facet: 'lyricist_sim'
+    config.add_show_field 'composer_tesim', label: 'Composer', link_to_facet: 'composer_sim'
+    config.add_show_field 'illustrator_tesim', label: 'Illustrator', link_to_facet: 'illustrator_sim'
+    config.add_show_field 'editor_tesim', label: 'Editor', link_to_facet: 'editor_sim'
+    config.add_show_field 'calligrapher_tesim', label: 'Calligrapher', link_to_facet: 'calligrapher_sim'
+    config.add_show_field 'engraver_tesim', label: 'Engraver', link_to_facet: 'engraver_sim'
+    config.add_show_field 'printmaker_tesim', label: 'Printmaker', link_to_facet: 'printmaker_sim'
+    config.add_show_field 'date_created_tesim', label: 'Date created'
+    # 'Normalized date'
     # 'Year'
-    config.add_show_field 'place_of_origin_tesim', label: 'Place of origin', separator_options: BREAKS
-    config.add_show_field 'publisher_tesim', label: 'Publisher', separator_options: BREAKS
-    config.add_show_field 'human_readable_language_tesim', label: 'Language', link_to_facet: 'human_readable_language_sim', separator_options: BREAKS
+    config.add_show_field 'place_of_origin_tesim', label: 'Place of origin'
+    config.add_show_field 'publisher_tesim', label: 'Publisher'
+    config.add_show_field 'human_readable_language_tesim', label: 'Language', link_to_facet: 'human_readable_language_sim'
     config.add_show_field 'member_of_collections_ssim', label: 'Collection', link_to_facet: 'member_of_collections_ssim' unless Flipflop.sinai?
-    config.add_show_field 'creator_tesim', label: 'Creator', link_to_facet: 'creator_sim', separator_options: BREAKS
+    config.add_show_field 'creator_tesim', label: 'Creator', link_to_facet: 'creator_sim'
 
     # IF SINAI ?
-    config.add_show_field 'explicit_tesim', label: 'Explicit', separator_options: BREAKS
-    config.add_show_field 'features_tesim', label: 'Features', link_to_facet: 'features_sim', separator_options: BREAKS
-    config.add_show_field 'incipit_tesim', label: 'Incipit', separator_options: BREAKS
-    config.add_show_field 'inscription_tesim', label: 'Inscription', separator_options: BREAKS
-    config.add_show_field 'script_tesim', label: 'Script', link_to_facet: 'script_sim', separator_options: BREAKS
-    config.add_show_field 'writing_and_hands_tesim', link_to_facet: 'writing_and_hands_sim', label: 'Writing and hands', separator_options: BREAKS
-    config.add_show_field 'writing_system_tesim', link_to_facet: 'writing_system_sim', label: 'Writing system', separator_options: BREAKS
+    config.add_show_field 'explicit_tesim', label: 'Explicit'
+    config.add_show_field 'features_tesim', label: 'Features', link_to_facet: 'features_sim'
+    config.add_show_field 'incipit_tesim', label: 'Incipit'
+    config.add_show_field 'inscription_tesim', label: 'Inscription'
+    config.add_show_field 'script_tesim', label: 'Script'
+    config.add_show_field 'writing_and_hands_tesim', label: 'Writing and hands'
+    config.add_show_field 'writing_system_tesim', label: 'Writing system'
 
     # Notes
-    config.add_show_field 'summary_tesim', label: 'Summary', separator_options: BREAKS
-    config.add_show_field 'description_tesim', label: 'Description', separator_options: BREAKS
-    config.add_show_field 'caption_tesim', label: 'Caption', separator_options: BREAKS
-    config.add_show_field 'contents_note_tesim', label: 'Contents note', separator_options: BREAKS
-    config.add_show_field 'colophon_tesim', label: 'Colophon', separator_options: BREAKS
-    config.add_show_field 'provenance_tesim', label: 'Provenance', separator_options: BREAKS
-    config.add_show_field 'note_tesim', label: 'Note', separator_options: BREAKS
-    config.add_show_field 'toc_tesim', label: 'Table of Contents', separator_options: BREAKS
+    config.add_show_field 'summary_tesim', label: 'Summary'
+    config.add_show_field 'description_tesim', label: 'Description'
+    config.add_show_field 'caption_tesim', label: 'Caption'
+    config.add_show_field 'toc_tesim', label: 'Table of Contents'
+    config.add_show_field 'contents_note_tesim', label: 'Contents note'
+    config.add_show_field 'provenance_tesim', label: 'Provenance'
+    config.add_show_field 'colophon_tesim', label: 'Colophon'
+    config.add_show_field 'note_tesim', label: 'Note'
 
     # Physical description
-    config.add_show_field 'extent_tesim', label: 'Extent', separator_options: BREAKS
-    config.add_show_field 'dimensions_tesim', label: 'Dimensions', separator_options: BREAKS
-    config.add_show_field 'format_tesim', label: 'Format', separator_options: BREAKS
+    config.add_show_field 'format_tesim', label: 'Format'
     # 'Book format'
-    config.add_show_field 'support_tesim', label: 'Support', link_to_facet: 'support_sim', separator_options: BREAKS
-    config.add_show_field 'medium_tesim', label: 'Medium', separator_options: BREAKS
+    config.add_show_field 'medium_tesim', label: 'Medium'
+    config.add_show_field 'support_tesim', label: 'Support'
+    config.add_show_field 'extent_tesim', label: 'Extent'
+    config.add_show_field 'dimensions_tesim', label: 'Dimensions'
     config.add_show_field 'page_layout_ssim', label: 'Page layout'
     config.add_show_field 'binding_note_ssi', label: 'Binding note'
-    config.add_show_field 'condition_note_ssi', label: 'Condition note', separator_options: BREAKS
-    config.add_show_field 'collation_tesim', label: 'Collation', separator_options: BREAKS
-    config.add_show_field 'foliation_tesim', label: 'Foliation', separator_options: BREAKS
-    config.add_show_field 'illustrations_note_tesim', label: 'Illustrations note', separator_options: BREAKS
+    config.add_show_field 'condition_note_ssi', label: 'Condition note'
+    config.add_show_field 'collation_tesim', label: 'Collation'
+    config.add_show_field 'foliation_tesim', label: 'Foliation'
+    config.add_show_field 'illustrations_note_tesim', label: 'Illustrations note'
 
     # Keywords
-    config.add_show_field 'genre_tesim', label: 'Genre', link_to_facet: 'genre_sim', separator_options: BREAKS
-    config.add_show_field 'subject_tesim', label: 'Subject', link_to_facet: 'subject_sim', separator_options: BREAKS
-    config.add_show_field 'subject_topic_tesim', label: 'Subject topic', separator_options: BREAKS
-    config.add_show_field 'named_subject_tesim', label: 'Named subject', link_to_facet: 'named_subject_sim', separator_options: BREAKS
-    config.add_show_field 'subject_geographic_tesim', label: 'Subject geographic', separator_options: BREAKS
-    config.add_show_field 'subject_temporal_tesim', label: 'Subject'
-    config.add_show_field 'location_tesim', label: 'Location', link_to_facet: 'location_sim', separator_options: BREAKS
-    config.add_show_field 'latitude_tesim', label: 'Latitude', separator_options: BREAKS
-    config.add_show_field 'longitude_tesim', label: 'Longitude', separator_options: BREAKS
-    config.add_show_field 'human_readable_resource_type_tesim', label: 'Resource type', link_to_facet: 'human_readable_resource_type_sim', separator_options: BREAKS
+    config.add_show_field 'human_readable_resource_type_tesim', label: 'Resource type', link_to_facet: 'human_readable_resource_type_sim'
+    config.add_show_field 'genre_tesim', label: 'Genre', link_to_facet: 'genre_sim'
+    config.add_show_field 'subject_tesim', label: 'Subject', link_to_facet: 'subject_sim'
+    config.add_show_field 'named_subject_tesim', label: 'Named subject', link_to_facet: 'named_subject_sim'
+    config.add_show_field 'subject_topic_tesim', label: 'Subject topic'
+    # 'Subject geographic'
+    # 'Subject temporal'
+    config.add_show_field 'location_tesim', label: 'Location', link_to_facet: 'location_sim'
+    config.add_show_field 'latitude_tesim', label: 'Latitude'
+    config.add_show_field 'longitude_tesim', label: 'Longitude'
     config.add_show_field 'geographic_coordinates_ssim'
 
     # SECONDARY
     # Find This Item
-    config.add_show_field 'repository_tesim', label: 'Repository', separator_options: BREAKS
-    config.add_show_field 'local_identifier_ssm', label: 'Local identifier', separator_options: BREAKS
+    config.add_show_field 'repository_tesim', label: 'Repository'
+    config.add_show_field 'local_identifier_ssm', label: 'Local identifier'
     config.add_show_field 'oclc_ssi', label: 'OCLC Number'
     config.add_show_field 'iiif_manifest_url_ssi', label: 'Manifest url'
     config.add_show_field 'finding_aid_url_ssm', label: 'Finding aid url'
@@ -234,12 +234,13 @@ class CatalogController < ApplicationController
     config.add_show_field 'ark_ssi', label: 'ARK'
 
     # Access Conditions
+    config.add_show_field 'human_readable_rights_statement_tesim', label: 'Rights statement'
     config.add_show_field 'local_rights_statement_ssim', label: 'Local rights statement'
-    config.add_show_field 'rights_country_tesim', label: 'Rights (country of creation', separator_options: BREAKS
-    config.add_show_field 'rights_holder_tesim', label: 'Rights holder', separator_options: BREAKS
+    config.add_show_field 'rights_country_tesim', label: 'Rights (country of creation'
+    config.add_show_field 'rights_holder_tesim', label: 'Rights holder'
     config.add_show_field 'services_contact_ssm', label: 'Rights contact'
-    config.add_show_field 'license_tesim', label: 'License'
-    config.add_show_field 'funding_note_tesim', label: 'Funding note', separator_options: BREAKS
+    # 'License'
+    config.add_show_field 'funding_note_tesim', label: 'Funding note'
 
     # RECORD INFO
     # 'Depositer'
@@ -254,14 +255,14 @@ class CatalogController < ApplicationController
     # 'IIIF Range'
 
     # NOT USING
-    config.add_show_field 'contributor_tesim', label: 'Contributor', separator_options: BREAKS
+    config.add_show_field 'contributor_tesim', label: 'Contributor'
     config.add_show_field 'dlcs_collection_name_tesim' unless Flipflop.sinai?
-    config.add_show_field 'identifier_tesim', label: 'Identifier', separator_options: BREAKS
+    config.add_show_field 'identifier_tesim', label: 'Identifier'
     # 'Citation'
     # 'Arkivo Checksum'
     # 'Folder'
-    config.add_show_field 'keyword_tesim', label: 'Keyword', separator_options: BREAKS
-    config.add_show_field 'based_near_label_tesim', label: 'Location (based near)', separator_options: BREAKS
+    config.add_show_field 'keyword_tesim', label: 'Keyword'
+    config.add_show_field 'based_near_label_tesim', label: 'Location (based near)'
     # 'Related URL'
 
     # ----------------------------------------------

--- a/app/helpers/ursus/catalog_helper.rb
+++ b/app/helpers/ursus/catalog_helper.rb
@@ -33,13 +33,5 @@ module Ursus
         return description
       end
     end
-
-    402 	
-
-    def field_value_separator
-      ', test '
-    end
-
-
   end
 end

--- a/app/helpers/ursus/catalog_helper.rb
+++ b/app/helpers/ursus/catalog_helper.rb
@@ -33,5 +33,13 @@ module Ursus
         return description
       end
     end
+
+    402 	
+
+    def field_value_separator
+      ', test '
+    end
+
+
   end
 end

--- a/app/processors/custom_join.rb
+++ b/app/processors/custom_join.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# Joins values using configured value or linebreak
+class CustomJoin < Blacklight::Rendering::AbstractStep
+  include ActionView::Helpers::TextHelper
+
+  def render
+    joiner = config.join_with || '<br/>'
+    next_step(safe_join(values, joiner))
+  end
+end

--- a/app/processors/custom_join.rb
+++ b/app/processors/custom_join.rb
@@ -4,7 +4,7 @@ class CustomJoin < Blacklight::Rendering::AbstractStep
   include ActionView::Helpers::TextHelper
 
   def render
-    joiner = config.join_with || '<br/>'
+    joiner = config.join_with || '<br>'.html_safe
     next_step(safe_join(values, joiner))
   end
 end

--- a/config/initializers/blacklight.rb
+++ b/config/initializers/blacklight.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+Blacklight::Rendering::Pipeline.operations = [Blacklight::Rendering::HelperMethod,
+                                              Blacklight::Rendering::LinkToFacet,
+                                              Blacklight::Rendering::Microdata,
+                                              CustomJoin]


### PR DESCRIPTION
Connected to [URS-908](https://jira.library.ucla.edu/browse/URS-908)

### Change default so that metadata fields with multiple values are split with new lines (break tags) in the item detail page

#### Acceptance criteria:

- [x] Metadata fields with multiple values are split with new lines (break tags) in the item detail page

---

#### Files
+ `.rubocop.yml`
+ `app/controllers/catalog_controller.rb`
+ `app/processors/custom_join.rb`
+ `config/initializers/blacklight.rb`
