### PR TITLE
URS-943 Sinai: Change fields on index (results) page

### DIFF
--- a/app/assets/stylesheets/theme_sinai/components/_si-list-view.scss
+++ b/app/assets/stylesheets/theme_sinai/components/_si-list-view.scss
@@ -6,8 +6,14 @@
   margin-right: 0;
   margin-left: 2rem;
 
+  a,
+  a:visited {
+    color: $sinai-primary;
+  }
+
   a:hover {
     color: $sinai-primary;
+    text-decoration: underline;
   }
 }
 

--- a/app/assets/stylesheets/theme_sinai/components/_si-metadata-block.scss
+++ b/app/assets/stylesheets/theme_sinai/components/_si-metadata-block.scss
@@ -18,4 +18,12 @@
     text-decoration: none;
     color: $sinai-primary;
   }
+
+  .metadata-block__label-key {
+    text-align: left;
+  }
+
+  .metadata-block__label-value--sinai {
+    
+  }
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -225,7 +225,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'format_tesim', label: 'Format'
     # 'Book format'
     config.add_show_field 'medium_tesim', label: 'Medium'
-    config.add_show_field 'support_tesim', label: 'Support', link_to_facet: 'support_tesim'
+    config.add_show_field 'support_tesim', label: 'Support', link_to_facet: 'support_sim'
     config.add_show_field 'extent_tesim', label: 'Extent'
     config.add_show_field 'dimensions_tesim', label: 'Dimensions'
     config.add_show_field 'page_layout_ssim', label: 'Page layout'

--- a/app/presenters/ursus/sinai_index_header_metadata_presenter.rb
+++ b/app/presenters/ursus/sinai_index_header_metadata_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Ursus
+  class SinaiIndexHeaderMetadataPresenter
+    attr_reader :document
+
+    def initialize(document:)
+      @document = document
+      @config = YAML.safe_load(File.open(Rails.root.join('config', 'metadata/sinai_index_header_metadata.yml')))
+    end
+
+    def sinai_index_header_terms
+      @document.slice(*@config.keys)
+    end
+  end
+end

--- a/app/presenters/ursus/sinai_index_metadata_presenter.rb
+++ b/app/presenters/ursus/sinai_index_metadata_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Ursus
+  class SinaiIndexMetadataPresenter
+    attr_reader :document
+
+    def initialize(document:)
+      @document = document
+      @config = YAML.safe_load(File.open(Rails.root.join('config', 'metadata/sinai_index_metadata.yml')))
+    end
+
+    def sinai_index_terms
+      @document.slice(*@config.keys)
+    end
+  end
+end

--- a/app/presenters/ursus/sinai_index_title_metadata_presenter.rb
+++ b/app/presenters/ursus/sinai_index_title_metadata_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Ursus
+  class SinaiIndexTitleMetadataPresenter
+    attr_reader :document
+
+    def initialize(document:)
+      @document = document
+      @config = YAML.safe_load(File.open(Rails.root.join('config', 'metadata/sinai_index_title_metadata.yml')))
+    end
+
+    def sinai_index_title_terms
+      @document.slice(*@config.keys)
+    end
+  end
+end

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -37,8 +37,8 @@
           <dl class='metadata-block__group'>
             <%= render 'catalog/index_title_sinai', document: document %>
             <%= render 'catalog/index_metadata_sinai', document: document %>
-            <br><br>
-            <%= "NOT LOGGED IN" %>
+            <!--<br><br>
+            <%#= "NOT LOGGED IN" %> -->
           </dl>
         </div>
 
@@ -58,8 +58,8 @@
           <dl class='metadata-block__group'>
             <%= render 'catalog/index_title_sinai', document: document %>
             <%= render 'catalog/index_metadata_sinai', document: document %>
-            <br><br>
-            <%= "LOGGED IN" %>
+            <!--<br><br>
+            <%#= "LOGGED IN" %> -->
           </dl>
         </div>
       <% end %>

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -6,13 +6,13 @@
 
       <%# THUMBNAIL %>
       <% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({}, counter: document_counter_with_offset(document_counter)) %>
