### PR TITLE
Apps 612 configure metadata fields in rails for tabbed metadata box

### DIFF
--- a/app/presenters/sinai/codicology_metadata_presenter.rb
+++ b/app/presenters/sinai/codicology_metadata_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Sinai
+  class CodicologyMetadataPresenter
+    attr_reader :document
+
+    def initialize(document:)
+      @document = document
+      @config = YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/codicology_metadata.yml')))
+    end
+
+    def codicology_terms
+      @document.slice(*@config.keys)
+    end
+  end
+end

--- a/app/presenters/sinai/contents_metadata_presenter.rb
+++ b/app/presenters/sinai/contents_metadata_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Sinai
+  class ContentsMetadataPresenter
+    attr_reader :document
+
+    def initialize(document:)
+      @document = document
+      @config = YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/contents_metadata.yml')))
+    end
+
+    def contents_terms
+      @document.slice(*@config.keys)
+    end
+  end
+end

--- a/app/presenters/sinai/decoration_metadata_presenter.rb
+++ b/app/presenters/sinai/decoration_metadata_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Sinai
+  class DecorationMetadataPresenter
+    attr_reader :document
+
+    def initialize(document:)
+      @document = document
+      @config = YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/decoration_metadata.yml')))
+    end
+
+    def decoration_terms
+      @document.slice(*@config.keys)
+    end
+  end
+end

--- a/app/presenters/sinai/history_metadata_presenter.rb
+++ b/app/presenters/sinai/history_metadata_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Sinai
+  class HistoryMetadataPresenter
+    attr_reader :document
+
+    def initialize(document:)
+      @document = document
+      @config = YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/history_metadata.yml')))
+    end
+
+    def history_terms
+      @document.slice(*@config.keys)
+    end
+  end
+end

--- a/app/presenters/sinai/keywords_metadata_presenter.rb
+++ b/app/presenters/sinai/keywords_metadata_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Sinai
+  class KeywordsMetadataPresenter
+    attr_reader :document
+
+    def initialize(document:)
+      @document = document
+      @config = YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/keywords_metadata.yml')))
+    end
+
+    def keywords_terms
+      @document.slice(*@config.keys)
+    end
+  end
+end

--- a/app/presenters/sinai/overview_metadata_presenter.rb
+++ b/app/presenters/sinai/overview_metadata_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Sinai
+  class OverviewMetadataPresenter
+    attr_reader :document
+
+    def initialize(document:)
+      @document = document
+      @config = YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/overview_metadata.yml')))
+    end
+
+    def overview_terms
+      @document.slice(*@config.keys)
+    end
+  end
+end

--- a/app/presenters/sinai/references_metadata_presenter.rb
+++ b/app/presenters/sinai/references_metadata_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Sinai
+  class ReferencesMetadataPresenter
+    attr_reader :document
+
+    def initialize(document:)
+      @document = document
+      @config = YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/references_metadata.yml')))
+    end
+
+    def references_terms
+      @document.slice(*@config.keys)
+    end
+  end
+end

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -21,6 +21,7 @@
     <%= render 'catalog/work_record/secondary_metadata', document: document %>
   </div>
 
+<%# ----------- Ursus --------------- %>
 <% else %>
   <div class='item-page__metadata-wrapper'>
     <%= render 'catalog/work_record/primary_metadata', document: document %>

--- a/app/views/catalog/work_record/_primary_metadata.html.erb
+++ b/app/views/catalog/work_record/_primary_metadata.html.erb
@@ -8,5 +8,4 @@
   <%= render 'catalog/work_record/note_metadata', document: document %>
   <%= render 'catalog/work_record/physical_description_metadata', document: document %>
   <%= render 'catalog/work_record/keyword_metadata', document: document %>
-  <%= document['genre_sim'] %>
 </div>

--- a/config/metadata-sinai/codicology_metadata.yml
+++ b/config/metadata-sinai/codicology_metadata.yml
@@ -1,0 +1,15 @@
+# These fields are in order of display
+
+# Sinai only - Codicology
+extent_tesim: 'Extent'
+collation_tesim: 'Collation'
+form_sim: 'Form'
+support_tesim: 'Support'
+writing_system_tesim: 'Writing system'
+script_tesim: 'Script'
+page_layout_ssim: 'Page layout'
+foliation_tesim: 'Foliation note'
+hand_note_tesim: 'Hand note'
+binding_note_tesim: 'Binding note'
+condition_note_tesim: 'Condition note'
+description_tesim: 'Physical Description note'

