### PR TITLE
Add PR-updater github action

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -1,0 +1,17 @@
+name: Post-merge chores
+
+on:
+    push:
+        branches: 
+            - main
+
+jobs:
+    autoupdate:
+        name: Update outstanding PRs
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v1
+        - name: update all prs
+            uses: maxkomarychev/pr-updater-action@92cb6e15dc3c4b9b148b65eef32836bb428587b9  # v1.0.1
+            with:
+                token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Creates a new Github Action "Post-merge chores", which will run whenever a PR is merged into `main`. Initially this workflow runs a PR update, which automatically updates all outstanding PRs to the new head of `main`.