-          <%# NOT LOGGED IN %>
+          <%# Thumnail NOT logged in %>
           <% if !cookies[:sinai_authenticated] %>
           <div class="document__gallery-thumbnail document__gallery-thumbnail--sinai-generic">
            <a href="#" data-toggle="modal" data-target="#exampleModalCenter">
                 <%= image_tag("sinai/sinai-generic-thumbnail.png") %>
               </a>
-          <%# LOGGED IN %>
+          <%# Thumbnail logged in%>
           <% else %>
           <div class="document__gallery-thumbnail document__gallery-thumbnail--sinai">
             <%= tn %>
@@ -22,72 +22,20 @@
       <!-- ----------------- -->
 
       <span class="document__list-title document__list-title--sinai">
-        <%# NOT LOGGED IN %>
+        <%# Header NOT Logged in %>
         <% if !cookies[:sinai_authenticated] %>
           <%# cookies[:request_original_url] = request.original_url %>
-          <a href="#" data-toggle="modal" data-target="#exampleModalCenter">
-          <%= "NOT LOGGED IN" %>
-          <%#= render "index_header_sinai" %>
-            <%# document['title_tesim'][0] %>
-            <%#= document['date_created_tesim'][0] %>
-            <%#= document['form_ssi'][0] %>
-            <%#= document['extent_tesim'][0] %>
-            Shelfmark: <%= document['shelfmark_ssi'] %>
+          <header class='document__list-header'>
+            <a href="#" data-toggle="modal" data-target="#exampleModalCenter">
+              <%= document['shelfmark_ssi'] %>, <%= document['date_created_tesim'][0] %>, <%= document['form_ssi'] %>, <%= document['date_created_tesim'][0] %>, <%= document['extent_tesim'][0] %>
+            </a>
+          </header>
 
-<!-- OOOOOOOOOOOOOOOOOO -->
-<%# SINAI ONLY %>
-<%# doc_presenter = index_presenter(document) %>
-<%= sinai_index_header = Ursus::SinaiIndexHeaderMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_header_terms %>
-<%# sinai_index_header returns: {"date_created_tesim"=>#<Blacklight::Configuration::ShowField label="Date created", key="date_created_tesim", field="date_created_tesim", if=true, unless=false>, "extent_tesim"=>#<Blacklight::Configuration::ShowField label="Extent", key="extent_tesim", field="extent_tesim", if=true, unless=false>} %>
-
-
-<% if sinai_index_header.length > 0 %>
-  <header class= 'document__list-header document__list-header--sinai'>
-    <span class='document__list-item-link--sinai'>
-      <% sinai_index_header.each do |index, field_name, field| -%>
-      Index:<%= index %><br>
-      Field name: <%= field_name%><br>
-      Field: <%= field %>
-        <%#= doc_presenter.field_value field %> 
-        <%# if index < sinai_index_header.length %>
-          <%#= ', ' %>
-        <%# end %>
-      <% end %>
-    </span>
-  </header>
-<% end %>
-
-<header class='document__list-header document__list-header--sinai'>
-  <% all_header_fields = "" %>
-
-  <% if sinai_index_header['shelfmark_ssi'] %>
-    <% all_header_fields << ("<span class='document__list-item-link--sinai'>" + (link_to_document document, (doc_presenter.field_value sinai_index_header['shelfmark_ssi'])) + ', ' + '</span>') %>
-  <% end %>
-
-  <% header = ['date_created_tesim', 'form_ssi', 'extent_tesim'] %>
-  <% header.each do |field| -%>
-    <% if sinai_index_header[field] %><%# if field exists append to variable header %>
-      <% header_field = (doc_presenter.field_value sinai_index_header[field]) + ', ' %>
-      <% all_header_fields << header_field %>
-    <% end %>
-    <%= all_header_fields.delete_suffix(', ').html_safe %>
-  <% end %>
-</header>
-<!-- OOOOOOOOOOOOOOOOOO -->
-
-
-
-
-
-
-
-          </a>
-
-      <%# LOGGED IN %>
+      <%# Header Logged in %>
       <% else %>
       <%= "LOGGED IN" %>
