### PR TITLE
Apps 653/sinai default search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -401,7 +401,6 @@ class CatalogController < ApplicationController
     # and whether the sort is ascending or descending
     # (it must be asc or desc except in the relevancy case)
     # label is key, solr field is value
-    
 
     # config.add_sort_field 'sort_title_ssort asc', label: 'Title (A-Z)'
     # config.add_sort_field 'sort_title_ssort desc', label: 'Title (Z-A)'
@@ -414,7 +413,6 @@ class CatalogController < ApplicationController
       config.add_sort_field 'title_alpha_numeric_ssort asc', label: 'Title (A-Z)'
       config.add_sort_field 'title_alpha_numeric_ssort desc', label: 'Title (Z-A)'
     end
-    
 
     config.add_sort_field 'date_dtsort desc', label: 'Date (newest)'
     config.add_sort_field 'date_dtsort asc', label: 'Date (oldest)'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -401,7 +401,7 @@ class CatalogController < ApplicationController
     # and whether the sort is ascending or descending
     # (it must be asc or desc except in the relevancy case)
     # label is key, solr field is value
-    config.add_sort_field 'score desc', label: 'Relevance'
+    
 
     # config.add_sort_field 'sort_title_ssort asc', label: 'Title (A-Z)'
     # config.add_sort_field 'sort_title_ssort desc', label: 'Title (Z-A)'
@@ -414,9 +414,11 @@ class CatalogController < ApplicationController
       config.add_sort_field 'title_alpha_numeric_ssort asc', label: 'Title (A-Z)'
       config.add_sort_field 'title_alpha_numeric_ssort desc', label: 'Title (Z-A)'
     end
+    
 
     config.add_sort_field 'date_dtsort desc', label: 'Date (newest)'
     config.add_sort_field 'date_dtsort asc', label: 'Date (oldest)'
+    config.add_sort_field 'score desc', label: 'Relevance'
     #------------------------------------------------------
     # AUTO_SUGGEST / AUTO_COMPLETE
     # If there are more than this many search results,

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -61,18 +61,3 @@
     </div>
   <% end %>
 <% end %>
-
-<!-- add Title/Shelfmark Sort -->
-<script type="text/javascript">
-  var urlFacet = window.location.search;
-  if ( urlFacet.indexOf("catalog?sort=" ) !== -1){
-    window.history.replaceState('page2', 'Title', '/catalog');
-  } else if ( ((urlFacet.indexOf("&q=&") !== -1) || (urlFacet.indexOf("%5B%5D=") !== -1)) && ((urlFacet.indexOf("[member_of_collections_") !== -1) || ((urlFacet.indexOf("&sort=") == -1) && (urlFacet != "?utf8=%E2%9C%93&q=&search_field=all_fields"))) ) {
-    <% if Flipflop.sinai? %>
-      var titleSortUrl = urlFacet+"&sort=shelfmark_alpha_numeric_ssort+asc";
-    <% else %>
-      var titleSortUrl = urlFacet+"&sort=title_alpha_numeric_ssort+asc";
-    <% end %>
-      window.location = titleSortUrl;
-  }
-</script>


### PR DESCRIPTION
Connected to [APPS-653](https://jira.library.ucla.edu/browse/APPS-653)

Acceptance Criteria:
- [x] The default sort if no search terms have been entered should be "Sort by Shelfmark (A-Z)"

Works by reordering dropdown facets and remove previous javascript