--- a/config/metadata-sinai/contents_metadata.yml
+++ b/config/metadata-sinai/contents_metadata.yml
@@ -1,0 +1,11 @@
+# These fields are in order of display
+
+# Sinai only - Contents
+descriptive_title_tesim: 'Descriptive title'
+uniform_title_tesim: 'Uniform title'
+alternative_title_tesim: 'Alternative title'
+incipit_tesim: 'Incipit'
+explicit_tesim: 'Explicit'
+author_tesim: 'Author'
+associated_name_tesim: 'Associated Name'
+contents_note_tesim: 'Contents note'

--- a/config/metadata-sinai/decoration_metadata.yml
+++ b/config/metadata-sinai/decoration_metadata.yml
@@ -1,0 +1,4 @@
+# These fields are in order of display
+
+# Sinai only - Decoration
+illustrations_note_tesim: 'Illustrations note'

--- a/config/metadata-sinai/history_metadata.yml
+++ b/config/metadata-sinai/history_metadata.yml
@@ -1,0 +1,10 @@
+# These fields are in order of display
+
+# Sinai only - History
+date_created_tesim: 'Date created'
+scribe_tesim: 'Scribe'
+place_of_origin_tesim: 'Place of Origin'
+colophon_tesim: 'Colophon'
+hand_note_tesim: 'Hand note'
+script_tesim: 'Script note'
+provenance_tesim: 'Provenance'

--- a/config/metadata-sinai/keywords_metadata.yml
+++ b/config/metadata-sinai/keywords_metadata.yml
@@ -1,0 +1,8 @@
+# These fields are in order of display
+
+# Sinai only - Keywords
+genre_tesim: 'Genre'
+features_tesim: 'Features'
+place_of_origin_tesim: 'Place of Origin'
+support_tesim: 'Support'
+form_ssi: 'Form'

--- a/config/metadata-sinai/overview_metadata.yml
+++ b/config/metadata-sinai/overview_metadata.yml
@@ -1,0 +1,13 @@
+# These fields are in order of display
+
+# Sinai only - Overview
+place_of_origin_tesim: 'Place of origin'
+date_created_tesim: 'Date created'
+foliation_tesim: 'Foliation'
+form_ssi: 'Form'
+human_readable_language_tesim: 'Language'
+writing_system_tesim: 'Writing system'
+script_tesim: 'Script'
+repository_tesim: 'Repository'
+human_readable_rights_statement_tesim: 'Rights statement'
+services_contact_ssm: 'Rights contact'

--- a/config/metadata-sinai/references_metadata.yml
+++ b/config/metadata-sinai/references_metadata.yml
@@ -1,0 +1,5 @@
+# These fields are in order of display
+
+# Sinai only - References
+references_tesim: 'References'
+other_versions_tesim: 'Other version(s)'