-        <% if counter = document_counter_with_offset(document_counter) %>
-          <%#= link_to_document(document, counter: counter) %>
+      <%# link all to the work %><% link_to document['shelfmark_ssi'],  %>
+        <%= document['shelfmark_ssi'] %>, <%= document['date_created_tesim'][0] %>, <%= document['form_ssi'] %>, <%= document['date_created_tesim'][0] %>, <%= document['extent_tesim'][0] %>
         <% end %>
       <% end %>
       </span>

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -4,52 +4,66 @@
   <div class="document__list-item-wrapper document__list-item-wrapper--sinai">
     <!-- default partial to display solr document fields in catalog index view -->
 
-      <%# THUMBNAIL %>
-      <% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({}, counter: document_counter_with_offset(document_counter)) %>
-          <%# Thumnail NOT logged in %>
-          <% if !cookies[:sinai_authenticated] %>
-          <div class="document__gallery-thumbnail document__gallery-thumbnail--sinai-generic">
-           <a href="#" data-toggle="modal" data-target="#exampleModalCenter">
-                <%= image_tag("sinai/sinai-generic-thumbnail.png") %>
-              </a>
-          <%# Thumbnail logged in%>
-          <% else %>
-          <div class="document__gallery-thumbnail document__gallery-thumbnail--sinai">
-            <%= tn %>
-          <% end %>
-        </div>
-      <% end %>
-      <!-- ----------------- -->
-
-      <span class="document__list-title document__list-title--sinai">
-
-        <%# Header NOT LOGGED IN %>
+    <%# THUMBNAIL %>
+    <% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({}, counter: document_counter_with_offset(document_counter)) %>
+        <%# Thumnail NOT logged in %>
         <% if !cookies[:sinai_authenticated] %>
-          <%# cookies[:request_original_url] = request.original_url %>
-          <%= "NOT LOGGED IN" %>
-          <br><br>
-          <header class='document__list-header'>
-            <a href="#" data-toggle="modal" data-target="#exampleModalCenter">
-              <%= render 'catalog/index_header_sinai', document: document %>
+        <div class="document__gallery-thumbnail document__gallery-thumbnail--sinai-generic">
+          <a href="#" data-toggle="modal" data-target="#exampleModalCenter">
+              <%= image_tag("sinai/sinai-generic-thumbnail.png") %>
             </a>
-          </header>
-          <div class='metadata-block'>
-            <dl class='metadata-block__group'>
-              <%= render 'catalog/index_title_sinai', document: document %>
-              <%= render 'catalog/index_metadata_sinai', document: document %>
-            </dl>
-          </div>
+        <%# Thumbnail logged in%>
+        <% else %>
+        <div class="document__gallery-thumbnail document__gallery-thumbnail--sinai">
+          <%= tn %>
+        <% end %>
+      </div>
+    <% end %>
+    <!-- ----------------- -->
 
-      <%# Header LOGGED IN %>
+    <span class="document__list-title document__list-title--sinai">
+
+      <% if !cookies[:sinai_authenticated] %>
+        <%# Sinai NOT LOGGED IN %>
+        <%# cookies[:request_original_url] = request.original_url %>
+
+        <header class='document__list-header'>
+          <%# link the header to the block access modal%>
+          <a href="#" data-toggle="modal" data-target="#exampleModalCenter">
+            <%= render 'catalog/index_header_sinai', document: document %>
+          </a>
+        </header>
+        <div class='metadata-block'>
+          <dl class='metadata-block__group'>
+            <%= render 'catalog/index_title_sinai', document: document %>
+            <%= render 'catalog/index_metadata_sinai', document: document %>
+            <br><br>
+            <%= "NOT LOGGED IN" %>
+          </dl>
+        </div>
+
       <% else %>
-        <%= "LOGGED IN" %>
-        <br><br>
+        <%# Sinai LOGGED IN %>
         <%# link the header to the work by the ark %>
         <% the_ark = CGI.escape document['ark_ssi'] %>
         <% index_header_sinai = render 'catalog/index_header_sinai', document: document %>
-        <%= link_to index_header_sinai, "/catalog/#{the_ark}" %>
+
+        <header class='document__list-header'>
+          <%# link the header to the work by the ark %>
+          <a href="#" data-toggle="modal" data-target="#exampleModalCenter">
+            <%= link_to index_header_sinai, "/catalog/#{the_ark}" %>
+          </a>
+        </header>
+        <div class='metadata-block'>
+          <dl class='metadata-block__group'>
+            <%= render 'catalog/index_title_sinai', document: document %>
+            <%= render 'catalog/index_metadata_sinai', document: document %>
+            <br><br>
+            <%= "LOGGED IN" %>
+          </dl>
+        </div>
       <% end %>
