### PR TITLE
Add 4-column grid at Sinai XL breakpoint

### DIFF
--- a/app/assets/stylesheets/theme_sinai/components/_si-gallery-view.scss
+++ b/app/assets/stylesheets/theme_sinai/components/_si-gallery-view.scss
@@ -1,3 +1,8 @@
+.document__gallery-item--sinai {
+  // Note, bc of the way our sass compiles, classes in the .document__gallery-item base class will override these values. This is fine for now bc that class doesn't use the xl breakpoint. Hopefully we'll have the sinai and ursus codebases separated before we need to do anything else.
+  @extend .col-xl-3;
+}
+
 .document__gallery-thumbnail--sinai {
   img {
     width: 190px;

--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,5 +1,5 @@
 <% if Flipflop.sinai? %>
-  <div class="document document__gallery-item">
+  <div class="document document__gallery-item document__gallery-item--sinai">
     <div class="document__gallery-item-wrapper">
       <% if !cookies[:sinai_authenticated] %>
         <a href="#" class="document__gallery-item-thumbnail-link--sinai" data-toggle="modal" data-target="#exampleModalCenter">

--- a/e2e/cypress/integration/sinai_search_spec.js
+++ b/e2e/cypress/integration/sinai_search_spec.js
@@ -1,9 +1,9 @@
 /// <reference types="Cypress" />
-beforeEach(() => {
-  cy.visit(Cypress.env('SINAI_BASE_URL') + '/catalog');
-});
-
 describe('Sinai Search', () => {
+  beforeEach(() => {
+    cy.visit(Cypress.env('SINAI_BASE_URL') + '/catalog');
+  });
+
   it('Search Blank', () => {
     cy.get('[id=search]').click();
     cy.contains('span', 'You searched for:').should('not.exist');
@@ -24,7 +24,7 @@ describe('Sinai Search', () => {
     cy.get('[id=search]').click();
     cy.get('.search-count__heading').contains('Catalog Results');
     cy.get('.document-position-0 > .document__list-item-wrapper > .document__gallery-thumbnail > a > img').click();
-    cy.contains('h4','Item Overview');
+    cy.contains('h4', 'Item Overview');
   });
 
   it('Search Shelfmark Found', () => {

--- a/e2e/cypress/integration/ursus_facets_spec.js
+++ b/e2e/cypress/integration/ursus_facets_spec.js
@@ -1,8 +1,9 @@
-beforeEach(() => {
-  cy.visit(Cypress.env('baseUrl'));
-});
 
 describe('Facets', () => {
+  beforeEach(() => {
+    cy.visit(Cypress.env('baseUrl'));
+  });
+
   it('Subject', () => {
     cy.visit('/');
     cy.contains('a', 'Subject').click({ force: true });


### PR DESCRIPTION
Also fixes a bug that caused cypress to load the Sinai homepage before *every* test, including Ursus tests, sometimes causing an error.