### PR TITLE
Urs 960 sinai truncate to no more than 3 values per field on index page

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,6 +1,9 @@
 ---
 EnableDefaultLinters: true
-exclude: ["**/views_legacy/**"]
+exclude: 
+  - '**/views_legacy/**'
+  - '**/vendor/**/*'
+  - '**/node_modules/**/*'
 linters:
   ErbSafety:
     enabled: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,14 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: erblint
       run: bundle exec erblint --lint-all
+  
+  stylelint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
+    - run: yarn install --frozen-lockfile
+    - run: yarn run lint
 
   rspec:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: Run CI Suite
+
+on:
+  pull_request:
+    branches: [ master ]
+
+env:
+  COMPOSE_FILE: docker-compose-standalone.yml
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@b818bea8cf015031920150a891dbdd4105cc7e47
+      with:
+        ruby-version: '2.5'
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: rubocop
+      run: bundle exec rubocop
+
+  erblint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@b818bea8cf015031920150a891dbdd4105cc7e47
+      with:
+        ruby-version: '2.5'
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: erblint
+      run: bundle exec erblint --lint-all
+
+  rspec:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - name: Login to DockerHub
+      uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    - name: Start docker services
+      run: docker-compose up --detach db solr_test
+    - name: Initialize DB
+      run: docker-compose run web bundle exec rails db:setup
+    - name: run rspec
+      run: docker-compose run web bundle exec rspec spec
+    - name: Stop docker services
+      run: docker-compose down
+  
+  cypress:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+    - name: Login to DockerHub
+      uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    - name: Start docker services
+      run: docker-compose up --detach
+    - name: Initialize DBs
+      run: |
+        docker-compose up --detach db
+        docker-compose run web bundle exec rails db:setup
+        docker-compose run sinai bundle exec rails db:setup
+    - name: restart sinai container (can only set feature flag after db init)
+      run: docker-compose restart sinai
+    - name: prime the OAI-PMH rails engine (first load can be very slow)
+      run: curl localhost:3003/catalog/oai?verb=Identify
+    - uses: cypress-io/github-action@224f894ce0b082eba28a3a4562f630c54a17b432
+      with:
+        command-prefix: 'percy exec -- npx'
+        working-directory: e2e
+      env: 
+        PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+    - name: Stop docker services
+      run: docker-compose down

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,10 @@ Layout/BlockEndNewline:
   Exclude:
     - spec/features/search_catalog_spec.rb
 
+Performance/HashEachMethods:
+  Exclude:
+    - app/helpers/blacklight_helper.rb
+
 Lint/RequireParentheses:
   Exclude:
     - app/helpers/blacklight_helper.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,5 @@
 ---
 sudo: true
-language: node_js
-node_js:
-  - 10
-addons:
-  apt:
-    packages:
-      # Ubuntu 16+ does not install this dependency by default, so we need to install it ourselves
-      - libgconf-2-4
-cache:
-  # Caches $HOME/.npm when npm ci is default script command
-  # Caches node_modules in all other cases
-  npm: true
-  directories:
-    # we also need to cache folder with Cypress binary
-    - ~/.cache
-install:
-  - cd e2e && npm ci && cd .. && pwd
-services:
-  - docker
 env:
   global:
     - COMPOSE_FILE=docker-compose-ci.yml
@@ -27,13 +8,7 @@ env:
     - JENKINS_API_CALLISTO="${TRAVIS_JENKINS_API_CALLISTO}"
     - JENKINS_API_URSUS="${TRAVIS_JENKINS_API_URSUS}"
 script:
-  - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USER" --password-stdin
-  - docker-compose up --detach db
-  - docker-compose run web bundle exec rails db:setup
-  - docker-compose run sinai bundle exec rails db:setup
-  - docker-compose up --detach
-  - docker-compose run web sh start-ci.sh
-  - cd e2e && sh start-e2e.sh
+  - echo "No more tests in Travis! The only function remaining is to trigger Jenkins deploys."
 notifications:
   email: false
 after_success:

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -72,20 +72,43 @@ module BlacklightHelper
     end
   end
 