-      </span>
+    </span>
   </div>
 
 <!-- URSUS -->
@@ -59,9 +73,9 @@
     <!-- default partial to display solr document fields in catalog index view -->
     <dl class="document-metadata document__list-metadata-group">
       <% doc_presenter.fields_to_render.each do | field_name, field | %>
-      <% if field_name == "member_of_collections_ssim" %>
-        <% if document[:member_of_collections_ssim] && document[:member_of_collection_ids_ssim] %>
-          <dt class="document__list-metadata-key document__list-metadata-key--ursus blacklight-<%= field_name.parameterize %>">
+        <% if field_name == "member_of_collections_ssim" %>
+          <% if document[:member_of_collections_ssim] && document[:member_of_collection_ids_ssim] %>
+            <dt class="document__list-metadata-key document__list-metadata-key--ursus blacklight-<%= field_name.parameterize %>">
             <%= render_index_field_label document, field: field_name %>
           </dt>
           <dd class="document__list-metadata-value document__list-metadata-value--ursus blacklight-<%= field_name.parameterize %>">
@@ -69,9 +83,9 @@
               <% document[:member_of_collections_ssim].each_with_index do | member, index | %>
                 <%= link_to member, "/catalog/#{document[:member_of_collection_ids_ssim][index]}" %><br>
               <% end %>
-              <% else %>
-                <%= link_to document[:member_of_collections_ssim][0], "/catalog/#{document[:member_of_collection_ids_ssim][0]}" %>
-              <% end %>
+            <% else %>
+              <%= link_to document[:member_of_collections_ssim][0], "/catalog/#{document[:member_of_collection_ids_ssim][0]}" %>
+            <% end %>
           </dd>
         <% end %>
 

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -33,6 +33,12 @@
               <%= render 'catalog/index_header_sinai', document: document %>
             </a>
           </header>
+          <div class='metadata-block'>
+            <dl class='metadata-block__group'>
+              <%= render 'catalog/index_title_sinai', document: document %>
+              <%= render 'catalog/index_metadata_sinai', document: document %>
+            </dl>
+          </div>
 
       <%# Header LOGGED IN %>
       <% else %>

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -1,37 +1,100 @@
-<% if Flipflop.sinai? %><!-- SINAI -->
+<!-- SINAI -->
+<% if Flipflop.sinai? %>
   <% doc_presenter = index_presenter(document) %>
   <div class="document__list-item-wrapper document__list-item-wrapper--sinai">
     <!-- default partial to display solr document fields in catalog index view -->
 
+      <%# THUMBNAIL %>
       <% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({}, counter: document_counter_with_offset(document_counter)) %>
+          <%# NOT LOGGED IN %>
           <% if !cookies[:sinai_authenticated] %>
           <div class="document__gallery-thumbnail document__gallery-thumbnail--sinai-generic">
            <a href="#" data-toggle="modal" data-target="#exampleModalCenter">
                 <%= image_tag("sinai/sinai-generic-thumbnail.png") %>
               </a>
+          <%# LOGGED IN %>
           <% else %>
           <div class="document__gallery-thumbnail document__gallery-thumbnail--sinai">
             <%= tn %>
           <% end %>
         </div>
       <% end %>
+      <!-- ----------------- -->
 
       <span class="document__list-title document__list-title--sinai">
+        <%# NOT LOGGED IN %>
         <% if !cookies[:sinai_authenticated] %>
           <%# cookies[:request_original_url] = request.original_url %>
           <a href="#" data-toggle="modal" data-target="#exampleModalCenter">
