### PR TITLE
Fix Sinai default sort to Title (A-Z)

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -115,7 +115,7 @@ class CatalogController < ApplicationController
       config.add_facet_field 'features_sim', limit: 7, label: 'Features'
       config.add_facet_field 'support_sim', limit: 7, label: 'Support'
       config.add_facet_field 'form_sim', limit: 7, label: 'Form'
-      config.add_facet_field 'title_sim', limit: 7
+      config.add_facet_field 'names_sim', limit: 7, label: 'Names'
 
     # URSUS
     else

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -115,6 +115,7 @@ class CatalogController < ApplicationController
       config.add_facet_field 'features_sim', limit: 7, label: 'Features'
       config.add_facet_field 'support_sim', limit: 7, label: 'Support'
       config.add_facet_field 'form_sim', limit: 7, label: 'Form'
+      config.add_facet_field 'title_sim', limit: 7
 
     # URSUS
     else

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -54,15 +54,19 @@
       <%= render 'search_results' %>
     </div>
   <% end %>
-
-  <!-- add Title Sort -->
-  <script type="text/javascript">
-    var urlFacet = window.location.search;
-    if ( urlFacet.indexOf("catalog?sort=" ) !== -1){
-      window.history.replaceState('page2', 'Title', '/catalog');
-    } else if ( ((urlFacet.indexOf("&q=&") !== -1) || (urlFacet.indexOf("%5B%5D=") !== -1)) && ((urlFacet.indexOf("[member_of_collections_") !== -1) || ((urlFacet.indexOf("&sort=") == -1) && (urlFacet != "?utf8=%E2%9C%93&q=&search_field=all_fields"))) ) {
-        var titleSortUrl = urlFacet+"&sort=title_alpha_numeric_ssort+asc";
-        window.location = titleSortUrl;
-    }
-  </script>
 <% end %>
+
+<!-- add Title/Shelfmark Sort -->
+<script type="text/javascript">
+  var urlFacet = window.location.search;
+  if ( urlFacet.indexOf("catalog?sort=" ) !== -1){
+    window.history.replaceState('page2', 'Title', '/catalog');
+  } else if ( ((urlFacet.indexOf("&q=&") !== -1) || (urlFacet.indexOf("%5B%5D=") !== -1)) && ((urlFacet.indexOf("[member_of_collections_") !== -1) || ((urlFacet.indexOf("&sort=") == -1) && (urlFacet != "?utf8=%E2%9C%93&q=&search_field=all_fields"))) ) {
+    <% if Flipflop.sinai? %>
+      var titleSortUrl = urlFacet+"&sort=shelfmark_alpha_numeric_ssort+asc";
+    <% else %>
+      var titleSortUrl = urlFacet+"&sort=title_alpha_numeric_ssort+asc";
+    <% end %>
+      window.location = titleSortUrl;
+  }
+</script>


### PR DESCRIPTION
Connected to [URS-941](https://jira.library.ucla.edu/browse/URS-941)

### Fix Sinai default sort to Title (A-Z)

Related to [URS-805](https://jira.library.ucla.edu/browse/URS-805): Set default sort to Title (A-Z)

#### Acceptance Criteria:

- [x] If no search terms are provided, the default sort is by Title (A-Z)
- [x] Otherwise default sort is by relevance
- [x] Linted
- [x] Tested

---

#### Files
+ `app/controllers/catalog_controller.rb`
+ `app/views/catalog/index.html.erb`

