### PR TITLE
APPS-646 Sinai: Replace "Foliation" field in item overview with "Extent" field

### DIFF
--- a/config/metadata-sinai/overview_metadata.yml
+++ b/config/metadata-sinai/overview_metadata.yml
@@ -3,7 +3,7 @@
 # Sinai only - Overview
 place_of_origin_tesim: 'Place of origin'
 date_created_tesim: 'Date created'
-foliation_tesim: 'Foliation'
+extent_tesim: 'Extent'
 form_ssi: 'Form'
 human_readable_language_tesim: 'Language'
 writing_system_tesim: 'Writing system'

--- a/e2e/cypress/integration/ursus_search_spec.js
+++ b/e2e/cypress/integration/ursus_search_spec.js
@@ -71,7 +71,7 @@ describe('Search', () => {
   it('Title links to item page', () => {
     cy.visit('/catalog?utf8=%E2%9C%93&q=&search_field=all_fields');
     cy.get('h3.document__list-title').eq(0).find('a').click();
-    cy.get('.item-page__pagination-widgets').should('contain', '1 of')
+    cy.get('.item-page__pagination-widgets',{ timeout: 100000 }).should('contain', '1 of')
   });
 
   it('Thumbnail links to item page', () => {

--- a/spec/presenters/sinai/overview_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/overview_metadata_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Sinai::OverviewMetadataPresenter do
     {
       'place_of_origin_tesim' => 'Place of origin',
       'date_created_tesim' => 'Date created',
-      'foliation_tesim' => 'Foliation',
+      'extent_tesim' => 'Extent',
       'form_ssi' => 'Form',
       'human_readable_language_tesim' => 'Language',
       'writing_system_tesim' => 'Writing system',
@@ -20,7 +20,7 @@ RSpec.describe Sinai::OverviewMetadataPresenter do
     {
       'place_of_origin_tesim' => 'Place of origin',
       'date_created_tesim' => 'Date created',
-      'foliation_tesim' => 'Foliation',
+      'extent_tesim' => 'Extent',
       'form_ssi' => 'Form',
       'human_readable_language_tesim' => 'Language'
     }
@@ -39,8 +39,8 @@ RSpec.describe Sinai::OverviewMetadataPresenter do
         expect(config['date_created_tesim'].to_s).to eq('Date created')
       end
 
-      it 'returns the Foliation Key' do
-        expect(config['foliation_tesim'].to_s).to eq('Foliation')
+      it 'returns the Extent Key' do
+        expect(config['extent_tesim'].to_s).to eq('Extent')
       end
 
       it 'returns the Form Key' do


### PR DESCRIPTION
Related to [APPS-646](https://jira.library.ucla.edu/browse/APPS-646)

Acceptance Criteria:

- [x] In the Item Overview section of the Sinai Item page, the Foliation field label and value pair is removed and replaced with the Extent label and value.