--- a/spec/presenters/sinai/codicology_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/codicology_metadata_presenter_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Sinai::CodicologyMetadataPresenter do
+  let(:solr_doc) do
+    {
+      'extent_tesim' => 'Extent',
+      'collation_tesim' => 'Collation',
+      'form_sim' => 'Form',
+      'support_tesim' => 'Support',
+      'writing_system_tesim' => 'Writing system',
+      'script_tesim' => 'Script',
+      'page_layout_ssim' => 'Page layout',
+      'foliation_tesim' => 'Foliation note',
+      'hand_note_tesim' => 'Hand note',
+      'binding_note_tesim' => 'Binding note',
+      'condition_note_tesim' => 'Condition note',
+      'description_tesim' => 'Physical Description note'
+    }
+  end
+  let(:solr_doc_missing_items) do
+    {
+      'extent_tesim' => 'Extent',
+      'collation_tesim' => 'Collation',
+      'form_sim' => 'Form',
+      'support_tesim' => 'Support',
+      'writing_system_tesim' => 'Writing system',
+      'script_tesim' => 'Script'
+    }
+  end
+  let(:presenter_object) { described_class.new(document: solr_doc) }
+  let(:presenter_object_missing_items) { described_class.new(document: solr_doc_missing_items) }
+  let(:config) { YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/codicology_metadata.yml'))) }
+
+  context 'with a solr document containing codicology metadata' do
+    describe '#terms' do
+      it 'returns the Title Key' do
+        expect(config['extent_tesim'].to_s).to eq('Extent')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['collation_tesim'].to_s).to eq('Collation')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['form_sim'].to_s).to eq('Form')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['support_tesim'].to_s).to eq('Support')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['writing_system_tesim'].to_s).to eq('Writing system')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['script_tesim'].to_s).to eq('Script')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['page_layout_ssim'].to_s).to eq('Page layout')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['foliation_tesim'].to_s).to eq('Foliation note')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['hand_note_tesim'].to_s).to eq('Hand note')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['binding_note_tesim'].to_s).to eq('Binding note')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['condition_note_tesim'].to_s).to eq('Condition note')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['description_tesim'].to_s).to eq('Physical Description note')
+      end
+    end
+  
+    describe "#codicology_terms terms" do
+      let(:all) { presenter_object.codicology_terms.keys.length }
+      let(:missing) { presenter_object_missing_items.codicology_terms.keys.length }
+
+      it "returns existing keys" do
+        expect(all).to eq 12
+        expect(config.length).to eq all
+      end
+
+      it "is missing elements" do
+        expect(all - missing).to_not eq 0
+        expect(config.length - missing).to_not eq 0
+      end
+    end
+  end
+end

--- a/spec/presenters/sinai/codicology_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/codicology_metadata_presenter_spec.rb
@@ -34,55 +34,55 @@ RSpec.describe Sinai::CodicologyMetadataPresenter do
 
   context 'with a solr document containing codicology metadata' do
     describe '#terms' do
-      it 'returns the Title Key' do
+      it 'returns the Extent Key' do
         expect(config['extent_tesim'].to_s).to eq('Extent')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Collation Key' do
         expect(config['collation_tesim'].to_s).to eq('Collation')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Form Key' do
         expect(config['form_sim'].to_s).to eq('Form')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Support Key' do
         expect(config['support_tesim'].to_s).to eq('Support')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Writing system Key' do
         expect(config['writing_system_tesim'].to_s).to eq('Writing system')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Script Key' do
         expect(config['script_tesim'].to_s).to eq('Script')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Page layout Key' do
         expect(config['page_layout_ssim'].to_s).to eq('Page layout')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Foliation note Key' do
         expect(config['foliation_tesim'].to_s).to eq('Foliation note')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Hand note Key' do
         expect(config['hand_note_tesim'].to_s).to eq('Hand note')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Binding note Key' do
         expect(config['binding_note_tesim'].to_s).to eq('Binding note')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Condition note Key' do
         expect(config['condition_note_tesim'].to_s).to eq('Condition note')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Physical Description note Key' do
         expect(config['description_tesim'].to_s).to eq('Physical Description note')
       end
     end
-  
+
     describe "#codicology_terms terms" do
       let(:all) { presenter_object.codicology_terms.keys.length }
       let(:missing) { presenter_object_missing_items.codicology_terms.keys.length }

--- a/spec/presenters/sinai/contents_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/contents_metadata_presenter_spec.rb
@@ -28,39 +28,39 @@ RSpec.describe Sinai::ContentsMetadataPresenter do
 
   context 'with a solr document containing contents metadata' do
     describe '#terms' do
-      it 'returns the Title Key' do
+      it 'returns the Descriptive title Key' do
         expect(config['descriptive_title_tesim'].to_s).to eq('Descriptive title')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Uniform title Key' do
         expect(config['uniform_title_tesim'].to_s).to eq('Uniform title')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Alternative title Key' do
         expect(config['alternative_title_tesim'].to_s).to eq('Alternative title')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Incipit Key' do
         expect(config['incipit_tesim'].to_s).to eq('Incipit')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Explicit Key' do
         expect(config['explicit_tesim'].to_s).to eq('Explicit')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Author Key' do
         expect(config['author_tesim'].to_s).to eq('Author')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Associated Name Key' do
         expect(config['associated_name_tesim'].to_s).to eq('Associated Name')
       end
-      
+
       it 'returns the Title Key' do
         expect(config['contents_note_tesim'].to_s).to eq('Contents note')
       end
     end
