### PR TITLE
Recognize query parameters in URLs

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -493,7 +493,9 @@ class CatalogController < ApplicationController
     # For old-style reversed-ark URLs, redirect to a URL with the forward ARK, BUT only  if the record exists
     # otherwise, short-circuit to a 404
     unless params[:id].start_with?('ark:/')
-      redirect_to solr_document_path('ark:/' + params[:id].reverse.sub('-', '/')) if SolrDocument.find(params[:id])
+      if SolrDocument.find(params[:id])
+        redirect_to solr_document_path('ark:/' + params[:id].reverse.sub('-', '/')) + ("?cv=#{params[:cv]}" if params.include? :cv)
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
   devise_for :users
   concern :exportable, Blacklight::Routes::Exportable.new
 
-  resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
+  resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog', constraints: { id: /(ark\:)?[\w\=\#\*\+\@\_\$\%\-\/]+/ } do
     concerns :exportable
   end
 
@@ -48,19 +48,6 @@ Rails.application.routes.draw do
   mount BlacklightDynamicSitemap::Engine => '/'
 
   root to: "catalog#index"
-  concern :exportable, Blacklight::Routes::Exportable.new
-
-  resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog', constraints: { id: /.*/ } do
-    concerns :exportable
-  end
-
-  resources :bookmarks do
-    concerns :exportable
-
-    collection do
-      delete 'clear'
-    end
-  end
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -2,6 +2,26 @@
 require 'rails_helper'
 
 RSpec.describe CatalogController, type: :controller do
+  # rubocop:disable RSpec/ExpectActual
+  describe 'routes' do
+    it 'recognizes an ark' do
+      expect(get: '/catalog/ark:/123/abc').to route_to(controller: 'catalog', action: 'show', id: 'ark:/123/abc')
+    end
+
+    it 'recognizes a content type extension' do
+      expect(get: '/catalog/ark:/123/abc.json').to route_to(controller: 'catalog', action: 'show', id: 'ark:/123/abc', format: 'json')
+    end
+
+    it 'recognizes a URL query parameter' do
+      expect(get: '/catalog/ark:/123/abc.json?cv=3').to route_to(controller: 'catalog', action: 'show', id: 'ark:/123/abc', format: 'json', cv: '3')
+    end
+
+    it 'recognizes a reversed ark' do
+      # This will get forwarded, but that happens in #show, not in the route, so we don't test it here.
+      expect(get: '/catalog/cba-321').to route_to(controller: 'catalog', action: 'show', id: 'cba-321')
+    end
+  end
+
   describe 'facets' do
     context 'in the default site' do
       before do


### PR DESCRIPTION
This functionality was broken by the forward ark work.