-            <%= document['title_tesim'][0] %>
+          <%= "NOT LOGGED IN" %>
+          <%#= render "index_header_sinai" %>
+            <%# document['title_tesim'][0] %>
+            <%#= document['date_created_tesim'][0] %>
+            <%#= document['form_ssi'][0] %>
+            <%#= document['extent_tesim'][0] %>
+            Shelfmark: <%= document['shelfmark_ssi'] %>
+
+<!-- OOOOOOOOOOOOOOOOOO -->
+<%# SINAI ONLY %>
+<%# doc_presenter = index_presenter(document) %>
+<%= sinai_index_header = Ursus::SinaiIndexHeaderMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_header_terms %>
+<%# sinai_index_header returns: {"date_created_tesim"=>#<Blacklight::Configuration::ShowField label="Date created", key="date_created_tesim", field="date_created_tesim", if=true, unless=false>, "extent_tesim"=>#<Blacklight::Configuration::ShowField label="Extent", key="extent_tesim", field="extent_tesim", if=true, unless=false>} %>
+
+
+<% if sinai_index_header.length > 0 %>
+  <header class= 'document__list-header document__list-header--sinai'>
+    <span class='document__list-item-link--sinai'>
+      <% sinai_index_header.each do |index, field_name, field| -%>
+      Index:<%= index %><br>
+      Field name: <%= field_name%><br>
+      Field: <%= field %>
+        <%#= doc_presenter.field_value field %> 
+        <%# if index < sinai_index_header.length %>
+          <%#= ', ' %>
+        <%# end %>
+      <% end %>
+    </span>
+  </header>
+<% end %>
+
+<header class='document__list-header document__list-header--sinai'>
+  <% all_header_fields = "" %>
+
+  <% if sinai_index_header['shelfmark_ssi'] %>
+    <% all_header_fields << ("<span class='document__list-item-link--sinai'>" + (link_to_document document, (doc_presenter.field_value sinai_index_header['shelfmark_ssi'])) + ', ' + '</span>') %>
+  <% end %>
+
+  <% header = ['date_created_tesim', 'form_ssi', 'extent_tesim'] %>
+  <% header.each do |field| -%>
+    <% if sinai_index_header[field] %><%# if field exists append to variable header %>
+      <% header_field = (doc_presenter.field_value sinai_index_header[field]) + ', ' %>
+      <% all_header_fields << header_field %>
+    <% end %>
+    <%= all_header_fields.delete_suffix(', ').html_safe %>
+  <% end %>
+</header>
+<!-- OOOOOOOOOOOOOOOOOO -->
+
+
+
+
+
+
+
           </a>
 
-       <% else %>
-          <% if counter = document_counter_with_offset(document_counter) %>
-            <%= link_to_document(document, counter: counter) %>
-          <% end %>
+      <%# LOGGED IN %>
+      <% else %>
+      <%= "LOGGED IN" %>
+        <% if counter = document_counter_with_offset(document_counter) %>
+          <%#= link_to_document(document, counter: counter) %>
+        <% end %>
       <% end %>
       </span>
   </div>
 
-<% else %><!-- URSUS -->
+<!-- URSUS -->
+<% else %>
   <% doc_presenter = index_presenter(document) %>
   <div class="document__list-item-wrapper">
     <!-- default partial to display solr document fields in catalog index view -->

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -22,21 +22,26 @@
       <!-- ----------------- -->
 
       <span class="document__list-title document__list-title--sinai">
-        <%# Header NOT Logged in %>
+
+        <%# Header NOT LOGGED IN %>
         <% if !cookies[:sinai_authenticated] %>
           <%# cookies[:request_original_url] = request.original_url %>
+          <%= "NOT LOGGED IN" %>
+          <br><br>
           <header class='document__list-header'>
             <a href="#" data-toggle="modal" data-target="#exampleModalCenter">
-              <%= document['shelfmark_ssi'] %>, <%= document['date_created_tesim'][0] %>, <%= document['form_ssi'] %>, <%= document['date_created_tesim'][0] %>, <%= document['extent_tesim'][0] %>
+              <%= render 'catalog/index_header_sinai', document: document %>
             </a>
           </header>
 
-      <%# Header Logged in %>
+      <%# Header LOGGED IN %>
       <% else %>
