### PR TITLE
Removes title on Sinai Item Page 

### DIFF
--- a/app/views/catalog/_show_header.html.erb
+++ b/app/views/catalog/_show_header.html.erb
@@ -1,3 +1,4 @@
 <%# bookmark/folder functions -%>
-
+<% if !Flipflop.sinai? %>
   <%= render_document_heading(document, tag: :h1) %>
+<% end %>

--- a/app/views/catalog/work_record/_item_overview_metadata.html.erb
+++ b/app/views/catalog/work_record/_item_overview_metadata.html.erb
@@ -6,6 +6,9 @@
     <h4 class='metadata-block__title'>Item Overview</h4>
     <dl class='metadata-block__group'>
       <% overview.each do |field_name, field| -%>
+        <% if Flipflop.sinai? && field_name == "title_tesim" %>
+          <% next %>
+        <% end %>
         <dt class="blacklight-<%= field_name.parameterize %> metadata-block__label-key">
           <!-- KEY -->
           <%= (render_document_show_field_label document, field: field_name).tr(':', '') %>

--- a/e2e/cypress/integration/sinai_search_spec.js
+++ b/e2e/cypress/integration/sinai_search_spec.js
@@ -22,6 +22,6 @@ describe('Sinai Search', () => {
     cy.get('[id=search]').click();
     cy.get('.search-count__heading').contains('Catalog Results');
     cy.get('.document-position-1 > .document__list-item-wrapper > .document__list-title > a').click();
-    cy.get('.item-page__title');
+    cy.contains('h4','Item Overview');
   });
 });

--- a/e2e/cypress/integration/sinai_work_show_spec.js
+++ b/e2e/cypress/integration/sinai_work_show_spec.js
@@ -1,20 +1,20 @@
 describe('Sinai Work show pages', () => {
   it('Sinai Syriac 2A', () => {
     cy.visit(Cypress.env('SINAI_BASE_URL') + '/catalog/' + encodeURIComponent('ark:/21198/z1x07bdf'));
-    cy.contains('h1', 'Sinai Syriac 2A. Four Gospels');
+    cy.contains('dd', 'ark:/21198/z1x07bdf');
     cy.percySnapshot();
   });
 
   it('MSinai Syriac 45', () => {
     cy.visit(Cypress.env('SINAI_BASE_URL') + '/catalog/' + encodeURIComponent('ark:/21198/z1zs40v7'));
-    cy.contains('h1', 'Sinai Syriac 45');
-    cy.get('.item-page__title')
+    cy.contains('dd', 'ark:/21198/z1zs40v7');
+    //cy.get('.item-page__title')
     cy.percySnapshot();
   });
 
   it('Sinai Syriac 70', () => {
     cy.visit(Cypress.env('SINAI_BASE_URL') + '/catalog/' + encodeURIComponent('ark:/21198/z1s76kq5'));
-    cy.contains('h1', 'Sinai Syriac 70');
+    cy.contains('dd', 'ark:/21198/z1s76kq5');
     cy.percySnapshot();
   });
 });


### PR DESCRIPTION
Connected to [APPS-542](https://jira.library.ucla.edu/browse/APPS-542)

- [x] The "Title" no longer displays anywhere on the Item page

- [x] There is no field above the image viewer
![image](https://user-images.githubusercontent.com/4259468/99460459-c18f9880-28e4-11eb-8512-de4629ada215.png)

![image](https://user-images.githubusercontent.com/4259468/99460492-cbb19700-28e4-11eb-9478-411789586796.png)