-  def render_truncated_list(d_presenter, sinai_index)
-    if sinai_index.length.positive?
-      sinai_index.each do |_field_name, field|
-        trunc = "<div class='metadata-value-index--sinai'>"
-        all_vals_array_truncated = (d_presenter.field_value field).split("&nbsp;|&nbsp;")[0..2]
-        count = 1
-        all_vals_array_truncated.each do |each_val|
-          trunc += each_val
-          trunc += " | " if count < all_vals_array_truncated.length
-          count += 1
-        end
-        trunc += "&nbsp;|&nbsp;..." if (d_presenter.field_value field).split("&nbsp;|&nbsp;").length > all_vals_array_truncated.length
-        return (trunc += "</div>").html_safe
+  def render_truncated_list(doc_presenter, sinai_index_language)
+
+    if sinai_index_language.length > 0
+      sinai_index_language.each do |field_name, field|
+        pone = "<div class='metadata-value-index--sinai'>".html_safe
+          all_vals = doc_presenter.field_value field
+          all_vals_array = all_vals.split("&nbsp;|&nbsp;")
+          all_vals_array_truncated = all_vals_array[0..2]
+          count = 1
+          all_vals_array_truncated.each do |each_val|
+            pone += each_val
+            if count < all_vals_array_truncated.length
+              pone += " | "
+            end
+            count += 1
+          end
+          if all_vals_array.length > all_vals_array_truncated.length
+            pone += ". ..."
+          end
+          return pone += "</div>".html_safe
       end
+
+    end
+
+
+
+
+  end
+
+  def render_truncated_list_oem(list_name)
+    truncated_output = String.new
+    content_tag :div, class: 'truncate-description' do
+      description = args[:value].first
+      button = "<span class='view-more' href>Read More <div class='down-arrow'>&raquo;</div></span></br>"
+      truncated_output << "<div class='description'>#{description}</div>#{button}</br>"
+      # return truncated_output.html_safe
+      return description
     end
   end
 end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -71,4 +71,44 @@ module BlacklightHelper
       table_contents[0]
     end
   end
+
+  def render_truncated_list(doc_presenter, sinai_index_language)
+
+    if sinai_index_language.length > 0
+      sinai_index_language.each do |field_name, field|
+        pone = "<div class='metadata-value-index--sinai'>".html_safe
+          all_vals = doc_presenter.field_value field
+          all_vals_array = all_vals.split("&nbsp;|&nbsp;")
+          all_vals_array_truncated = all_vals_array[0..2]
+          count = 1
+          all_vals_array_truncated.each do |each_val|
+            pone += each_val
+            if count < all_vals_array_truncated.length
+              pone += " | "
+            end
+            count += 1
+          end
+          if all_vals_array.length > all_vals_array_truncated.length
+            pone += ". ..."
+          end
+          return pone += "</div>".html_safe
+      end
+
+    end
+
+
+
+
+  end
+
+  def render_truncated_list_oem(list_name)
+    truncated_output = String.new
+    content_tag :div, class: 'truncate-description' do
+      description = args[:value].first
+      button = "<span class='view-more' href>Read More <div class='down-arrow'>&raquo;</div></span></br>"
+      truncated_output << "<div class='description'>#{description}</div>#{button}</br>"
+      # return truncated_output.html_safe
+      return description
+    end
+  end
 end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -80,9 +80,6 @@ module BlacklightHelper
         field_values = value.split("&nbsp;|&nbsp;") 
         trunc += field_values[0..2].join("&nbsp;|&nbsp;")
         trunc += "&nbsp;|&nbsp;..." if field_values.length > 3
-        trunc += "....."
-        trunc += sinai_index.length.to_s
-        trunc += "....."
         return (trunc += "</div>").html_safe
       end
     end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -72,12 +72,11 @@ module BlacklightHelper
     end
   end
 
-  def render_truncated_list(doc_presenter, sinai_index_language)
-
-    if sinai_index_language.length > 0
-      sinai_index_language.each do |field_name, field|
-        pone = "<div class='metadata-value-index--sinai'>".html_safe
-          all_vals = doc_presenter.field_value field
+  def render_truncated_list(d_presenter, sinai_index)
+    if sinai_index.length > 0
+      sinai_index.each do |field_name, field|
+        pone = "<div class='metadata-value-index--sinai'>"
+          all_vals = d_presenter.field_value field
           all_vals_array = all_vals.split("&nbsp;|&nbsp;")
           all_vals_array_truncated = all_vals_array[0..2]
           count = 1
@@ -89,26 +88,12 @@ module BlacklightHelper
             count += 1
           end
           if all_vals_array.length > all_vals_array_truncated.length
-            pone += ". ..."
+            pone += "&nbsp;|&nbsp;..."
           end
-          return pone += "</div>".html_safe
+          pone += "</div>"
+          return pone.html_safe
       end
-
-    end
-
-
-
-
-  end
-
-  def render_truncated_list_oem(list_name)
-    truncated_output = String.new
-    content_tag :div, class: 'truncate-description' do
-      description = args[:value].first
-      button = "<span class='view-more' href>Read More <div class='down-arrow'>&raquo;</div></span></br>"
-      truncated_output << "<div class='description'>#{description}</div>#{button}</br>"
-      # return truncated_output.html_safe
-      return description
     end
   end
+
 end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -76,14 +76,13 @@ module BlacklightHelper
     if sinai_index.length.positive?
       sinai_index.each do |_field_name, field|
         trunc = "<div class='metadata-value-index--sinai'>"