-      <%= "LOGGED IN" %>
-      <%# link all to the work %><% link_to document['shelfmark_ssi'],  %>
-        <%= document['shelfmark_ssi'] %>, <%= document['date_created_tesim'][0] %>, <%= document['form_ssi'] %>, <%= document['date_created_tesim'][0] %>, <%= document['extent_tesim'][0] %>
-        <% end %>
+        <%= "LOGGED IN" %>
+        <br><br>
+        <%# link the header to the work by the ark %>
+        <% the_ark = CGI.escape document['ark_ssi'] %>
+        <% index_header_sinai = render 'catalog/index_header_sinai', document: document %>
+        <%= link_to index_header_sinai, "/catalog/#{the_ark}" %>
       <% end %>
       </span>
   </div>

--- a/app/views/catalog/_index_header.html.erb
+++ b/app/views/catalog/_index_header.html.erb
@@ -1,20 +1,21 @@
 <%# header bar for doc items in index view -%>
+<%# URSUS ONLY %>
 <% if not Flipflop.sinai? %>
-<header class='document__list-header'>
-  <%# main title container for doc partial view
-      How many bootstrap columns need to be reserved
-      for bookmarks control depends on size. -%>
-  <% document_actions = capture do %>
-    <%# bookmark functions for items/docs -%>
-    <%= render_index_doc_actions document, wrapping_class: 'index-document-functions' %>
-  <% end %>
-
-  <h3 class="document__list-title document__list-title--ursus <%= document_actions.present? %>">
-    <% if counter = document_counter_with_offset(document_counter) %>
+  <header class='document__list-header'>
+    <%# main title container for doc partial view
+        How many bootstrap columns need to be reserved
+        for bookmarks control depends on size. -%>
+    <% document_actions = capture do %>
+      <%# bookmark functions for items/docs -%>
+      <%= render_index_doc_actions document, wrapping_class: 'index-document-functions' %>
     <% end %>
-    <%= link_to_document document, counter: counter %>
-  </h3>
 
-  <%= document_actions %>
-</header>
+    <h3 class="document__list-title document__list-title--ursus <%= document_actions.present? %>">
+      <% if counter = document_counter_with_offset(document_counter) %>
+      <% end %>
+      <%= link_to_document document, counter: counter %>
+    </h3>
+
+    <%= document_actions %>
+  </header>
 <% end %>

--- a/app/views/catalog/_index_header_sinai.html.erb
+++ b/app/views/catalog/_index_header_sinai.html.erb
@@ -11,5 +11,5 @@
     <% header_field = (doc_presenter.field_value field) + ', ' %>
     <% concatonated_header << header_field %>
   <% end %>
-  <%= concatonated_header.delete_suffix(', ').html_safe  %>
+  <%= concatonated_header.delete_suffix(', ').html_safe %>
 <% end %>

--- a/app/views/catalog/_index_header_sinai.html.erb
+++ b/app/views/catalog/_index_header_sinai.html.erb
@@ -1,0 +1,21 @@
+<%# SINAI ONLY %>
+<% doc_presenter = index_presenter(document) %>
+<% sinai_index_header = Ursus::SinaiIndexHeaderMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_header_terms %>
+<%# sinai_index_header returns: {"date_created_tesim"=>#<Blacklight::Configuration::ShowField label="Date created", key="date_created_tesim", field="date_created_tesim", if=true, unless=false>, "extent_tesim"=>#<Blacklight::Configuration::ShowField label="Extent", key="extent_tesim", field="extent_tesim", if=true, unless=false>} %>
+
+<header class='document__list-header document__list-header--sinai'>
+  <% all_header_fields = "" %>
+
+  <% if sinai_index_header['shelfmark_ssi'] %>
+    <% all_header_fields << ("<span class='document__list-item-link--sinai'>" + (link_to_document document, (doc_presenter.field_value sinai_index_header['shelfmark_ssi'])) + ', ' + '</span>') %>
+  <% end %>
+
+  <% header = ['date_created_tesim', 'form_ssi', 'extent_tesim'] %>
+  <% header.each do |field| -%>
+    <% if sinai_index_header[field] %><%# if field exists append to variable header %>
+      <% header_field = (doc_presenter.field_value sinai_index_header[field]) + ', ' %>
+      <% all_header_fields << header_field %>
+    <% end %>
+    <%= all_header_fields.delete_suffix(', ').html_safe %>
+  <% end %>
+</header>

--- a/app/views/catalog/_index_header_sinai.html.erb
+++ b/app/views/catalog/_index_header_sinai.html.erb
@@ -1,17 +1,15 @@
 <%# SINAI ONLY %>
