### PR TITLE
Fix redirect to canonical url

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -115,7 +115,7 @@ class ApplicationController < ActionController::Base
   def solr_document_path(*args)
     ark = case args[0]
           when nil
-            document.id
+            params[:id]
           when SolrDocument
             args[0].id
           when String
@@ -123,7 +123,7 @@ class ApplicationController < ActionController::Base
           else
             raise ArgumentError, 'Argument must be a SolrDocument with an ARK, or a string containing a SolrDocument ARK'
           end
-    "/catalog/#{ark}"
+    "/catalog/#{CGI.unescape(ark)}"
   end
 
   def solr_document_url(*args)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -487,16 +487,13 @@ class CatalogController < ApplicationController
   end
 
   def cannonical_url_redirect
-    # If the ARK is URL-escaped, redirect to an unescaped URL
-    redirect_to solr_document_path(params[:id]) unless request.path == solr_document_path(params[:id])
-
-    # For old-style reversed-ark URLs, redirect to a URL with the forward ARK, BUT only  if the record exists
-    # otherwise, short-circuit to a 404
-    unless params[:id].start_with?('ark:/')
-      if SolrDocument.find(params[:id])
-        redirect_to solr_document_path('ark:/' + params[:id].reverse.sub('-', '/')) + ("?cv=#{params[:cv]}" if params.include? :cv)
-      end
+    if params[:id].start_with?('ark:/')
+      return if request.path == CGI.unescape(request.path) # Good URL!
+      target = solr_document_path(params[:id]) # redirect to an unescaped URL
+    else
+      target = solr_document_path(SolrDocument.find(params[:id])) # redirect to forward-ARK URL, but only if document exists; otherwise raises a 404
     end
+    redirect_to target + (request.query_string.to_s.empty? ? '' : '?' + request.query_string)
   end
 
   def oai_provider


### PR DESCRIPTION
Allows redirect to canonical url when `cv` query parameter is not present.