-  
+
     describe "#contents_terms terms" do
       let(:all) { presenter_object.contents_terms.keys.length }
       let(:missing) { presenter_object_missing_items.contents_terms.keys.length }

--- a/spec/presenters/sinai/contents_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/contents_metadata_presenter_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Sinai::ContentsMetadataPresenter do
+  let(:solr_doc) do
+    {
+      'descriptive_title_tesim' => 'Descriptive title',
+      'uniform_title_tesim' => 'Uniform title',
+      'alternative_title_tesim' => 'Alternative title',
+      'incipit_tesim' => 'Incipit',
+      'explicit_tesim' => 'Explicit',
+      'author_tesim' => 'Author',
+      'associated_name_tesim' => 'Associated Name',
+      'contents_note_tesim' => 'Contents note'
+    }
+  end
+  let(:solr_doc_missing_items) do
+    {
+      'descriptive_title_tesim' => 'Descriptive title',
+      'uniform_title_tesim' => 'Uniform title',
+      'alternative_title_tesim' => 'Alternative title',
+      'incipit_tesim' => 'Incipit'
+    }
+  end
+  let(:presenter_object) { described_class.new(document: solr_doc) }
+  let(:presenter_object_missing_items) { described_class.new(document: solr_doc_missing_items) }
+  let(:config) { YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/contents_metadata.yml'))) }
+
+  context 'with a solr document containing contents metadata' do
+    describe '#terms' do
+      it 'returns the Title Key' do
+        expect(config['descriptive_title_tesim'].to_s).to eq('Descriptive title')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['uniform_title_tesim'].to_s).to eq('Uniform title')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['alternative_title_tesim'].to_s).to eq('Alternative title')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['incipit_tesim'].to_s).to eq('Incipit')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['explicit_tesim'].to_s).to eq('Explicit')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['author_tesim'].to_s).to eq('Author')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['associated_name_tesim'].to_s).to eq('Associated Name')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['contents_note_tesim'].to_s).to eq('Contents note')
+      end
+    end
+  
+    describe "#contents_terms terms" do
+      let(:all) { presenter_object.contents_terms.keys.length }
+      let(:missing) { presenter_object_missing_items.contents_terms.keys.length }
+
+      it "returns existing keys" do
+        expect(all).to eq 8
+        expect(config.length).to eq all
+      end
+
+      it "is missing elements" do
+        expect(all - missing).to_not eq 0
+        expect(config.length - missing).to_not eq 0
+      end
+    end
+  end
+end

--- a/spec/presenters/sinai/decoration_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/decoration_metadata_presenter_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Sinai::DecorationMetadataPresenter do
       'illustrations_note_tesim' => 'Illustrations note'
     }
   end
