### PR TITLE
Fix support link in Sinai

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -225,7 +225,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'format_tesim', label: 'Format'
     # 'Book format'
     config.add_show_field 'medium_tesim', label: 'Medium'
-    config.add_show_field 'support_tesim', label: 'Support', link_to_facet: 'support_tesim'
+    config.add_show_field 'support_tesim', label: 'Support', link_to_facet: 'support_sim'
     config.add_show_field 'extent_tesim', label: 'Extent'
     config.add_show_field 'dimensions_tesim', label: 'Dimensions'
     config.add_show_field 'page_layout_ssim', label: 'Page layout'


### PR DESCRIPTION
#### Bug fix
Changes this:  
<img width="608" alt="Screen Shot 2021-01-12 at 2 44 40 PM" src="https://user-images.githubusercontent.com/751697/104383506-c9cf1300-54e4-11eb-9d06-48c006220335.png">

To this:  
<img width="530" alt="Screen Shot 2021-01-12 at 2 50 37 PM" src="https://user-images.githubusercontent.com/751697/104383977-93de5e80-54e5-11eb-9e37-93a519b43d11.png">

