### PR TITLE
Apps 598 configure mirador 3

### DIFF
--- a/public/mirador.html
+++ b/public/mirador.html
@@ -95,27 +95,6 @@
         height: 200, // height of gallery view thumbnails
         width: null, // width of gallery view thumbnails (or null, to auto-calculate an aspect-ratio appropriate size)
       },
-      "layout": "1",
-      "buildPath": "https://unpkg.com/mirador@3.0.0/dist/",
-      "data": [
-        { "manifestUri": manifestURL, 
-        "location": "UCLA Library"}
-      ],
-
-      "annotationEndpoint": {
-        "name": "Local Storage",
-        "module": "LocalStorageEndpoint"
-      },
-      "windowSettings": {
-        "canvasControls": { // The types of controls available to be displayed on a canvas
-          "imageManipulation": {
-            "manipulationLayer": true,
-            "controls": {
-              "mirror": true
-            }
-          }
-        }
-      }
     });
   </script>
 </body>

--- a/public/mirador.html
+++ b/public/mirador.html
@@ -39,6 +39,7 @@
         sr: 'Српски',
       },
       window: { //global window defaults
+        allowClose: false, // Configure if windows can be closed or not
         allowFullscreen: true, // Configure to show a "fullscreen" button in the     WindowTopBar
         allowMaximize: true, // Configure if windows can be maximized or not
         allowTopMenuButton: true, // Configure if window view and thumbnail display   menu   are visible or not

--- a/public/mirador.html
+++ b/public/mirador.html
@@ -9,13 +9,14 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <link rel="icon" href="favicon.ico">
-  <link rel="stylesheet" type="text/css" href="https://unpkg.com/mirador@2.6.0/dist/css/mirador-combined.min.css">
-  <script src="https://unpkg.com/mirador@3.0.0/dist/mirador.min.js"></script>
+  <link rel="stylesheet" type="text/css" href="http://unpkg.com/mirador@2.6.0/dist/css/mirador-combined.min.css">
+  <script src="http://unpkg.com/mirador@3.0.0/dist/mirador.min.js"></script>
 </head>
 
 <body>
   <div id="viewer"></div>
   <script type="text/javascript">
+    __Zone_disable_IntersectionObserver = true
     var urlParams = {};
     var urlParts = window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function (m, key, value) {
       urlParams[key] = value;
@@ -69,8 +70,8 @@
           layers: false,
         },
         views: [
-          { key: 'single', behaviors: ['individuals'] },
-          { key: 'gallery', behaviors: ['paged'] },
+          { key: 'single' },
+          { key: 'book', behaviors: ['paged'] },
           { key: 'scroll', behaviors: ['continuous'] },
           { key: 'gallery' },
         ],
@@ -95,6 +96,27 @@
         height: 200, // height of gallery view thumbnails
         width: null, // width of gallery view thumbnails (or null, to auto-calculate an aspect-ratio appropriate size)
       },
+      "layout": "1",
+      "buildPath": "https://unpkg.com/mirador@3.0.0/dist/",
+      "data": [
+        { "manifestUri": manifestURL, 
+        "location": "UCLA Library"}
+      ],
+
+      "annotationEndpoint": {
+        "name": "Local Storage",
+        "module": "LocalStorageEndpoint"
+      },
+      "windowSettings": {
+        "canvasControls": { // The types of controls available to be displayed on a canvas
+          "imageManipulation": {
+            "manipulationLayer": true,
+            "controls": {
+              "mirror": true
+            }
+          }
+        }
+      }
     });
   </script>
 </body>

--- a/public/mirador.html
+++ b/public/mirador.html
@@ -9,8 +9,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <link rel="icon" href="favicon.ico">
-  <link rel="stylesheet" type="text/css" href="http://unpkg.com/mirador@2.6.0/dist/css/mirador-combined.min.css">
-  <script src="http://unpkg.com/mirador@3.0.0/dist/mirador.min.js"></script>
+  <link rel="stylesheet" type="text/css" href="https://unpkg.com/mirador@2.6.0/dist/css/mirador-combined.min.css">
+  <script src="https://unpkg.com/mirador@3.0.0/dist/mirador.min.js"></script>
 </head>
 
 <body>