-<% doc_presenter = index_presenter(document) %>
+<%# (this needs the show_presenter or it does not work) %>
+
+<% doc_presenter = show_presenter(document) %>
 <% sinai_index_header = Ursus::SinaiIndexHeaderMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_header_terms %>
 
-<header class='document__list-header document__list-header--sinai'>
-  <% all_header_fields = "" %>
+<% if sinai_index_header.length > 0 %>
+  <% concatonated_header = "" %>
 
-
-  <% header = ['shelfmark_ssi', 'date_created_tesim', 'form_ssi', 'extent_tesim'] %>
-  <% header.each do |field| -%>
-    <% if sinai_index_header[field] %><%# if field exists append to variable header %>
-      <% header_field = (doc_presenter.field_value sinai_index_header[field]) + ', ' %>
-      <% all_header_fields << header_field %>
-    <% end %>
-    <%= all_header_fields.delete_suffix(', ').html_safe %>
+  <% sinai_index_header.each do |field_name, field| %>
+    <% header_field = (doc_presenter.field_value field) + ', ' %>
+    <% concatonated_header << header_field %>
   <% end %>
-</header>
+  <%= concatonated_header.delete_suffix(', ').html_safe  %>
+<% end %>

--- a/app/views/catalog/_index_header_sinai.html.erb
+++ b/app/views/catalog/_index_header_sinai.html.erb
@@ -1,16 +1,12 @@
 <%# SINAI ONLY %>
 <% doc_presenter = index_presenter(document) %>
 <% sinai_index_header = Ursus::SinaiIndexHeaderMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_header_terms %>
-<%# sinai_index_header returns: {"date_created_tesim"=>#<Blacklight::Configuration::ShowField label="Date created", key="date_created_tesim", field="date_created_tesim", if=true, unless=false>, "extent_tesim"=>#<Blacklight::Configuration::ShowField label="Extent", key="extent_tesim", field="extent_tesim", if=true, unless=false>} %>
 
 <header class='document__list-header document__list-header--sinai'>
   <% all_header_fields = "" %>
 
-  <% if sinai_index_header['shelfmark_ssi'] %>
-    <% all_header_fields << ("<span class='document__list-item-link--sinai'>" + (link_to_document document, (doc_presenter.field_value sinai_index_header['shelfmark_ssi'])) + ', ' + '</span>') %>
-  <% end %>
 
-  <% header = ['date_created_tesim', 'form_ssi', 'extent_tesim'] %>
+  <% header = ['shelfmark_ssi', 'date_created_tesim', 'form_ssi', 'extent_tesim'] %>
   <% header.each do |field| -%>
     <% if sinai_index_header[field] %><%# if field exists append to variable header %>
       <% header_field = (doc_presenter.field_value sinai_index_header[field]) + ', ' %>

--- a/app/views/catalog/_index_metadata_sinai.html.erb
+++ b/app/views/catalog/_index_metadata_sinai.html.erb
@@ -1,0 +1,18 @@
+<%# SINAI ONLY %>
+<%# (this needs the show_presenter or it does not work) %>
+
+<% doc_presenter = show_presenter(document) %>
+<% sinai_index_metadata= Ursus::SinaiIndexMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_terms %>
+
+<% if sinai_index_metadata.length > 0 %>
+  <% sinai_index_metadata.each do |field_name, field| -%>
+    <dt class="metadata-block__label-key">
+      <!-- KEY -->
+      <%= (render_document_show_field_label document, field: field_name).tr(':', '') %>
+    </dt>
+    <!-- VALUE -->
+    <dd class="metadata-block__label-value">
+      <%= doc_presenter.field_value field %>
+    </dd>
+  <% end %>
+<% end %>

--- a/app/views/catalog/_index_metadata_sinai.html.erb
+++ b/app/views/catalog/_index_metadata_sinai.html.erb
@@ -2,7 +2,7 @@
 <%# (this needs the show_presenter or it does not work) %>
 
 <% doc_presenter = show_presenter(document) %>