-        all_vals_array_truncated = (d_presenter.field_value field).split("&nbsp;|&nbsp;")[0..2]
-        count = 1
-        all_vals_array_truncated.each do |each_val|
-          trunc += each_val
-          trunc += " | " if count < all_vals_array_truncated.length
-          count += 1
-        end
-        trunc += "&nbsp;|&nbsp;..." if (d_presenter.field_value field).split("&nbsp;|&nbsp;").length > all_vals_array_truncated.length
+        value = (d_presenter.field_value field)
+        field_values = value.split("&nbsp;|&nbsp;") 
+        trunc += field_values[0..2].join("&nbsp;|&nbsp;")
+        trunc += "&nbsp;|&nbsp;..." if field_values.length > 3
+        trunc += "....."
+        trunc += sinai_index.length.to_s
+        trunc += "....."
         return (trunc += "</div>").html_safe
       end
     end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -73,27 +73,19 @@ module BlacklightHelper
   end
 
   def render_truncated_list(d_presenter, sinai_index)
-    if sinai_index.length > 0
-      sinai_index.each do |field_name, field|
-        pone = "<div class='metadata-value-index--sinai'>"
-          all_vals = d_presenter.field_value field
-          all_vals_array = all_vals.split("&nbsp;|&nbsp;")
-          all_vals_array_truncated = all_vals_array[0..2]
-          count = 1
-          all_vals_array_truncated.each do |each_val|
-            pone += each_val
-            if count < all_vals_array_truncated.length
-              pone += " | "
-            end
-            count += 1
-          end
-          if all_vals_array.length > all_vals_array_truncated.length
-            pone += "&nbsp;|&nbsp;..."
-          end
-          pone += "</div>"
-          return pone.html_safe
+    if sinai_index.length.positive?
+      sinai_index.each do |_field_name, field|
+        trunc = "<div class='metadata-value-index--sinai'>"
+        all_vals_array_truncated = (d_presenter.field_value field).split("&nbsp;|&nbsp;")[0..2]
+        count = 1
+        all_vals_array_truncated.each do |each_val|
+          trunc += each_val
+          trunc += " | " if count < all_vals_array_truncated.length
+          count += 1
+        end
+        trunc += "&nbsp;|&nbsp;..." if (d_presenter.field_value field).split("&nbsp;|&nbsp;").length > all_vals_array_truncated.length
+        return (trunc += "</div>").html_safe
       end
     end
   end
-
 end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -77,10 +77,11 @@ module BlacklightHelper
       sinai_index.each do |_field_name, field|
         trunc = "<div class='metadata-value-index--sinai'>"
         value = (d_presenter.field_value field)
-        field_values = value.split("&nbsp;|&nbsp;") 
+        field_values = value.split("&nbsp;|&nbsp;")
         trunc += field_values[0..2].join("&nbsp;|&nbsp;")
         trunc += "&nbsp;|&nbsp;..." if field_values.length > 3
-        return (trunc += "</div>").html_safe
+        trunc += "</div>"
+        return trunc.html_safe
       end
     end
   end

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -48,6 +48,7 @@
         </div>
         <%# NAMES %>
         <% name_field = render 'catalog/index_name_sinai', document: document %>
+        111<%= name_field %>222
         <% if name_field.length > 2 %>
           <div class='metadata-block-index--sinai'>
             <div class='metadata-value-index--sinai'>
@@ -84,9 +85,10 @@
         </div>
         <%# NAMES %>
         <% name_field = render 'catalog/index_name_sinai', document: document %>
+        333<%= name_field.to_s %>444
         <% if name_field.length > 2 %>
           <div class='metadata-block-index--sinai'>
-            <%= image_tag('sinai-icons/people-icon.svg', class: 'icon-people-index--sinai') %><%= name_field.length %>
+            <%= image_tag('sinai-icons/people-icon.svg', class: 'icon-people-index--sinai') %><%= name_field %>
           </div><%# metadata-block-index--sinai %>
         <% end %>
       </div><%# metadata-wrapper-index--sinai %>

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -48,8 +48,7 @@
         </div>
         <%# NAMES %>
         <% name_field = render 'catalog/index_name_sinai', document: document %>
-        111<%= name_field %>222
-        <% if name_field.length > 2 %>
+        <% if name_field =~ /href/ %>
           <div class='metadata-block-index--sinai'>
             <div class='metadata-value-index--sinai'>
                 <%= image_tag('sinai-icons/people-icon.svg', class: 'icon-people-index--sinai') %><%= name_field %>
@@ -85,8 +84,7 @@
         </div>
         <%# NAMES %>
         <% name_field = render 'catalog/index_name_sinai', document: document %>