--- a/public/mirador.html
+++ b/public/mirador.html
@@ -96,27 +96,6 @@
         height: 200, // height of gallery view thumbnails
         width: null, // width of gallery view thumbnails (or null, to auto-calculate an aspect-ratio appropriate size)
       },
-      "layout": "1",
-      "buildPath": "https://unpkg.com/mirador@3.0.0/dist/",
-      "data": [
-        { "manifestUri": manifestURL, 
-        "location": "UCLA Library"}
-      ],
-
-      "annotationEndpoint": {
-        "name": "Local Storage",
-        "module": "LocalStorageEndpoint"
-      },
-      "windowSettings": {
-        "canvasControls": { // The types of controls available to be displayed on a canvas
-          "imageManipulation": {
-            "manipulationLayer": true,
-            "controls": {
-              "mirror": true
-            }
-          }
-        }
-      }
     });
   </script>
 </body>

--- a/public/mirador.html
+++ b/public/mirador.html
@@ -9,16 +9,22 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <link rel="icon" href="favicon.ico">
-  <link rel="stylesheet" type="text/css" href="https://unpkg.com/mirador@3.0.0/dist/css/mirador-combined.min.css">
-  <script src="https://unpkg.com/mirador@3.0.0/dist/mirador.min.js"></script>
+  <link rel="stylesheet" type="text/css" href="http://unpkg.com/mirador@2.6.0/dist/css/mirador-combined.min.css">
+  <script src="http://unpkg.com/mirador@3.0.0/dist/mirador.min.js"></script>
 </head>
 
 <body>
   <div id="viewer"></div>
   <script type="text/javascript">
+    var urlParams = {};
+    var urlParts = window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function (m, key, value) {
+      urlParams[key] = value;
+    });
+
     //manifestURL = 'manifest_test.json';
     //manifestURL = 'https://iiif.library.ucla.edu/ark%3A%2F21198%2Fzz002kh3x8/manifest';