-<% sinai_index_metadata= Ursus::SinaiIndexMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_terms %>
+<% sinai_index_metadata = Ursus::SinaiIndexMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_terms %>
 
 <% if sinai_index_metadata.length > 0 %>
   <% sinai_index_metadata.each do |field_name, field| -%>

--- a/app/views/catalog/_index_title_sinai.html.erb
+++ b/app/views/catalog/_index_title_sinai.html.erb
@@ -1,0 +1,26 @@
+<%# SINAI ONLY %>
+<%# (this needs the show_presenter or it does not work) %>
+
+<% doc_presenter = show_presenter(document) %>
+<% sinai_index_title = Ursus::SinaiIndexTitleMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_title_terms %>
+
+<% if sinai_index_title.length > 0 %>
+  <% concatonated_title_key = "TITLE" %>
+  <% concatonated_title = "" %>
+
+  <% sinai_index_title.each do |field_name, field| %>
+    <% title_field = (doc_presenter.field_value field) + ', ' %>
+    <% concatonated_title << title_field %>
+  <% end %>
+
+  <% concat_title = concatonated_title.delete_suffix(', ').html_safe %>
+
+  <dt class="metadata-block__label-key">
+    <!-- KEY -->
+    <%= concatonated_title_key %>
+  </dt>
+  <!-- VALUE -->
+  <dd class="metadata-block__label-value">
+    <%= concat_title %>
+  </dd>
+<% end %>

--- a/config/metadata/sinai_index_header_metadata.yml
+++ b/config/metadata/sinai_index_header_metadata.yml
@@ -1,0 +1,5 @@
+shelfmark_ssi: 'Shelfmark'
+date_created_tesim: 'Date Created'
+form_ssi: 'Form'
+extent_tesim: 'Format'
+member_of_collections_ssim: 'Collection'

--- a/config/metadata/sinai_index_header_metadata.yml
+++ b/config/metadata/sinai_index_header_metadata.yml
@@ -1,5 +1,4 @@
 shelfmark_ssi: 'Shelfmark'
 date_created_tesim: 'Date Created'
-form_ssi: 'Form'
 extent_tesim: 'Format'
 member_of_collections_ssim: 'Collection'

--- a/config/metadata/sinai_index_metadata.yml
+++ b/config/metadata/sinai_index_metadata.yml
@@ -1,0 +1,2 @@
+human_readable_language_tesim: 'Format'
+genre_tesim: 'Genre'

--- a/config/metadata/sinai_index_title_metadata.yml
+++ b/config/metadata/sinai_index_title_metadata.yml
@@ -1,0 +1,2 @@
+uniform_title_tesim: 'Title'
+descriptive_title_tesim: 'Title'

--- a/default.env
+++ b/default.env
@@ -16,7 +16,7 @@ RAILS_SERVE_STATIC_FILES=true
 RAILS_HOST=localhost
 
 # skip the auth check in development - don't set this in prod!
-SINAI_ID_BYPASS=true
+# SINAI_ID_BYPASS=true
 
 # The solr for the Californica environment that this Ursus environment will use as its data source
 SOLR_URL=http://127.0.0.1:8983/solr/ursus

--- a/docker-compose-standalone.yml
+++ b/docker-compose-standalone.yml
@@ -36,7 +36,8 @@ services:
       - ./docker.env
     environment:
       DATABASE_NAME: sinai
-      SOLR_URL: http://solr:8983/solr/sinai
+      # SOLR_URL: http://solr:8983/solr/sinai
+      SOLR_URL: http://host.docker.internal:6983/solr/californica
       SOLR_TEST_URL: http://solr_test:8983/solr/sinai
       DATABASE_USERNAME: ursus
       DATABASE_PASSWORD: ursus


### PR DESCRIPTION
1. Line 1: [Shelfmark], [Date.creation], [Format.extent], [Collection]
2. Line 2: Title(s): 
3. Line 3: Language(s): [Language], Language
4. Line 4: Genre(s): [Genre], [Genre]...

#### Acceptance criteria:
- [x] The "Title" field is removed from the Index page
- [x] Fields are added and organized following the layout described above
- [x] In line 2, the Title values are pulled from the Uniform title and Descriptive title fields
- [x] Uniform title is a clickable facet that results in a search of the facet term
- [x] Genre and Language terms are clickable facets that results in a search of the facet term