-        333<%= name_field.to_s %>444
-        <% if name_field.length > 2 %>
+        <% if name_field =~ /href/ %>
           <div class='metadata-block-index--sinai'>
             <%= image_tag('sinai-icons/people-icon.svg', class: 'icon-people-index--sinai') %><%= name_field %>
           </div><%# metadata-block-index--sinai %>

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -86,7 +86,7 @@
         <% name_field = render 'catalog/index_name_sinai', document: document %>
         <% if name_field.length > 2 %>
           <div class='metadata-block-index--sinai'>
-            <%= image_tag('sinai-icons/people-icon.svg', class: 'icon-people-index--sinai') %><%= name_field %>
+            <%= image_tag('sinai-icons/people-icon.svg', class: 'icon-people-index--sinai') %><%= name_field.length %>
           </div><%# metadata-block-index--sinai %>
         <% end %>
       </div><%# metadata-wrapper-index--sinai %>

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -84,7 +84,7 @@
         </div>
         <%# NAMES %>
         <% name_field = render 'catalog/index_name_sinai', document: document %>
-        <% if name_field.length > 97 %>
+        <% if name_field.length > 100 %>
           <div class='metadata-block-index--sinai'>
             <%= image_tag('sinai-icons/people-icon.svg', class: 'icon-people-index--sinai') %><%= name_field %>
           </div><%# metadata-block-index--sinai %>

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -84,7 +84,7 @@
         </div>
         <%# NAMES %>
         <% name_field = render 'catalog/index_name_sinai', document: document %>
-        <% if name_field.length > 100 %>
+        <% if name_field.length > 2 %>
           <div class='metadata-block-index--sinai'>
             <%= image_tag('sinai-icons/people-icon.svg', class: 'icon-people-index--sinai') %><%= name_field %>
           </div><%# metadata-block-index--sinai %>

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -84,7 +84,7 @@
         </div>
         <%# NAMES %>
         <% name_field = render 'catalog/index_name_sinai', document: document %>
-        <% if name_field.length > 2 && name_field.length != 101 %>
+        <% if name_field.length > 97 %>
           <div class='metadata-block-index--sinai'>
             <%= image_tag('sinai-icons/people-icon.svg', class: 'icon-people-index--sinai') %><%= name_field %>
           </div><%# metadata-block-index--sinai %>

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -84,11 +84,9 @@
         </div>
         <%# NAMES %>
         <% name_field = render 'catalog/index_name_sinai', document: document %>
-        <% if name_field.length > 2 %>
+        <% if name_field.length > 2 && name_field.length != 101 %>
           <div class='metadata-block-index--sinai'>
-            <div class='metadata-value-index--sinai'>
-                <%= image_tag('sinai-icons/people-icon.svg', class: 'icon-people-index--sinai') %><%= name_field %>
-            </div>
+            <%= image_tag('sinai-icons/people-icon.svg', class: 'icon-people-index--sinai') %><%= name_field %>
           </div><%# metadata-block-index--sinai %>
         <% end %>
       </div><%# metadata-wrapper-index--sinai %>

--- a/app/views/catalog/_index_language_sinai.html.erb
+++ b/app/views/catalog/_index_language_sinai.html.erb
@@ -4,10 +4,28 @@
 <% sinai_index_language = Ursus::SinaiIndexLanguagePresenter.new(document: doc_presenter.fields_to_render).sinai_index_language_terms %>
 
 <% if sinai_index_language.length > 0 %>
+  <% count = 1 %>
   <% sinai_index_language.each do |field_name, field| -%>
-    <!-- VALUE -->
     <div class='metadata-value-index--sinai'>
-      <%= doc_presenter.field_value field %>
+    <% if count < sinai_index_language.length %>
+      <%= doc_presenter.field_value field %>&nbsp;|
+      <% count += 1 %>
+    <% else %>
+      <% all_vals = doc_presenter.field_value field %>
+      <% all_vals_array = all_vals.split("|") %>
+      <% all_vals_array_truncated = all_vals_array[0..2] %>
+      <% count2 = 1 %>
+      <% all_vals_array_truncated.each do |each_val| -%>
+        <%= each_val.html_safe %>
+        <% if count2 < all_vals_array_truncated.length %>
+          <%= '|'.html_safe %>
+        <% end %>
+        <% count2 += 1 %>
+      <% end %>
+      <% if all_vals_array.length > all_vals_array_truncated.length %>
+        <%= '| ...'.html_safe %>
+      <% end %>
+    <% end %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/catalog/_index_language_sinai.html.erb
+++ b/app/views/catalog/_index_language_sinai.html.erb
@@ -3,27 +3,4 @@
 <% doc_presenter = index_presenter(document) %>
 <% sinai_index_language = Ursus::SinaiIndexLanguagePresenter.new(document: doc_presenter.fields_to_render).sinai_index_language_terms %>
 
