### PR TITLE
APPS-654 - Re-arranged and re-spaced Search, About and Signin menu items

### DIFF
--- a/app/assets/stylesheets/theme_sinai/elements/_si-buttons.scss
+++ b/app/assets/stylesheets/theme_sinai/elements/_si-buttons.scss
@@ -78,9 +78,9 @@
 .btn_nav_link--sinai {
   padding-top: 0;
   padding-left: 0;
+  font-size: 16px;
   font-family: 'Dosis', sans-serif;
   font-weight: 600;
-  font-size: 16px;
   border: none transparent;
 
   &:hover {

--- a/app/assets/stylesheets/theme_sinai/elements/_si-buttons.scss
+++ b/app/assets/stylesheets/theme_sinai/elements/_si-buttons.scss
@@ -80,6 +80,8 @@
   padding-left: 0;
   font-family: 'Dosis', sans-serif;
   font-weight: 600;
+  font-size: 16px;
+  border: none transparent;
 
   &:hover {
     text-decoration: underline;

--- a/app/assets/stylesheets/theme_sinai/header/_si-navbar.scss
+++ b/app/assets/stylesheets/theme_sinai/header/_si-navbar.scss
@@ -94,14 +94,13 @@
 }
 
 .site-navbar__item--sinai:not(:last-child) {
-  padding-right: 10px;
+  padding-right: 15px;
 }
 
 // Aligns "Login" link to "About" link
 .site-navbar__item--sinai .button_to {
   position: relative;
   top: -0.0625rem;
-  left: 0.75rem;
 }
 
 .site-header__search-icon--sinai {

--- a/app/views/shared/header/_sinai_header.html.erb
+++ b/app/views/shared/header/_sinai_header.html.erb
@@ -12,13 +12,13 @@
     <div class='site-navbar__link-block--sinai'>
       <ul class='nav'>
 
-        <li class='nav-item site-navbar__item--sinai'><%= link_to 'About', sinai_about_path %></li>
         <li class='nav-item site-navbar__item--sinai'><%= link_to "Search#{image_tag('sinai-logos/search-icon-bold.svg', class: 'site-header__search-icon--sinai', alt: 'Search icon')}".html_safe, '/catalog?utf8=%E2%9C%93&q=&search_field=all_fields' %></li>
-
+        <li class='nav-item site-navbar__item--sinai'><%= link_to 'About', sinai_about_path %></li>
+        
         <% if !cookies[:sinai_authenticated] %>
           <% cookies[:request_original_url] = request.original_url %>
           <li class='nav-item site-navbar__item--sinai'><%#= link_to 'Login', login_path %>
-          <%= button_to 'LOGIN', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn btn_nav_link--sinai' %>
+          <%= button_to 'LOGIN/REGISTER', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn btn_nav_link--sinai' %>
           </li>
         <% end %>
 

--- a/app/views/shared/header/_sinai_header.html.erb
+++ b/app/views/shared/header/_sinai_header.html.erb
@@ -14,7 +14,7 @@
 
         <li class='nav-item site-navbar__item--sinai'><%= link_to "Search#{image_tag('sinai-logos/search-icon-bold.svg', class: 'site-header__search-icon--sinai', alt: 'Search icon')}".html_safe, '/catalog?utf8=%E2%9C%93&q=&search_field=all_fields' %></li>
         <li class='nav-item site-navbar__item--sinai'><%= link_to 'About', sinai_about_path %></li>
-        
+
         <% if !cookies[:sinai_authenticated] %>
           <% cookies[:request_original_url] = request.original_url %>
           <li class='nav-item site-navbar__item--sinai'><%#= link_to 'Login', login_path %>

--- a/e2e/cypress/integration/sinai_homepage_spec.js
+++ b/e2e/cypress/integration/sinai_homepage_spec.js
@@ -11,7 +11,7 @@ describe('Sinai Homepage', () => {
 
   it('Search Component', () => {
     cy.visit(Cypress.env('SINAI_BASE_URL'));
-    cy.get('.nav > :nth-child(2) > a').click();
+    cy.get('.nav').contains('Search').click(); 
     cy.url().should('include', 'search_field=all_fields');
   });
 


### PR DESCRIPTION
Connected to [APPS-654](https://jira.library.ucla.edu/browse/APPS-654)
Adjust spacing and placement of the menu items in the Sinai heading:

- Search
- About
- Sigin

Acceptance Criteria:

- [x] The Sinai heading banner menu items include "Search" (with the search icon), "About", and "Login/Register"
- [x] The menu items are spaced consistently with sufficient space

---

#### Files
+ `app/assets/stylesheets/theme_sinai/header/_si-navbar.scss`
+ `app/views/shared/header/_sinai_header.html.erb`

---

![20210308_apps_654](https://user-images.githubusercontent.com/2350153/110383204-cf426880-8010-11eb-8812-45102d9b7064.jpg)