-  #let(:solr_doc_missing_items) do
-  #  {
-  #    'illustrations_note_tesim' => 'Illustrations note'
-  #  }
-  #end
+  # let(:solr_doc_missing_items) do
+  #   {
+  #     'illustrations_note_tesim' => 'Illustrations note'
+  #   }
+  # end
   let(:presenter_object) { described_class.new(document: solr_doc) }
   let(:presenter_object_missing_items) { described_class.new(document: solr_doc_missing_items) }
   let(:config) { YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/decoration_metadata.yml'))) }
@@ -21,7 +21,6 @@ RSpec.describe Sinai::DecorationMetadataPresenter do
       it 'returns the Illustrations note' do
         expect(config['illustrations_note_tesim'].to_s).to eq('Illustrations note')
       end
-
     end
 
     describe "#decoration_terms" do
@@ -34,10 +33,10 @@ RSpec.describe Sinai::DecorationMetadataPresenter do
         expect(config.length).to eq all
       end
 
-      #it "is missing some elements" do
-      #  expect(all - missing).to_not eq 0
-      #  expect(config.length - missing).to_not eq 0
-      #end
+      # it "is missing some elements" do
+      #   expect(all - missing).to_not eq 0
+      #   expect(config.length - missing).to_not eq 0
+      # end
     end
   end
 end

--- a/spec/presenters/sinai/decoration_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/decoration_metadata_presenter_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Sinai::DecorationMetadataPresenter do
+  let(:solr_doc) do
+    {
+      'illustrations_note_tesim' => 'Illustrations note'
+    }
+  end
+  #let(:solr_doc_missing_items) do
+  #  {
+  #    'illustrations_note_tesim' => 'Illustrations note'
+  #  }
+  #end
+  let(:presenter_object) { described_class.new(document: solr_doc) }
+  let(:presenter_object_missing_items) { described_class.new(document: solr_doc_missing_items) }
+  let(:config) { YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/decoration_metadata.yml'))) }
+
+  context 'with a solr document containing overview metadata' do
+    describe 'config' do
+      it 'returns the Illustrations note' do
+        expect(config['illustrations_note_tesim'].to_s).to eq('Illustrations note')
+      end
+
+    end
+
+    describe "#decoration_terms" do
+      let(:all) { presenter_object.decoration_terms.keys.length }
+      let(:missing) { presenter_object_missing_items.decoration_terms.keys.length }
+
+      it "returns existing keys" do
+        expect(presenter_object.decoration_terms).to be_instance_of(Hash)
+        expect(all).to eq 1
+        expect(config.length).to eq all
+      end
+
+      #it "is missing some elements" do
+      #  expect(all - missing).to_not eq 0
+      #  expect(config.length - missing).to_not eq 0
+      #end
+    end
+  end
+end

--- a/spec/presenters/sinai/history_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/history_metadata_presenter_spec.rb
@@ -26,35 +26,35 @@ RSpec.describe Sinai::HistoryMetadataPresenter do
 
   context 'with a solr document containing history metadata' do
     describe '#terms' do
-      it 'returns the Title Key' do
+      it 'returns the Date created Key' do
         expect(config['date_created_tesim'].to_s).to eq('Date created')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Scribe Key' do
         expect(config['scribe_tesim'].to_s).to eq('Scribe')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Place of Origin Key' do
         expect(config['place_of_origin_tesim'].to_s).to eq('Place of Origin')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Colophon Key' do
         expect(config['colophon_tesim'].to_s).to eq('Colophon')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Hand note Key' do
         expect(config['hand_note_tesim'].to_s).to eq('Hand note')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Script note Key' do
         expect(config['script_tesim'].to_s).to eq('Script note')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Provenance Key' do
         expect(config['provenance_tesim'].to_s).to eq('Provenance')
       end
     end
-  
+
     describe "#history_terms terms" do
       let(:all) { presenter_object.history_terms.keys.length }
       let(:missing) { presenter_object_missing_items.history_terms.keys.length }

--- a/spec/presenters/sinai/history_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/history_metadata_presenter_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Sinai::HistoryMetadataPresenter do
+  let(:solr_doc) do
+    {
+      'date_created_tesim' => 'Date created',
+      'scribe_tesim' => 'Scribe',
+      'place_of_origin_tesim' => 'Place of Origin',
+      'colophon_tesim' => 'Colophon',
+      'hand_note_tesim' => 'Hand note',
+      'script_tesim' => 'Script note',
+      'provenance_tesim' => 'Provenance'
+    }
+  end
+  let(:solr_doc_missing_items) do
+    {
+      'date_created_tesim' => 'Date created',
+      'scribe_tesim' => 'Scribe',
+      'place_of_origin_tesim' => 'Place of Origin'
+    }
+  end
+  let(:presenter_object) { described_class.new(document: solr_doc) }
+  let(:presenter_object_missing_items) { described_class.new(document: solr_doc_missing_items) }
+  let(:config) { YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/history_metadata.yml'))) }
+
+  context 'with a solr document containing history metadata' do
+    describe '#terms' do
+      it 'returns the Title Key' do
+        expect(config['date_created_tesim'].to_s).to eq('Date created')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['scribe_tesim'].to_s).to eq('Scribe')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['place_of_origin_tesim'].to_s).to eq('Place of Origin')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['colophon_tesim'].to_s).to eq('Colophon')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['hand_note_tesim'].to_s).to eq('Hand note')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['script_tesim'].to_s).to eq('Script note')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['provenance_tesim'].to_s).to eq('Provenance')
+      end
+    end
+  
+    describe "#history_terms terms" do
+      let(:all) { presenter_object.history_terms.keys.length }
+      let(:missing) { presenter_object_missing_items.history_terms.keys.length }
+
+      it "returns existing keys" do
+        expect(all).to eq 7
+        expect(config.length).to eq all
+      end
+
+      it "is missing elements" do
+        expect(all - missing).to_not eq 0
+        expect(config.length - missing).to_not eq 0
+      end
+    end
+  end
+end