-<% if sinai_index_language.length > 0 %>
-  <% sinai_index_language.each do |field_name, field| -%>
-    <div class='metadata-value-index--sinai'>
-      <% all_vals = doc_presenter.field_value field %>
-      <% all_vals_array = all_vals.split("&nbsp;|&nbsp;") %>
-      <% all_vals_array_truncated = all_vals_array[0..2] %>
-      <% count = 1 %>
-      <% all_vals_array_truncated.each do |each_val| -%>
-        <%= each_val.html_safe %>
-        <% if count < all_vals_array_truncated.length %>
-          <%= '|'.html_safe %>
-        <% end %>
-        <% count += 1 %>
-      <% end %>
-      <% if all_vals_array.length > all_vals_array_truncated.length %>
-        <%= '| ...'.html_safe %>
-      <% end %>
-    </div>
-  <% end %>
-<% end %>
-
-
 <%= render_truncated_list(doc_presenter, sinai_index_language) %>
-  

--- a/app/views/catalog/_index_language_sinai.html.erb
+++ b/app/views/catalog/_index_language_sinai.html.erb
@@ -4,28 +4,26 @@
 <% sinai_index_language = Ursus::SinaiIndexLanguagePresenter.new(document: doc_presenter.fields_to_render).sinai_index_language_terms %>
 
 <% if sinai_index_language.length > 0 %>
-  <% count = 1 %>
   <% sinai_index_language.each do |field_name, field| -%>
     <div class='metadata-value-index--sinai'>
-    <% if count < sinai_index_language.length %>
-      <%= doc_presenter.field_value field %>&nbsp;|
-      <% count += 1 %>
-    <% else %>
       <% all_vals = doc_presenter.field_value field %>
-      <% all_vals_array = all_vals.split("|") %>
+      <% all_vals_array = all_vals.split("&nbsp;|&nbsp;") %>
       <% all_vals_array_truncated = all_vals_array[0..2] %>
-      <% count2 = 1 %>
+      <% count = 1 %>
       <% all_vals_array_truncated.each do |each_val| -%>
         <%= each_val.html_safe %>
-        <% if count2 < all_vals_array_truncated.length %>
+        <% if count < all_vals_array_truncated.length %>
           <%= '|'.html_safe %>
         <% end %>
-        <% count2 += 1 %>
+        <% count += 1 %>
       <% end %>
       <% if all_vals_array.length > all_vals_array_truncated.length %>
         <%= '| ...'.html_safe %>
       <% end %>
-    <% end %>
     </div>
   <% end %>
 <% end %>
+
+
+<%= render_truncated_list(doc_presenter, sinai_index_language) %>
+  

--- a/app/views/catalog/_index_language_sinai.html.erb
+++ b/app/views/catalog/_index_language_sinai.html.erb
@@ -3,4 +3,29 @@
 <% doc_presenter = index_presenter(document) %>
 <% sinai_index_language = Ursus::SinaiIndexLanguagePresenter.new(document: doc_presenter.fields_to_render).sinai_index_language_terms %>
 
-<%= render_truncated_list(doc_presenter, sinai_index_language) %>
+<% if sinai_index_language.length > 0 %>
+  <% count = 1 %>
+  <% sinai_index_language.each do |field_name, field| -%>
+    <div class='metadata-value-index--sinai'>
+    <% if count < sinai_index_language.length %>
+      <%= doc_presenter.field_value field %>&nbsp;|
+      <% count += 1 %>
+    <% else %>
+      <% all_vals = doc_presenter.field_value field %>
+      <% all_vals_array = all_vals.split("|") %>
+      <% all_vals_array_truncated = all_vals_array[0..2] %>
+      <% count2 = 1 %>
+      <% all_vals_array_truncated.each do |each_val| -%>
+        <%= each_val.html_safe %>
+        <% if count2 < all_vals_array_truncated.length %>
+          <%= '|'.html_safe %>
+        <% end %>
+        <% count2 += 1 %>
+      <% end %>
+      <% if all_vals_array.length > all_vals_array_truncated.length %>
+        <%= '| ...'.html_safe %>
+      <% end %>
+    <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/catalog/_index_name_sinai.html.erb
+++ b/app/views/catalog/_index_name_sinai.html.erb
@@ -3,7 +3,4 @@
 <% doc_presenter = index_presenter(document) %>
 <% sinai_index_name = Ursus::SinaiIndexNameMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_name_terms %>
 
-zzzzzzz<%= sinai_index_name %>qqqqqqqqqqq
-
-
-<%= render_truncated_list(doc_presenter, sinai_index_name) if sinai_index_name.eql?("{}") %>
+<%= render_truncated_list(doc_presenter, sinai_index_name) %>

--- a/app/views/catalog/_index_name_sinai.html.erb
+++ b/app/views/catalog/_index_name_sinai.html.erb
@@ -3,4 +3,7 @@
 <% doc_presenter = index_presenter(document) %>
 <% sinai_index_name = Ursus::SinaiIndexNameMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_name_terms %>
 
