### PR TITLE
Apps 521 sinai add fields to pulldown on search bar2

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -345,7 +345,7 @@ class CatalogController < ApplicationController
 
     # SINAI
     if Flipflop.sinai?
-      config.add_search_field('shelfmark_tsi', label: 'shelfmark') do |field|
+      config.add_search_field('shelfmark_tsi', label: 'Shelfmark') do |field|
         field.solr_parameters = {
           qf: 'shelfmark_tsi',
           pf: ''

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -320,6 +320,8 @@ class CatalogController < ApplicationController
     # since we aren't specifying it otherwise.
 
     search_field_service = ::SearchFieldService.instance
+
+    unless Flipflop.sinai?
     config.add_search_field('all_fields', label: 'All Fields') do |field|
       field.solr_parameters = {
         qf: search_field_service.search_fields
@@ -338,6 +340,8 @@ class CatalogController < ApplicationController
         qf: 'subject_tesim',
         pf: ''
       }
+    end
+
     end
 
     # SINAI

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -320,42 +320,58 @@ class CatalogController < ApplicationController
     # since we aren't specifying it otherwise.
 
     search_field_service = ::SearchFieldService.instance
-
-    unless Flipflop.sinai?
     config.add_search_field('all_fields', label: 'All Fields') do |field|
       field.solr_parameters = {
         qf: search_field_service.search_fields
       }
     end
 
-    config.add_search_field('title_tesim', label: 'Title') do |field|
-      field.solr_parameters = {
-        qf: 'title_tesim',
-        pf: ''
-      }
-    end
-
-    config.add_search_field('subject_tesim', label: 'Subject') do |field|
-      field.solr_parameters = {
-        qf: 'subject_tesim',
-        pf: ''
-      }
-    end
-
-    end
-
-    # SINAI
-    if Flipflop.sinai?
+    # URSUS
+    unless Flipflop.sinai?
       config.add_search_field('title_tesim', label: 'Title') do |field|
         field.solr_parameters = {
           qf: 'title_tesim',
           pf: ''
         }
       end
+      config.add_search_field('subject_tesim', label: 'Subject') do |field|
+        field.solr_parameters = {
+          qf: 'subject_tesim',
+          pf: ''
+        }
+      end
 
-      config.add_search_field('shelfmark_tsi', label: 'Shelfmark') do |field|
+    end
+
+    # SINAI
+    if Flipflop.sinai?
+      config.add_search_field('shelfmark_tsi', label: 'shelfmark') do |field|
         field.solr_parameters = {
           qf: 'shelfmark_tsi',
+          pf: ''
+        }
+      end
+      config.add_search_field('title_tesim descriptive_title_tesim alternative_title_tesim uniform_title_tesim', label: 'Title') do |field|
+        field.solr_parameters = {
+          qf: 'title_tesim descriptive_title_tesim alternative_title_tesim uniform_title_tesim',
+          pf: ''
+        }
+      end
+      config.add_search_field('author_tesim scribe_tesim associated_name_tesim translator_tesim', label: 'Names') do |field|
+        field.solr_parameters = {
+          qf: 'author_tesim scribe_tesim associated_name_tesim translator_tesim',
+          pf: ''
+        }
+      end
+      config.add_search_field('incipit_tesim explicit_tesim', label: 'Incipit/Explicit') do |field|
+        field.solr_parameters = {
+          qf: 'incipit_tesim explicit_tesim',
+          pf: ''
+        }
+      end
+      config.add_search_field('toc_tesim contents_note_tesim', label: 'Table of Contents') do |field|
+        field.solr_parameters = {
+          qf: 'toc_tesim contents_note_tesim',
           pf: ''
         }
       end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -342,9 +342,9 @@ class CatalogController < ApplicationController
 
     # SINAI
     if Flipflop.sinai?
-      config.add_search_field('shelfmark_ssi', label: 'Shelfmark') do |field|
+      config.add_search_field('shelfmark', label: 'Shelfmark') do |field|
         field.solr_parameters = {
-          qf: 'shelfmark',
+          qf: 'shelfmark_ssi',
           pf: ''
         }
       end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -346,6 +346,13 @@ class CatalogController < ApplicationController
 
     # SINAI
     if Flipflop.sinai?
+      config.add_search_field('title_tesim', label: 'Title') do |field|
+        field.solr_parameters = {
+          qf: 'title_tesim',
+          pf: ''
+        }
+      end
+
       config.add_search_field('shelfmark', label: 'Shelfmark') do |field|
         field.solr_parameters = {
           qf: 'shelfmark_ssi',

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -353,7 +353,7 @@ class CatalogController < ApplicationController
         }
       end
 
-      config.add_search_field('shelfmark', label: 'Shelfmark') do |field|
+      config.add_search_field('shelfmark_ssi', label: 'Shelfmark') do |field|
         field.solr_parameters = {
           qf: 'shelfmark_ssi',
           pf: ''

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -353,9 +353,9 @@ class CatalogController < ApplicationController
         }
       end
 
-      config.add_search_field('shelfmark_ssi', label: 'Shelfmark') do |field|
+      config.add_search_field('shelfmark_tsi', label: 'Shelfmark') do |field|
         field.solr_parameters = {
-          qf: 'shelfmark_ssi',
+          qf: 'shelfmark_tsi',
           pf: ''
         }
       end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -344,7 +344,7 @@ class CatalogController < ApplicationController
     if Flipflop.sinai?
       config.add_search_field('shelfmark_ssi', label: 'Shelfmark') do |field|
         field.solr_parameters = {
-          qf: 'shelfmark_ssi',
+          qf: 'shelfmark',
           pf: ''
         }
       end

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -27,7 +27,7 @@
 
 <!-- All Fields -->
     <% if Flipflop.sinai? %>
-    <input type="hidden" name="search_field" value="all_fields">
+    <input type="hidden" name="search_field" value="shelfmark_ssi">
          <!-- do nothing -->
     <% else %>
       <%= select_tag(

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -25,18 +25,14 @@
       </button>
     </div>
 
-<!-- All Fields -->
-    <% if Flipflop.sinai? %>
-    <input type="hidden" name="search_field" value="shelfmark_ssi">
-         <!-- do nothing -->
-    <% else %>
+    <!-- All Fields -->
+    <input type="hidden" name="search_field" value="all_fields">
       <%= select_tag(
-            :search_field,
-            options_for_select(search_fields, h(params[:search_field])),
-            title: t('blacklight.search.form.search_field.title'),
-            class: "custom-select site-searchbar__dropdown"
-          ) %>
-    <% end %>
+        :search_field,
+        options_for_select(search_fields, h(params[:search_field])),
+        title: t('blacklight.search.form.search_field.title'),
+        class: "custom-select site-searchbar__dropdown"
+      ) %>
 
   </div>
   <% end %>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -25,14 +25,13 @@
       </button>
     </div>
 
-    <!-- All Fields -->
-    <input type="hidden" name="search_field" value="all_fields">
+<!-- All Fields -->
       <%= select_tag(
-        :search_field,
-        options_for_select(search_fields, h(params[:search_field])),
-        title: t('blacklight.search.form.search_field.title'),
-        class: "custom-select site-searchbar__dropdown"
-      ) %>
+            :search_field,
+            options_for_select(search_fields, h(params[:search_field])),
+            title: t('blacklight.search.form.search_field.title'),
+            class: "custom-select site-searchbar__dropdown"
+          ) %>
 
   </div>
   <% end %>

