### PR TITLE
set auth cookie when SINAI_ID_BYPASS is true

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,8 +37,11 @@ class ApplicationController < ActionController::Base
   end
 
   def sinai_authn_check
-    return true if ENV['SINAI_ID_BYPASS'] # skip auth in development
     return true if !Flipflop.sinai? || [login_path, version_path].include?(request.path) || sinai_authenticated?
+    if ENV['SINAI_ID_BYPASS'] # skip auth in development
+      cookies[:sinai_authenticated] = 'true'
+      return true
+    end
     check_document_paths
     return unless ucla_token?
     set_auth_cookies

--- a/e2e/cypress/integration/sinai_homepage_spec.js
+++ b/e2e/cypress/integration/sinai_homepage_spec.js
@@ -15,7 +15,7 @@ describe('Sinai Homepage', () => {
     cy.get('[id=search]').click();
     cy.url().should('include', 'search_field=all_fields');
   });
-// Navbar Links
+  // Navbar Links
   it('About Link', () => {
     cy.visit(Cypress.env('SINAI_BASE_URL'));
     cy.contains('a', 'About');
@@ -23,10 +23,11 @@ describe('Sinai Homepage', () => {
     cy.url().should('include', '/sinai_about');
   });
 
-  it('Login Link', () => {
-    cy.visit(Cypress.env('SINAI_BASE_URL'));
-    cy.contains('[type="submit"]', 'LOGIN');
-  });
+  // Can't test login link because we bypass auth in the test server
+  // it('Login Link', () => {
+  //   cy.visit(Cypress.env('SINAI_BASE_URL'));
+  //   cy.contains('[type="submit"]', 'LOGIN');
+  // });
 
   // Static pages
   it('About Page', () => {
@@ -62,14 +63,14 @@ describe('Sinai Homepage', () => {
     cy.get('[alt="Arcadia logo"]').should('be.visible');
   });
 
-// Footer Secondary - Sinai Palimpsests Project Link
+  // Footer Secondary - Sinai Palimpsests Project Link
   it('Sinai Palimpsests Project', () => {
     cy.visit(Cypress.env('SINAI_BASE_URL'));
     cy.contains('a[href="http://sinaipalimpsests.org/"]', 'Sinai Palimpsests Project');
   });
 });
 
-/* 
-https://github.com/cypress-io/cypress-example-recipes/ Tab Handling and Links 
+/*
+https://github.com/cypress-io/cypress-example-recipes/ Tab Handling and Links
 https://docs.cypress.io/guides/guides/environment-variables.html#Option-1-configuration-file
 */


### PR DESCRIPTION
This should never be the case in production, and will disable granualar auth restrictions in development. When working on auth logic, developers can unset the SINAI_ID_BYPASS environment variable.