-<%= render_truncated_list(doc_presenter, sinai_index_name) %>
+zzzzzzz<%= sinai_index_name %>qqqqqqqqqqq
+
+
+<%= render_truncated_list(doc_presenter, sinai_index_name) if sinai_index_name.eql?("{}") %>

--- a/app/views/catalog/_index_name_sinai.html.erb
+++ b/app/views/catalog/_index_name_sinai.html.erb
@@ -4,26 +4,22 @@
 <% sinai_index_name = Ursus::SinaiIndexNameMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_name_terms %>
 
 <% if sinai_index_name.length > 0 %>
-  <% count = 1 %>
   <% sinai_index_name.each do |field_name, field| -%>
-    <% if count < sinai_index_name.length %>
-      <%= doc_presenter.field_value field %>&nbsp;|
-      <% count += 1 %>
-    <% else %>
+    <div class='metadata-value-index--sinai'>
       <% all_vals = doc_presenter.field_value field %>
       <% all_vals_array = all_vals.split("|") %>
       <% all_vals_array_truncated = all_vals_array[0..2] %>
-      <% count2 = 1 %>
+      <% count = 1 %>
       <% all_vals_array_truncated.each do |each_val| -%>
         <%= each_val.html_safe %>
-        <% if count2 < all_vals_array_truncated.length %>
+        <% if count < all_vals_array_truncated.length %>
           <%= '|'.html_safe %>
         <% end %>
-        <% count2 += 1 %>
+        <% count += 1 %>
       <% end %>
       <% if all_vals_array.length > all_vals_array_truncated.length %>
         <%= '| ...'.html_safe %>
       <% end %>
-    <% end %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/catalog/_index_name_sinai.html.erb
+++ b/app/views/catalog/_index_name_sinai.html.erb
@@ -3,4 +3,27 @@
 <% doc_presenter = index_presenter(document) %>
 <% sinai_index_name = Ursus::SinaiIndexNameMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_name_terms %>
 
-<%= render_truncated_list(doc_presenter, sinai_index_name) %>
+<% if sinai_index_name.length > 0 %>
+  <% count = 1 %>
+  <% sinai_index_name.each do |field_name, field| -%>
+    <% if count < sinai_index_name.length %>
+      <%= doc_presenter.field_value field %>&nbsp;|
+      <% count += 1 %>
+    <% else %>
+      <% all_vals = doc_presenter.field_value field %>
+      <% all_vals_array = all_vals.split("|") %>
+      <% all_vals_array_truncated = all_vals_array[0..2] %>
+      <% count2 = 1 %>
+      <% all_vals_array_truncated.each do |each_val| -%>
+        <%= each_val.html_safe %>
+        <% if count2 < all_vals_array_truncated.length %>
+          <%= '|'.html_safe %>
+        <% end %>
+        <% count2 += 1 %>
+      <% end %>
+      <% if all_vals_array.length > all_vals_array_truncated.length %>
+        <%= '| ...'.html_safe %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/catalog/_index_name_sinai.html.erb
+++ b/app/views/catalog/_index_name_sinai.html.erb
@@ -3,23 +3,4 @@
 <% doc_presenter = index_presenter(document) %>
 <% sinai_index_name = Ursus::SinaiIndexNameMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_name_terms %>
 
-<% if sinai_index_name.length > 0 %>
-  <% sinai_index_name.each do |field_name, field| -%>
-    <div class='metadata-value-index--sinai'>
-      <% all_vals = doc_presenter.field_value field %>
-      <% all_vals_array = all_vals.split("|") %>
-      <% all_vals_array_truncated = all_vals_array[0..2] %>
-      <% count = 1 %>
-      <% all_vals_array_truncated.each do |each_val| -%>
-        <%= each_val.html_safe %>
-        <% if count < all_vals_array_truncated.length %>
-          <%= '|'.html_safe %>
-        <% end %>
-        <% count += 1 %>
-      <% end %>
-      <% if all_vals_array.length > all_vals_array_truncated.length %>
-        <%= '| ...'.html_safe %>
-      <% end %>
-    </div>
-  <% end %>
-<% end %>
+<%= render_truncated_list(doc_presenter, sinai_index_name) %>

--- a/app/views/catalog/_index_name_sinai.html.erb
+++ b/app/views/catalog/_index_name_sinai.html.erb
@@ -4,8 +4,26 @@
 <% sinai_index_name = Ursus::SinaiIndexNameMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_name_terms %>
 
 <% if sinai_index_name.length > 0 %>
+  <% count = 1 %>
   <% sinai_index_name.each do |field_name, field| -%>