--- a/e2e/cypress/integration/sinai_search_spec.js
+++ b/e2e/cypress/integration/sinai_search_spec.js
@@ -21,7 +21,7 @@ describe('Sinai Search', () => {
     cy.get('[id=q]').type('manuscript');
     cy.get('[id=search]').click();
     cy.get('.search-count__heading').contains('Catalog Results');
-    cy.get('.document__list-title > a').click();
+    cy.get('.document-position-1 > .document__list-item-wrapper > .document__list-title > a').click();
     cy.contains('h4','Item Overview');
   });
 

--- a/e2e/cypress/integration/sinai_search_spec.js
+++ b/e2e/cypress/integration/sinai_search_spec.js
@@ -21,7 +21,23 @@ describe('Sinai Search', () => {
     cy.get('[id=q]').type('manuscript');
     cy.get('[id=search]').click();
     cy.get('.search-count__heading').contains('Catalog Results');
-    cy.get('.document-position-1 > .document__list-item-wrapper > .document__list-title > a').click();
+    cy.get('.document__list-title > a').click();
     cy.contains('h4','Item Overview');
+  });
+
+  it('Search Shelfmark Found', () => {
+    cy.get('[id=q]').type('sinai syriac 100');
+    cy.get('select').select('Shelfmark').should('have.value', 'shelfmark_tsi');
+    cy.get('[id=search]').click();
+    cy.get('.search-count__heading').contains('Catalog Results');
+    cy.percySnapshot();
+  });
+
+  it('Search Title Found', () => {
+    cy.get('[id=q]').type('sinai');
+    cy.get('select').select('Title').should('have.value', 'title_tesim descriptive_title_tesim alternative_title_tesim uniform_title_tesim');
+    cy.get('[id=search]').click();
+    cy.get('.search-count__heading').contains('Catalog Results');
+    cy.percySnapshot();
   });
 });


### PR DESCRIPTION
Connected to [APPS-521](https://jira.library.ucla.edu/browse/APPS-521)

### When using the search bar, users can limit their search to the specific fields/categories:

-  Everything
-  Shelfmark (searches the Shelfmark field)
-  Title (searches all title fields: Title, Descriptive title, Alternative title, Uniform title)
-  Names (searches all name fields: Author, Scribe, Associated name, Translator)
-  Incipt/Explicit (searches the Incipt and Explicit fields)
-  Table of Contents (searches Table of Contents and Contents note fields)

#### Acceptance criteria:

- [x] Searches can be limited to specified fields/categories when the user performs a search of the Sinai manuscripts.
- [x] Linted
- [x] Tested

---

#### Files
+ `app/views/catalog/_search_form.html.erb`
+ `app/controllers/catalog_controller.rb`

---

![sinai_search_dropdown](https://user-images.githubusercontent.com/2350153/101116569-3ed03400-359a-11eb-84f3-c1706f665243.jpg)
