### PR TITLE
Update Sinai typography

### DIFF
--- a/app/assets/stylesheets/base/components/_metadata-block.scss
+++ b/app/assets/stylesheets/base/components/_metadata-block.scss
@@ -3,8 +3,8 @@
 }
 
 .metadata-block-list {
-  font-weight: 300;
   margin-bottom: 0;
+  font-weight: 300;
 }
 
 .metadata-block__title {

--- a/app/assets/stylesheets/base/components/_metadata-block.scss
+++ b/app/assets/stylesheets/base/components/_metadata-block.scss
@@ -3,6 +3,7 @@
 }
 
 .metadata-block-list {
+  font-weight: 300;
   margin-bottom: 0;
 }
 

--- a/app/assets/stylesheets/theme_sinai/components/_si-facets.scss
+++ b/app/assets/stylesheets/theme_sinai/components/_si-facets.scss
@@ -5,7 +5,16 @@
 }
 
 .facets__navbar-heading--sinai {
+  padding-bottom: 2rem;
+  font-size: $text-20;
+  font-family: 'Dosis', sans-serif;
   font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+
+  @media (min-width: 800px) {
+    font-size: $text-24;
+  }
 
   @media (max-width: 991px) {
     color: $white;

--- a/app/assets/stylesheets/theme_sinai/elements/_si-body.scss
+++ b/app/assets/stylesheets/theme_sinai/elements/_si-body.scss
@@ -1,4 +1,3 @@
 body {
   font-family: 'Roboto', sans-serif;
-  font-weight: 300;
 }

--- a/app/assets/stylesheets/theme_sinai/elements/_si-body.scss
+++ b/app/assets/stylesheets/theme_sinai/elements/_si-body.scss
@@ -1,3 +1,4 @@
 body {
   font-family: 'Roboto', sans-serif;
+  font-weight: 300;
 }

--- a/app/assets/stylesheets/theme_sinai/pages/_si-homepage.scss
+++ b/app/assets/stylesheets/theme_sinai/pages/_si-homepage.scss
@@ -27,12 +27,17 @@
 }
 
 .lead__text--homepage--sinai {
-  font-size: $text-16;
+  font-size: $text-20;
+  font-family: 'Dosis', sans-serif;
   line-height: 1.75;
   letter-spacing: 0.5px;
 
   @media (min-width: 992px) {
     padding-top: 3.75rem;
+  }
+
+  @media (max-width: 500px) {
+    font-size: $text-16;
   }
 }
 

--- a/app/assets/stylesheets/theme_sinai/pages/_si-static-page.scss
+++ b/app/assets/stylesheets/theme_sinai/pages/_si-static-page.scss
@@ -46,9 +46,9 @@
 }
 
 .static-page__text--sinai {
+  margin-bottom: 1rem;
   font-weight: 300;
   line-height: 1.5;
-  margin-bottom: 1rem;
 }
 
 .static-page__list--sinai {

--- a/app/assets/stylesheets/theme_sinai/pages/_si-static-page.scss
+++ b/app/assets/stylesheets/theme_sinai/pages/_si-static-page.scss
@@ -46,12 +46,14 @@
 }
 
 .static-page__text--sinai {
+  font-weight: 300;
   line-height: 1.5;
   margin-bottom: 1rem;
 }
 
 .static-page__list--sinai {
   margin-bottom: 1rem;
+  font-weight: 300;
 
   @media (max-width: 767px) {
     font-size: $text-16;

--- a/docker-compose-standalone.yml
+++ b/docker-compose-standalone.yml
@@ -12,6 +12,7 @@ services:
       - ./docker.env
     environment:
       SOLR_URL: http://solr:8983/solr/ursus
+      # SOLR_URL: http://host.docker.internal:6983/solr/californica
       SOLR_TEST_URL: http://solr_test:8983/solr/ursus
       DATABASE_USERNAME: ursus
       DATABASE_PASSWORD: ursus


### PR DESCRIPTION
- [x] Intro text on the front page:
 + Update `font-family` to `'Dosis'`
 + Update `font-size` to `$text-20`
 + Return `font-size` to `$text-16` on mobile resolution
- [x] Facets heading text "Browse Item":
 + Update typography to be similar to "Browse Manuscripts" (Front page)
 + Browse Items: `.facets__navbar-heading--sinai`
 + Browse Manuscripts - `.homepage__subtitle--sinai`
- [x] Update the test on the static page to
 + `font-weight: 300`

+ Adds the the commented out internal SOLR link to the `docker-compose-standalone.yml` for feed_ursus   
`# SOLR_URL: `http://host.docker.internal:6983/solr/californica`

<img width="1219" alt="Screen Shot 2021-01-07 at 4 53 23 PM" src="https://user-images.githubusercontent.com/751697/103962484-e695d000-510b-11eb-9999-ae79fdee4e92.png">

---

modified:   
+ `app/assets/stylesheets/theme_sinai/components/_si-facets.scss`
+ `app/assets/stylesheets/theme_sinai/pages/_si-homepage.scss`
+ `app/assets/stylesheets/base/components/_metadata-block.scss`
+ `app/assets/stylesheets/theme_sinai/pages/_si-static-page.scss`
+ `docker-compose-standalone.yml`