### PR TITLE
Run CI when PR merged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Run CI Suite
 
 on:
+  push:
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
runs the CI suite on a push to master, which should only happen when a PR is merged. This should allow percy to set baseline screenshots.