--- a/spec/presenters/sinai/keywords_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/keywords_metadata_presenter_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Sinai::KeywordsMetadataPresenter do
         expect(config['genre_tesim'].to_s).to eq('Genre')
       end
 
-      it 'returns the Genre Key' do
-        expect(config['features_tesim'].to_s).to eq('Genre')
+      it 'returns the Features Key' do
+        expect(config['features_tesim'].to_s).to eq('Features')
       end
 
       it 'returns the Place of Origin Key' do

--- a/spec/presenters/sinai/keywords_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/keywords_metadata_presenter_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Sinai::KeywordsMetadataPresenter do
+  let(:solr_doc) do
+    {
+      'genre_tesim' => 'Genre',
+      'features_tesim' => 'Features',
+      'place_of_origin_tesim' => 'Place of Origin',
+      'support_tesim' => 'Support',
+      'form_ssi' => 'Form'
+    }
+  end
+  let(:solr_doc_missing_items) do
+    {
+      'genre_tesim' => 'Genre',
+      'features_tesim' => 'Features',
+      'place_of_origin_tesim' => 'Place of Origin'
+    }
+  end
+  let(:presenter_object) { described_class.new(document: solr_doc) }
+  let(:presenter_object_missing_items) { described_class.new(document: solr_doc_missing_items) }
+  let(:config) { YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/keywords_metadata.yml'))) }
+
+  context 'with a solr document containing keywords metadata' do
+    describe '#terms' do
+      it 'returns the Title Key' do
+        expect(config['genre_tesim'].to_s).to eq('Genre')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['features_tesim'].to_s).to eq('Features')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['place_of_origin_tesim'].to_s).to eq('Place of Origin')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['support_tesim'].to_s).to eq('Support')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['form_ssi'].to_s).to eq('Form')
+      end
+
+    end
+  
+    describe "#keywords_terms terms" do
+      let(:all) { presenter_object.keywords_terms.keys.length }
+      let(:missing) { presenter_object_missing_items.keywords_terms.keys.length }
+
+      it "returns existing keys" do
+        expect(all).to eq 5
+        expect(config.length).to eq all
+      end
+
+      it "is missing elements" do
+        expect(all - missing).to_not eq 0
+        expect(config.length - missing).to_not eq 0
+      end
+    end
+  end
+end

--- a/spec/presenters/sinai/keywords_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/keywords_metadata_presenter_spec.rb
@@ -24,28 +24,27 @@ RSpec.describe Sinai::KeywordsMetadataPresenter do
 
   context 'with a solr document containing keywords metadata' do
     describe '#terms' do
-      it 'returns the Title Key' do
+      it 'returns the Genre Key' do
         expect(config['genre_tesim'].to_s).to eq('Genre')
       end
-      
-      it 'returns the Title Key' do
-        expect(config['features_tesim'].to_s).to eq('Features')
-      end
-      
-      it 'returns the Title Key' do
-        expect(config['place_of_origin_tesim'].to_s).to eq('Place of Origin')
-      end
-      
-      it 'returns the Title Key' do
-        expect(config['support_tesim'].to_s).to eq('Support')
-      end
-      
-      it 'returns the Title Key' do
-        expect(config['form_ssi'].to_s).to eq('Form')
+
+      it 'returns the Genre Key' do
+        expect(config['features_tesim'].to_s).to eq('Genre')
       end
 
+      it 'returns the Place of Origin Key' do
+        expect(config['place_of_origin_tesim'].to_s).to eq('Place of Origin')
+      end
+
+      it 'returns the Support Key' do
+        expect(config['support_tesim'].to_s).to eq('Support')
+      end
+
+      it 'returns the Form Key' do
+        expect(config['form_ssi'].to_s).to eq('Form')
+      end
     end
-  
+
     describe "#keywords_terms terms" do
       let(:all) { presenter_object.keywords_terms.keys.length }
       let(:missing) { presenter_object_missing_items.keywords_terms.keys.length }

