### PR TITLE
APPS-651 Fix word break issue with long text on Sinai Item Page

### DIFF
--- a/app/assets/stylesheets/theme_sinai/components/_si-metadata-block.scss
+++ b/app/assets/stylesheets/theme_sinai/components/_si-metadata-block.scss
@@ -171,7 +171,7 @@
   display: flex;
   flex-wrap: wrap;
   font-weight: 300;
-  word-break: break-all;
+  overflow-wrap: break-word;
 
   span {
     margin: 5px 5px 5px 0;


### PR DESCRIPTION
modified: `app/assets/stylesheets/theme_sinai/components/_si-metadata-block.scss`