### PR TITLE
URS-931 Fix A11y errors in Ursus beta banner

### DIFF
--- a/app/assets/stylesheets/base/layout/header/_navbar-alert.scss
+++ b/app/assets/stylesheets/base/layout/header/_navbar-alert.scss
@@ -19,12 +19,19 @@
   font-weight: 700;
   flex-basis: 90%;
 
+  a {
+    text-decoration: underline;
+  }
+
   @media (max-width: 767px) {
     flex-basis: 80%;
   }
 }
 
 .alert-bar__close {
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
   font-weight: 500;
 
   &:hover {
@@ -36,4 +43,8 @@
     padding-left: 0.5rem;
     color: $gray-80;
   }
+}
+
+.alert-bar__button {
+  padding: 5px;
 }

--- a/app/views/shared/header/_alert-bar.html.erb
+++ b/app/views/shared/header/_alert-bar.html.erb
@@ -12,9 +12,9 @@
     <span class="alert-bar__text">
       Welcome to Digital Collections (Beta)! This site is growing each week as we migrate content from our <a href="http://digital2.library.ucla.edu/" target="_blank" rel="noopener">Legacy Site</a>.
     </span>
-    <span class="alert-bar__close" onclick="toggleFunction()">Close
-    <button type="button alert-bar__button" class="close" data-dismiss="alert" aria-label="Close">
-    <span aria-hidden="true">&times;</span>
+    <span class="alert-bar__close" onclick="toggleFunction()" onkeypress="toggleFunction()">Close
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <span class="alert-bar__button" aria-hidden="true">&times;</span>
     </span>
   </button>
   </div>

--- a/app/views/shared/header/_alert-bar.html.erb
+++ b/app/views/shared/header/_alert-bar.html.erb
@@ -12,6 +12,10 @@
     <span class="alert-bar__text">
       Welcome to Digital Collections (Beta)! This site is growing each week as we migrate content from our <a href="http://digital2.library.ucla.edu/" target="_blank" rel="noopener">Legacy Site</a>.
     </span>
-    <span class="alert-bar__close" onclick="toggleFunction()">Close<i class="fa fa-close"></i></span>
+    <span class="alert-bar__close" onclick="toggleFunction()">Close
+    <button type="button alert-bar__button" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+    </span>
+  </button>
   </div>
 </div>


### PR DESCRIPTION
Connected to [URS-931](https://jira.library.ucla.edu/browse/URS-931)

- [x] Update CSS for the "Legacy" link to show a visible underline
- [x] Restore the "Close" icon
- [x] Find/use alternate event handler for the "Close" icon/link

<img width="1440" alt="Screen Shot 2021-03-03 at 12 45 40 PM" src="https://user-images.githubusercontent.com/34147754/109870138-93795e80-7c1e-11eb-8b75-5239e0705748.png">
