### PR TITLE
Apps 559: Reorder Sinai facets term to display in A-Z order

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,8 +2,9 @@ FROM uclalibrary/ursus
 
 WORKDIR /ursus
 
+RUN apt-get update -qq
 # New apt packages - these can be removed once they're incorporated into the base uclalibrary/ursus image on dockerhub
-RUN apt-get install -y nodejs=10.21.0~dfsg-1~deb10u1
+RUN apt-get install -y nodejs
 
 EXPOSE 3000
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -106,16 +106,16 @@ class CatalogController < ApplicationController
 
     # SINAI
     if Flipflop.sinai?
-      config.add_facet_field 'genre_sim', limit: 7
-      config.add_facet_field 'place_of_origin_sim', limit: 7, label: 'Place of origin'
+      config.add_facet_field 'genre_sim', sort: 'index', limit: 7
+      config.add_facet_field 'place_of_origin_sim', sort: 'index', limit: 7, label: 'Place of origin'
       config.add_facet_field 'year_isim', limit: 7, range: true
-      config.add_facet_field 'human_readable_language_sim', limit: 7
-      config.add_facet_field 'writing_system_sim', limit: 7, label: 'Writing system'
-      config.add_facet_field 'script_sim', limit: 7, label: 'Script'
-      config.add_facet_field 'features_sim', limit: 7, label: 'Features'
-      config.add_facet_field 'support_sim', limit: 7, label: 'Support'
-      config.add_facet_field 'form_sim', limit: 7, label: 'Form'
-      config.add_facet_field 'names_sim', limit: 7, label: 'Names'
+      config.add_facet_field 'human_readable_language_sim',sort: 'index', limit: 7
+      config.add_facet_field 'writing_system_sim',sort: 'index', limit: 7, label: 'Writing system'
+      config.add_facet_field 'script_sim',sort: 'index', limit: 7, label: 'Script'
+      config.add_facet_field 'features_sim',sort: 'index', limit: 7, label: 'Features'
+      config.add_facet_field 'support_sim',sort: 'index', limit: 7, label: 'Support'
+      config.add_facet_field 'form_sim',sort: 'index', limit: 7, label: 'Form'
+      config.add_facet_field 'names_sim',sort: 'index', limit: 7, label: 'Names'
 
     # URSUS
     else

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -109,13 +109,13 @@ class CatalogController < ApplicationController
       config.add_facet_field 'genre_sim', sort: 'index', limit: 7
       config.add_facet_field 'place_of_origin_sim', sort: 'index', limit: 7, label: 'Place of origin'
       config.add_facet_field 'year_isim', limit: 7, range: true
-      config.add_facet_field 'human_readable_language_sim',sort: 'index', limit: 7
-      config.add_facet_field 'writing_system_sim',sort: 'index', limit: 7, label: 'Writing system'
-      config.add_facet_field 'script_sim',sort: 'index', limit: 7, label: 'Script'
-      config.add_facet_field 'features_sim',sort: 'index', limit: 7, label: 'Features'
-      config.add_facet_field 'support_sim',sort: 'index', limit: 7, label: 'Support'
-      config.add_facet_field 'form_sim',sort: 'index', limit: 7, label: 'Form'
-      config.add_facet_field 'names_sim',sort: 'index', limit: 7, label: 'Names'
+      config.add_facet_field 'human_readable_language_sim', sort: 'index', limit: 7
+      config.add_facet_field 'writing_system_sim', sort: 'index', limit: 7, label: 'Writing system'
+      config.add_facet_field 'script_sim', sort: 'index', limit: 7, label: 'Script'
+      config.add_facet_field 'features_sim', sort: 'index', limit: 7, label: 'Features'
+      config.add_facet_field 'support_sim', sort: 'index', limit: 7, label: 'Support'
+      config.add_facet_field 'form_sim', sort: 'index', limit: 7, label: 'Form'
+      config.add_facet_field 'names_sim', sort: 'index', limit: 7, label: 'Names'
 
     # URSUS
     else


### PR DESCRIPTION
Related to [APPS-559](https://jira.library.ucla.edu/browse/APPS-559)

Acceptance Criteria: 

- [x] Facet terms sort by A..Z
- [x] Implementation: Add sort key to facet configuration in CatalogController
<img width="263" alt="Screen Shot 2021-01-13 at 3 30 41 PM" src="https://user-images.githubusercontent.com/34147754/104525138-67ddde80-55b4-11eb-9736-7a68b3c7b568.png">