-    manifestURL = 'https://iiif.library.ucla.edu/ark%3A%2F21198%2Fz10c6dfr/manifest';
+    //manifestURL = 'https://iiif.library.ucla.edu/ark%3A%2F21198%2Fz10c6dfr/manifest';
+    manifestURL = decodeURIComponent(urlParams["manifest"]);
 
     Mirador.viewer({
       "id": "viewer",
@@ -89,28 +95,12 @@
         height: 200, // height of gallery view thumbnails
         width: null, // width of gallery view thumbnails (or null, to auto-calculate an aspect-ratio appropriate size)
       },
-
-
-
-
-
-
       "layout": "1",
       "buildPath": "https://unpkg.com/mirador@3.0.0/dist/",
       "data": [
         { "manifestUri": manifestURL, 
         "location": "UCLA Library"}
       ],
-
-
-
-
-
-
-
-
-
-
 
       "annotationEndpoint": {
         "name": "Local Storage",

--- a/public/mirador.html
+++ b/public/mirador.html
@@ -9,49 +9,122 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <link rel="icon" href="favicon.ico">
-  <link rel="stylesheet" type="text/css" href="https://unpkg.com/mirador@2.6.0/dist/css/mirador-combined.min.css">
-  <script src="https://unpkg.com/mirador@2.6.0/dist/mirador.min.js"></script>
+  <link rel="stylesheet" type="text/css" href="https://unpkg.com/mirador@3.0.0/dist/css/mirador-combined.min.css">
+  <script src="https://unpkg.com/mirador@3.0.0/dist/mirador.min.js"></script>
 </head>
 
 <body>
   <div id="viewer"></div>
   <script type="text/javascript">
-    $(function () {
-      var urlParams = {};
-      var urlParts = window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function (m, key, value) {
-        urlParams[key] = value;
-      });
+    //manifestURL = 'manifest_test.json';
+    //manifestURL = 'https://iiif.library.ucla.edu/ark%3A%2F21198%2Fzz002kh3x8/manifest';
+    manifestURL = 'https://iiif.library.ucla.edu/ark%3A%2F21198%2Fz10c6dfr/manifest';
 
-      manifestURL = decodeURIComponent(urlParams['manifest']);
-
-      myMiradorInstance = Mirador({
-        "id": "viewer",
-        "layout": "1",
-        "buildPath": "https://unpkg.com/mirador@2.6.0/dist/",
-        "data": [
-          { "manifestUri": manifestURL, 
-          "location": "UCLA Library"}
-        ],
-        "windowObjects": [{
-          loadedManifest: manifestURL,
-          viewType: "ImageView",
-          slotAddress: "row1.column1"
-        }],
-        "annotationEndpoint": {
-          "name": "Local Storage",
-          "module": "LocalStorageEndpoint"
+    Mirador.viewer({
+      "id": "viewer",
+      selectedTheme: 'dark',
+      language: 'en', // The default language set in the application
+      availableLanguages: { // All the languages available in the language switcher
+        ar: 'العربية',
+        de: 'Deutsch',
+        en: 'English',
+        fr: 'Français',
+        ja: '日本語',
+        lt: 'Lietuvių',
+        nl: 'Nederlands',
+        'pt-BR': 'Português do Brasil',
+        'zh-CN': '中文(简体)',
+        'zh-TW': '中文(繁體)',
+        it: "Italiano",
+        sr: 'Српски',
+      },
+      window: { //global window defaults
+        allowFullscreen: true, // Configure to show a "fullscreen" button in the     WindowTopBar
+        allowMaximize: true, // Configure if windows can be maximized or not
+        allowTopMenuButton: true, // Configure if window view and thumbnail display   menu   are visible or not
+        allowWindowSideBar: true, // Configure if side bar menu is visible or not
+        authNewWindowCenter: 'parent', // Configure how to center a new window created   by   the authentication flow. Options: parent, screen
+        sideBarPanel: 'info', // Configure which sidebar is selected by default.   Options:   info, attribution, canvas, annotations, search
+        defaultSidebarPanelHeight: 201,  // Configure default sidebar height in pixels
+        defaultSidebarPanelWidth: 235, // Configure default sidebar width in pixels
+        defaultView: 'gallery',  // Configure which viewing mode (e.g. single, book,     gallery) for windows to be opened in
+        forceDrawAnnotations: false,
+        hideWindowTitle: false, // Configure if the window title is shown in the   window   title bar or not
+        highlightAllAnnotations: false, // Configure whether to display annotations on   the   canvas by default
+        showLocalePicker: false, // Configure locale picker for multi-lingual metadata
+        sideBarOpen: false, // Configure if the sidebar (and its content panel) is open   by   default
+        panels: { // Configure which panels are visible in WindowSideBarButtons
+          info: true,
+          attribution: true,
+          canvas: true,
+          annotations: true,
+          search: true,
+          layers: false,
         },
-        "windowSettings": {
-          "canvasControls": { // The types of controls available to be displayed on a canvas
-            "imageManipulation": {
-              "manipulationLayer": true,
-              "controls": {
-                "mirror": true
-              }
+        views: [
+          { key: 'single', behaviors: ['individuals'] },
+          { key: 'gallery', behaviors: ['paged'] },
+          { key: 'scroll', behaviors: ['continuous'] },
+          { key: 'gallery' },
+        ],
+      },
+      windows: [{
+        loadedManifest: manifestURL,
+        viewType: "ImageView",
+        slotAddress: "row1.column1"
+      }],
+      workspace: {
+        draggingEnabled: true,
+        allowNewWindows: true,
+        showZoomControls: true, // Configure if zoom controls should be displayed by     default
+        type: 'mosaic', // Which workspace type to load by default. Other possible values     are "elastic". If "mosaic" or "elastic" are not selected no worksapce type will be     used.
+        viewportPosition: { // center coordinates for the elastic mode workspace
+          x: 0,
+          y: 0,
+        },
+        width: 5000, // width of the elastic mode's virtual canvas
+      },
+      galleryView: {
+        height: 200, // height of gallery view thumbnails
+        width: null, // width of gallery view thumbnails (or null, to auto-calculate an aspect-ratio appropriate size)
+      },
+
+
+
+
+
+
+      "layout": "1",
+      "buildPath": "https://unpkg.com/mirador@3.0.0/dist/",
+      "data": [
+        { "manifestUri": manifestURL, 
+        "location": "UCLA Library"}
+      ],
+
+
+
+
+
+
+
+
+
+
+
+      "annotationEndpoint": {
+        "name": "Local Storage",
+        "module": "LocalStorageEndpoint"
+      },
+      "windowSettings": {
+        "canvasControls": { // The types of controls available to be displayed on a canvas
+          "imageManipulation": {
+            "manipulationLayer": true,
+            "controls": {
+              "mirror": true
             }
           }
         }
-      });
+      }
     });
   </script>
 </body>

--- a/public/mirador2.html
+++ b/public/mirador2.html
@@ -1,0 +1,59 @@
+<!--
+    This is what the embed iframe src links to. It doesn't need to communicate with the parent page, only fill the available space and look for #? parameters
+-->
+
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <link rel="icon" href="favicon.ico">
+  <link rel="stylesheet" type="text/css" href="https://unpkg.com/mirador@2.6.0/dist/css/mirador-combined.min.css">
+  <script src="https://unpkg.com/mirador@2.6.0/dist/mirador.min.js"></script>
+</head>
+
+<body>
+  <div id="viewer"></div>
+  <script type="text/javascript">
+    $(function () {
+      var urlParams = {};
+      var urlParts = window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function (m, key, value) {
+        urlParams[key] = value;
+      });
+
+      manifestURL = decodeURIComponent(urlParams['manifest']);
+
+      myMiradorInstance = Mirador({
+        "id": "viewer",
+        "layout": "1",
+        "buildPath": "https://unpkg.com/mirador@2.6.0/dist/",
+        "data": [
+          { "manifestUri": manifestURL, 
+          "location": "UCLA Library"}
+        ],
+        "windowObjects": [{
+          loadedManifest: manifestURL,
+          viewType: "ImageView",
+          slotAddress: "row1.column1"
+        }],
+        "annotationEndpoint": {
+          "name": "Local Storage",
+          "module": "LocalStorageEndpoint"
+        },
+        "windowSettings": {
+          "canvasControls": { // The types of controls available to be displayed on a canvas
+            "imageManipulation": {
+              "manipulationLayer": true,
+              "controls": {
+                "mirror": true
+              }
+            }
+          }
+        }
+      });
+    });
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
Connected to [APPS-544](https://jira.library.ucla.edu/browse/APPS-544), [APPS-598](https://jira.library.ucla.edu/browse/APPS-598), [APPS-599](https://jira.library.ucla.edu/browse/APPS-599)

### Configure, test and update Mirador from version 2 to version 3

#### Acceptance Criteria:
- [x] Mirador 3 is loaded when a specific URL is entered into the browser
- [x] Sinai content and metadata are displayed when the manifest is entered into Mirador 3
- [x] Mirador 3 is configured per the attached options list and approved by Dawn Childress.
- [x] Mirador 3 is displaying Sinai content and metadata in the Index page of the Sinai Manuscripts site using the configuration developed in APPS-598
---

#### Files
+ `public/mirador.html`
+ `public/mirador2.html`
---

![image](https://user-images.githubusercontent.com/2350153/106954060-183c8f80-66e8-11eb-8ee7-8c560c8b04fd.png)