--- a/spec/presenters/sinai/overview_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/overview_metadata_presenter_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Sinai::OverviewMetadataPresenter do
+  let(:solr_doc) do
+    {
+      'place_of_origin_tesim' => 'Place of origin',
+      'date_created_tesim' => 'Date created',
+      'foliation_tesim' => 'Foliation',
+      'form_ssi' => 'Form',
+      'human_readable_language_tesim' => 'Language',
+      'writing_system_tesim' => 'Writing system',
+      'script_tesim' => 'Script',
+      'repository_tesim' => 'Repository',
+      'human_readable_rights_statement_tesim' => 'Rights statement',
+      'services_contact_ssm' => 'Rights contact'
+    }
+  end
+  let(:solr_doc_missing_items) do
+    {
+      'place_of_origin_tesim' => 'Place of origin',
+      'date_created_tesim' => 'Date created',
+      'foliation_tesim' => 'Foliation',
+      'form_ssi' => 'Form',
+      'human_readable_language_tesim' => 'Language'
+    }
+  end
+  let(:presenter_object) { described_class.new(document: solr_doc) }
+  let(:presenter_object_missing_items) { described_class.new(document: solr_doc_missing_items) }
+  let(:config) { YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/overview_metadata.yml'))) }
+
+  context 'with a solr document containing overview metadata' do
+    describe '#terms' do
+      it 'returns the Title Key' do
+        expect(config['place_of_origin_tesim'].to_s).to eq('Place of origin')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['date_created_tesim'].to_s).to eq('Date created')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['foliation_tesim'].to_s).to eq('Foliation')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['form_ssi'].to_s).to eq('Form')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['human_readable_language_tesim'].to_s).to eq('Language')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['writing_system_tesim'].to_s).to eq('Writing system')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['script_tesim'].to_s).to eq('Script')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['repository_tesim'].to_s).to eq('Repository')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['human_readable_rights_statement_tesim'].to_s).to eq('Rights statement')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['services_contact_ssm'].to_s).to eq('Rights contact')
+      end
+    end
+  
+    describe "#overview_terms terms" do
+      let(:all) { presenter_object.overview_terms.keys.length }
+      let(:missing) { presenter_object_missing_items.overview_terms.keys.length }
+
+      it "returns existing keys" do
+        expect(all).to eq 10
+        expect(config.length).to eq all
+      end
+
+      it "is missing elements" do
+        expect(all - missing).to_not eq 0
+        expect(config.length - missing).to_not eq 0
+      end
+    end
+  end
+end

--- a/spec/presenters/sinai/overview_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/overview_metadata_presenter_spec.rb
@@ -31,47 +31,47 @@ RSpec.describe Sinai::OverviewMetadataPresenter do
 
   context 'with a solr document containing overview metadata' do
     describe '#terms' do
-      it 'returns the Title Key' do
+      it 'returns the Place of origin Key' do
         expect(config['place_of_origin_tesim'].to_s).to eq('Place of origin')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Date created Key' do
         expect(config['date_created_tesim'].to_s).to eq('Date created')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Foliation Key' do
         expect(config['foliation_tesim'].to_s).to eq('Foliation')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Form Key' do
         expect(config['form_ssi'].to_s).to eq('Form')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Language Key' do
         expect(config['human_readable_language_tesim'].to_s).to eq('Language')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Writing system Key' do
         expect(config['writing_system_tesim'].to_s).to eq('Writing system')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Script Key' do
         expect(config['script_tesim'].to_s).to eq('Script')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Repository Key' do
         expect(config['repository_tesim'].to_s).to eq('Repository')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Rights statement Key' do
         expect(config['human_readable_rights_statement_tesim'].to_s).to eq('Rights statement')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Rights contact Key' do
         expect(config['services_contact_ssm'].to_s).to eq('Rights contact')
       end
     end
-  
+
     describe "#overview_terms terms" do
       let(:all) { presenter_object.overview_terms.keys.length }
       let(:missing) { presenter_object_missing_items.overview_terms.keys.length }

--- a/spec/presenters/sinai/references_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/references_metadata_presenter_spec.rb
@@ -19,16 +19,16 @@ RSpec.describe Sinai::ReferencesMetadataPresenter do
 
   context 'with a solr document containing references metadata' do
     describe '#terms' do
-      it 'returns the Title Key' do
+      it 'returns the References Key' do
         expect(config['references_tesim'].to_s).to eq('References')
       end
-      
-      it 'returns the Title Key' do
+
+      it 'returns the Other version(s) Key' do
         expect(config['other_versions_tesim'].to_s).to eq('Other version(s)')
       end
-      
+
     end