-    <!-- VALUE -->
-    <%= doc_presenter.field_value field %>
+    <% if count < sinai_index_name.length %>
+      <%= doc_presenter.field_value field %>&nbsp;|
+      <% count += 1 %>
+    <% else %>
+      <% all_vals = doc_presenter.field_value field %>
+      <% all_vals_array = all_vals.split("|") %>
+      <% all_vals_array_truncated = all_vals_array[0..2] %>
+      <% count2 = 1 %>
+      <% all_vals_array_truncated.each do |each_val| -%>
+        <%= each_val.html_safe %>
+        <% if count2 < all_vals_array_truncated.length %>
+          <%= '|'.html_safe %>
+        <% end %>
+        <% count2 += 1 %>
+      <% end %>
+      <% if all_vals_array.length > all_vals_array_truncated.length %>
+        <%= '| ...'.html_safe %>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/catalog/_index_title_sinai.html.erb
+++ b/app/views/catalog/_index_title_sinai.html.erb
@@ -1,5 +1,5 @@
 <%# SINAI ONLY %>
-<%# Combine fields for the Title value. %>
+<%# Combine fields for the Title value %>
 <%# TITLE: descriptive_title_one | descriptive_title_two | uniform_title_one | uniform_title_two %>
 
 <% doc_presenter = index_presenter(document) %>

--- a/app/views/catalog/_index_title_sinai.html.erb
+++ b/app/views/catalog/_index_title_sinai.html.erb
@@ -9,7 +9,7 @@
   <% count = 1 %>
   <% sinai_index_title.each do |field_name, field| -%>
     <% if count < sinai_index_title.length %>
-      <%= doc_presenter.field_value field %>
+      <%= doc_presenter.field_value field %>&nbsp;|
       <% count += 1 %>
     <% else %>
       <% all_vals = doc_presenter.field_value field %>

--- a/app/views/catalog/_index_title_sinai.html.erb
+++ b/app/views/catalog/_index_title_sinai.html.erb
@@ -1,5 +1,5 @@
 <%# SINAI ONLY %>
-<%# Combine fields for the Title value %>
+<%# Combine fields for the Title value. %>
 <%# TITLE: descriptive_title_one | descriptive_title_two | uniform_title_one | uniform_title_two %>
 
 <% doc_presenter = index_presenter(document) %>

--- a/app/views/catalog/_index_title_sinai.html.erb
+++ b/app/views/catalog/_index_title_sinai.html.erb
@@ -5,4 +5,27 @@
 <% doc_presenter = index_presenter(document) %>
 <% sinai_index_title = Ursus::SinaiIndexTitleMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_title_terms %>
 
-<%= render_truncated_list(doc_presenter, sinai_index_title) %>
+<% if sinai_index_title.length > 0 %>
+  <% count = 1 %>
+  <% sinai_index_title.each do |field_name, field| -%>
+    <% if count < sinai_index_title.length %>
+      <%= doc_presenter.field_value field %>
+      <% count += 1 %>
+    <% else %>
+      <% all_vals = doc_presenter.field_value field %>
+      <% all_vals_array = all_vals.split("|") %>
+      <% all_vals_array_truncated = all_vals_array[0..1] %>
+      <% count2 = 1 %>
+      <% all_vals_array_truncated.each do |each_val| -%>
+        <%= each_val.html_safe %>
+        <% if count2 < all_vals_array_truncated.length %>
+          <%= '|'.html_safe %>
+        <% end %>
+        <% count2 += 1 %>
+      <% end %>
+      <% if all_vals_array.length > all_vals_array_truncated.length %>
+        <%= '| ...'.html_safe %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/catalog/_index_title_sinai.html.erb
+++ b/app/views/catalog/_index_title_sinai.html.erb
@@ -9,10 +9,23 @@
   <% count = 1 %>
   <% sinai_index_title.each do |field_name, field| -%>
     <% if count < sinai_index_title.length %>
-      <%= doc_presenter.field_value field %>&nbsp;|
+      <%= doc_presenter.field_value field %>
       <% count += 1 %>
     <% else %>
-      <%= doc_presenter.field_value field %>
+      <% all_vals = doc_presenter.field_value field %>
+      <% all_vals_array = all_vals.split("|") %>
+      <% all_vals_array_truncated = all_vals_array[0..1] %>
+      <% count2 = 1 %>
+      <% all_vals_array_truncated.each do |each_val| -%>
+        <%= each_val.html_safe %>
+        <% if count2 < all_vals_array_truncated.length %>
+          <%= '|'.html_safe %>
+        <% end %>
+        <% count2 += 1 %>
+      <% end %>
+      <% if all_vals_array.length > all_vals_array_truncated.length %>
+        <%= '| ...'.html_safe %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/catalog/_index_title_sinai.html.erb
+++ b/app/views/catalog/_index_title_sinai.html.erb
@@ -5,27 +5,4 @@
 <% doc_presenter = index_presenter(document) %>
 <% sinai_index_title = Ursus::SinaiIndexTitleMetadataPresenter.new(document: doc_presenter.fields_to_render).sinai_index_title_terms %>
 
