### PR TITLE
APPS-614 Sinai: reduce font weights for search bar

### DIFF
--- a/app/assets/stylesheets/base/global/_typography.scss
+++ b/app/assets/stylesheets/base/global/_typography.scss
@@ -8,6 +8,7 @@ $text-16: 1rem;
 $text-14: 0.875rem;
 
 $font-bold: 600;
+$font-medium: 400;
 $font-light: 300;
 
 .bordered-title {

--- a/app/assets/stylesheets/theme_sinai/header/_si-searchbar.scss
+++ b/app/assets/stylesheets/theme_sinai/header/_si-searchbar.scss
@@ -10,6 +10,7 @@
 // Dropdown field
 .site-searchbar__dropdown--sinai {
   font-size: $text-14;
+  font-weight: $font-medium;
   color: $gray-60;
   border-right: 1px solid $gray-10;
 }
@@ -21,6 +22,7 @@
 
 .form-control--sinai {
   font-size: $text-14;
+  font-weight: $font-light;
 }
 
 .site-searchbar__search-icon--sinai .btn {


### PR DESCRIPTION
Connected to [APPS-614](https://jira.library.ucla.edu/browse/APPS-614)

Reduce font weight for Sinai search bar:
- [x] .site-searchbar__dropdown - font-weight: 400;
- [x] .form-control - font-weight: 300;
<img width="410" alt="Screen Shot 2021-01-28 at 1 21 42 PM" src="https://user-images.githubusercontent.com/751697/106200407-c89c1800-616b-11eb-8973-9dfd48829643.png">

---

Changes to be committed:
modified:   app/assets/stylesheets/base/global/_typography.scss
modified:   app/assets/stylesheets/theme_sinai/header/_si-searchbar.scss