-  
+
     describe "#references_terms terms" do
       let(:all) { presenter_object.references_terms.keys.length }
       let(:missing) { presenter_object_missing_items.references_terms.keys.length }

--- a/spec/presenters/sinai/references_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/references_metadata_presenter_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe Sinai::ReferencesMetadataPresenter do
       it 'returns the Other version(s) Key' do
         expect(config['other_versions_tesim'].to_s).to eq('Other version(s)')
       end
-
     end
 
     describe "#references_terms terms" do

--- a/spec/presenters/sinai/references_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/references_metadata_presenter_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Sinai::ReferencesMetadataPresenter do
+  let(:solr_doc) do
+    {
+      'references_tesim' => 'References',
+      'other_versions_tesim' => 'Other version(s)'
+    }
+  end
+  let(:solr_doc_missing_items) do
+    {
+      'references_tesim' => 'References'
+    }
+  end
+  let(:presenter_object) { described_class.new(document: solr_doc) }
+  let(:presenter_object_missing_items) { described_class.new(document: solr_doc_missing_items) }
+  let(:config) { YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/references_metadata.yml'))) }
+
+  context 'with a solr document containing references metadata' do
+    describe '#terms' do
+      it 'returns the Title Key' do
+        expect(config['references_tesim'].to_s).to eq('References')
+      end
+      
+      it 'returns the Title Key' do
+        expect(config['other_versions_tesim'].to_s).to eq('Other version(s)')
+      end
+      
+    end
+  
+    describe "#references_terms terms" do
+      let(:all) { presenter_object.references_terms.keys.length }
+      let(:missing) { presenter_object_missing_items.references_terms.keys.length }
+
+      it "returns existing keys" do
+        expect(all).to eq 2
+        expect(config.length).to eq all
+      end
+
+      it "is missing elements" do
+        expect(all - missing).to_not eq 0
+        expect(config.length - missing).to_not eq 0
+      end
+    end
+  end
+end

--- a/spec/presenters/ursus/item_overview_metadata_presenter_spec.rb
+++ b/spec/presenters/ursus/item_overview_metadata_presenter_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Ursus::ItemOverviewMetadataPresenter do
 
   context 'with a solr document containing overview metadata' do
     describe '#terms' do
-      it 'returns the Title Key' do
+      it 'returns the Sinai Title Key' do
         expect(config['title_tesim'].to_s).to eq('Title')
       end
 


### PR DESCRIPTION
Connected to [APPS-612](https://jira.library.ucla.edu/browse/APPS-612)
Configure metadata fields in rails for tabbed metadata box
Acceptance Criteria:

- [x] Consult with Dawn about new fields and content layout for the empty tab categories
- [x] New fields are configured in rails
---

#### Files
+ `app/presenters/sinai/codicology_metadata_presenter.rb`
+ `app/presenters/sinai/contents_metadata_presenter.rb`
+ `app/presenters/sinai/decoration_metadata_presenter.rb`
+ `app/presenters/sinai/history_metadata_presenter.rb`
+ `app/presenters/sinai/keywords_metadata_presenter.rb`
+ `app/presenters/sinai/overview_metadata_presenter.rb`
+ `app/presenters/sinai/references_metadata_presenter.rb`
+ `config/metadata-sinai/codicology_metadata.yml`
+ `config/metadata-sinai/contents_metadata.yml`
+ `config/metadata-sinai/decoration_metadata.yml`
+ `config/metadata-sinai/history_metadata.yml`
+ `config/metadata-sinai/keywords_metadata.yml`
+ `config/metadata-sinai/overview_metadata.yml`
+ `config/metadata-sinai/references_metadata.yml`
+ `app/views/catalog/_show.html.erb`
+ `config/metadata-sinai/codicology_metadata.yml`
+ `spec/presenters/sinai/codicology_metadata_presenter_spec.rb`
+ `spec/presenters/sinai/contents_metadata_presenter_spec.rb`
+ `spec/presenters/sinai/decoration_metadata_presenter_spec.rb`
+ `spec/presenters/sinai/history_metadata_presenter_spec.rb`
+ `spec/presenters/sinai/keywords_metadata_presenter_spec.rb`
+ `spec/presenters/sinai/overview_metadata_presenter_spec.rb`
+ `spec/presenters/sinai/references_metadata_presenter_spec.rb`
---