-<% if sinai_index_title.length > 0 %>
-  <% count = 1 %>
-  <% sinai_index_title.each do |field_name, field| -%>
-    <% if count < sinai_index_title.length %>
-      <%= doc_presenter.field_value field %>&nbsp;|
-      <% count += 1 %>
-    <% else %>
-      <% all_vals = doc_presenter.field_value field %>
-      <% all_vals_array = all_vals.split("|") %>
-      <% all_vals_array_truncated = all_vals_array[0..1] %>
-      <% count2 = 1 %>
-      <% all_vals_array_truncated.each do |each_val| -%>
-        <%= each_val.html_safe %>
-        <% if count2 < all_vals_array_truncated.length %>
-          <%= '|'.html_safe %>
-        <% end %>
-        <% count2 += 1 %>
-      <% end %>
-      <% if all_vals_array.length > all_vals_array_truncated.length %>
-        <%= '| ...'.html_safe %>
-      <% end %>
-    <% end %>
-  <% end %>
-<% end %>
+<%= render_truncated_list(doc_presenter, sinai_index_title) %>

--- a/config/metadata-sinai/overview_metadata.yml
+++ b/config/metadata-sinai/overview_metadata.yml
@@ -3,7 +3,7 @@
 # Sinai only - Overview
 place_of_origin_tesim: 'Place of origin'
 date_created_tesim: 'Date created'
-foliation_tesim: 'Foliation'
+extent_tesim: 'Extent'
 form_ssi: 'Form'
 human_readable_language_tesim: 'Language'
 writing_system_tesim: 'Writing system'

--- a/e2e/cypress/integration/ursus_search_spec.js
+++ b/e2e/cypress/integration/ursus_search_spec.js
@@ -71,7 +71,7 @@ describe('Search', () => {
   it('Title links to item page', () => {
     cy.visit('/catalog?utf8=%E2%9C%93&q=&search_field=all_fields');
     cy.get('h3.document__list-title').eq(0).find('a').click();
-    cy.get('.item-page__pagination-widgets').should('contain', '1 of')
+    cy.get('.item-page__pagination-widgets',{ timeout: 100000 }).should('contain', '1 of')
   });
 
   it('Thumbnail links to item page', () => {

--- a/spec/presenters/sinai/overview_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/overview_metadata_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Sinai::OverviewMetadataPresenter do
     {
       'place_of_origin_tesim' => 'Place of origin',
       'date_created_tesim' => 'Date created',
-      'foliation_tesim' => 'Foliation',
+      'extent_tesim' => 'Extent',
       'form_ssi' => 'Form',
       'human_readable_language_tesim' => 'Language',
       'writing_system_tesim' => 'Writing system',
@@ -20,7 +20,7 @@ RSpec.describe Sinai::OverviewMetadataPresenter do
     {
       'place_of_origin_tesim' => 'Place of origin',
       'date_created_tesim' => 'Date created',
-      'foliation_tesim' => 'Foliation',
+      'extent_tesim' => 'Extent',
       'form_ssi' => 'Form',
       'human_readable_language_tesim' => 'Language'
     }
@@ -39,8 +39,8 @@ RSpec.describe Sinai::OverviewMetadataPresenter do
         expect(config['date_created_tesim'].to_s).to eq('Date created')
       end
 
-      it 'returns the Foliation Key' do
-        expect(config['foliation_tesim'].to_s).to eq('Foliation')
+      it 'returns the Extent Key' do
+        expect(config['extent_tesim'].to_s).to eq('Extent')
       end
 
       it 'returns the Form Key' do


### PR DESCRIPTION
Connected to [URS-960](https://jira.library.ucla.edu/browse/URS-960)
Sinai: truncate three Sinai index page list view fields to a maximum of three values. If more than three values exist, display ellipsis (...) after the third value.

- Title
- Language
- Name

Acceptance Criteria:

- [x] The Title, Language and Name fields are truncated to a max of three values on the Sinai index page list view
- [x] If more than three values exist, ellipsis (...) are displayed after the third value

---

#### Files
+ `.rubocop.yml`
+ `app/helpers/blacklight_helper.rb`
+ `app/views/catalog/_index_language_sinai.html.erb`
+ `app/views/catalog/_index_name_sinai.html.erb`
+ `app/views/catalog/_index_title_sinai.html.erb`

---

Demo from local system (two values displayed due to limited data)
![20210225_urs-960_ ellipsis](https://user-images.githubusercontent.com/2350153/109225635-61758180-7772-11eb-8ae2-bfe88d0d86ac.jpg)
