### PR TITLE
Show default thumbnails by resource type

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -77,6 +77,7 @@ class CatalogController < ApplicationController
     config.index.title_field = 'title_tesim'
     config.index.display_type_field = 'has_model_ssim'
     config.index.thumbnail_field = 'thumbnail_url_ss'
+    config.index.document_presenter_class = Ursus::IndexPresenter
 
     # solr path which will be added to solr base url before the other solr params.
     # config.solr_path = 'select'

--- a/app/presenters/ursus/index_presenter.rb
+++ b/app/presenters/ursus/index_presenter.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+module Ursus
+  class IndexPresenter < Blacklight::IndexPresenter
+    self.thumbnail_presenter = Ursus::ThumbnailPresenter
+  end
+end

--- a/app/presenters/ursus/thumbnail_presenter.rb
+++ b/app/presenters/ursus/thumbnail_presenter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Ursus
-  module ThumbnailPresenter
+  class ThumbnailPresenter < Blacklight::ThumbnailPresenter
     ##
     # Render the thumbnail, if available, for a document and
     # link it to the document record.
@@ -21,7 +21,19 @@ module Ursus
     end
 
     def thumbnail_value_from_document(document)
-      document[:thumbnail_url_ss]
+      super(document) || thumbnail_default(document)
+    end
+
+    def thumbnail_default(document)
+      resource_type_id = document['resource_type_ssim'] || document['resource_type_tesim'] # We're indexing as _tesim, but should change to _ssim
+
+      # based on resource type ids from https://github.com/UCLALibrary/californica/blob/main/config/authorities/resource_types.yml
+      case resource_type_id.to_a.first.to_s.sub(/^http\:\/\/id\.loc\.gov\/vocabulary\/resourceTypes\//, '')
+      when 'mov' # moving image
+        'https://prod-uclalibrary-resources.s3-us-west-2.amazonaws.com/video_icon.svg'
+      when 'aud', 'aum', 'aun' # sound recording types
+        'https://prod-uclalibrary-resources.s3-us-west-2.amazonaws.com/audio_icon.svg'
+      end
     end
   end
 end

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -1,102 +1,3 @@
-<!-- SINAI -->
-<% if Flipflop.sinai? %>
-  <% doc_presenter = index_presenter(document) %>
-
-  <div class='document__list-item-wrapper document__list-item-wrapper--sinai'>
-    <!-- default partial to display solr document fields in catalog index view -->
-
-    <%# THUMBNAIL %>
-    <% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({}, counter: document_counter_with_offset(document_counter)) %>
-      <%# Thumnail NOT logged in %>
-      <% if !cookies[:sinai_authenticated] %>
-        <div class='document__gallery-thumbnail document__gallery-thumbnail--sinai-generic'>
-          <a href='#' data-toggle='modal' data-target='#exampleModalCenter'>
-              <%= image_tag('sinai/sinai-generic-thumbnail.png', class: 'document__gallery-thumbnail--sinai-generic') %>
-          </a>
-        </div>
-        <%# Thumbnail logged in%>
-      <% else %>
-        <div class='document__gallery-thumbnail document__gallery-thumbnail--sinai'>
-          <%= tn %>
-        </div>
-      <% end %>
-    <% end %>
-    <%# ----------------------------------------------- %>
-
-    <%# METADATA %>
-    <% if !cookies[:sinai_authenticated] %>
-      <%# Sinai NOT LOGGED IN %>
-      <%# cookies[:request_original_url] = request.original_url %>
-
-      <div class='metadata-wrapper-index--sinai'>
-
-        <header class='header-index--sinai'>
-          <%# link the header to the block access modal%>
-          <a href='#' data-toggle='modal' data-target='#exampleModalCenter'>
-            <%= render 'catalog/index_header_sinai', document: document %>
-          </a>
-        </header>
-
-        <%# TITLE: descriptive_title_one | descriptive_title_two | uniform_title_one | uniform_title_two %>
-        <div class='title-index--sinai'>
-          <%= render 'catalog/index_title_sinai', document: document %>
-        </div>
-
-        <%# DATE - LANGUAGE %>
-        <div class='metadata-block-index--sinai'>
-          <%= image_tag('sinai-icons/calendar-icon.png', class: 'icon-calendar-index--sinai') %><%= render 'catalog/index_date_sinai', document: document %>&nbsp;&nbsp;<%= image_tag('sinai-icons/world-icon.png', class: 'icon-world-index-sinai') %><%= render 'catalog/index_language_sinai', document: document %>
-        </div>
-        <%# NAMES %>
-        <% name_field = render 'catalog/index_name_sinai', document: document %>
-        <% if name_field =~ /href/ %>
-          <div class='metadata-block-index--sinai'>
-            <div class='metadata-value-index--sinai'>
-                <%= image_tag('sinai-icons/people-icon.svg', class: 'icon-people-index--sinai') %><%= name_field %>
-            </div>
-          </div><%# metadata-block-index--sinai %>
-        <% end %>
-      </div><%# metadata-wrapper-index--sinai %>
-
-    <%# ----------------------------------------------- %>
-
-    <% else %>
-      <%# Sinai LOGGED IN %>
-      <%# link the header to the work by the ark %>
-      <% the_ark = CGI.escape document['ark_ssi'] %>
-
-      <div class='metadata-wrapper-index--sinai'>
-
-        <header class='header-index--sinai'>
-          <%# link the header to the work by the ark %>
-          <a href='#' data-toggle='modal' data-target='#exampleModalCenter'>
-            <%= link_to (render 'catalog/index_header_sinai', document: document), "/catalog/#{the_ark}" %>
-          </a>
-        </header>
-
-        <%# TITLE: descriptive_title_one | descriptive_title_two | uniform_title_one | uniform_title_two %>
-        <div class='title-index--sinai'>
-          <%= render 'catalog/index_title_sinai', document: document %>
-        </div>
-
-        <%# DATE - LANGUAGE %>
-        <div class='metadata-block-index--sinai'>
-          <%= image_tag('sinai-icons/calendar-icon.png', class: 'icon-calendar-index--sinai') %><%= render 'catalog/index_date_sinai', document: document %>&nbsp;&nbsp;<%= image_tag('sinai-icons/world-icon.png', class: 'icon-world-index-sinai') %><%= render 'catalog/index_language_sinai', document: document %>
-        </div>
-        <%# NAMES %>
-        <% name_field = render 'catalog/index_name_sinai', document: document %>
-        <% if name_field =~ /href/ %>
-          <div class='metadata-block-index--sinai'>
-            <%= image_tag('sinai-icons/people-icon.svg', class: 'icon-people-index--sinai') %><%= name_field %>
-          </div><%# metadata-block-index--sinai %>
-        <% end %>
-      </div><%# metadata-wrapper-index--sinai %>
-    </div><%# document__list-item-wrapper--sinai %>
-  <% end %><%# if Flipflop.sinai? %>
-
-<%# ----------------------------------------------- %>
-
-<!-- URSUS -->
-<% else %>
   <% doc_presenter = index_presenter(document) %>
   <div class='document__list-item-wrapper'>
     <!-- default partial to display solr document fields in catalog index view -->
@@ -109,26 +10,25 @@
             </dt>
             <dd class="document__list-metadata-value document__list-metadata-value--ursus blacklight-<%= field_name.parameterize %>">
               <% document[:member_of_collections_ssim].zip(document[:member_of_collection_ids_ssim]).each do | title, id | %>
-                <%= link_to title, solr_document_path('ark:/' + id.reverse.sub('-', '/')) %><br>
-              <% end %>
-            </dd>
-          <% end %>
-        <% else %>
-          <dt class="document__list-metadata-key document__list-metadata-key--ursus blacklight-<%= field_name.parameterize %>">
-            <%= render_index_field_label document, field: field_name %>
-          </dt>
-          <dd class="document__list-metadata-value document__list-metadata-value--ursus blacklight-<%= field_name.parameterize %>">
-            <%= doc_presenter.field_value field %>
+              <%= link_to title, solr_document_path('ark:/' + id.reverse.sub('-', '/')) %><br>
+            <% end %>
           </dd>
-          <% if field_name == "Description" %>
-            <dt class="document__list-metadata-key blacklight-<%= field_name.parameterize %>"></dt>
-            <dd class="document__list-metadata-value blacklight-<%= field_name.parameterize %>">&nbsp;&nbsp;&nbsp;</dd>
-          <% end %>
+        <% end %>
+      <% else %>
+        <dt class="document__list-metadata-key document__list-metadata-key--ursus blacklight-<%= field_name.parameterize %>">
+          <%= render_index_field_label document, field: field_name %>
+        </dt>
+        <dd class="document__list-metadata-value document__list-metadata-value--ursus blacklight-<%= field_name.parameterize %>">
+          <%= doc_presenter.field_value field %>
+        </dd>
+        <% if field_name == "Description" %>
+          <dt class="document__list-metadata-key blacklight-<%= field_name.parameterize %>"></dt>
+          <dd class="document__list-metadata-value blacklight-<%= field_name.parameterize %>">&nbsp;&nbsp;&nbsp;</dd>
         <% end %>
       <% end %>
-    </dl>
-    <% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({}, counter: document_counter_with_offset(document_counter)) %>
-      <div class='document__gallery-thumbnail'><%= tn %></div>
     <% end %>
-  </div>
-<% end %>
+  </dl>
+  <% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({}, counter: document_counter_with_offset(document_counter)) %>
+    <div class='document__gallery-thumbnail'><%= tn %></div>
+  <% end %>
+</div>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,65 +1,13 @@
-<!-- SINAI -->
-<% if Flipflop.sinai? %>
-<% if !cookies[:sinai_authenticated] %>
-<%
-      cookies[:requested_path] = request.original_url
-      login_service = LoginService.new
-      @token = login_service.create_token
-%>
-<!-- Modal -->
-<div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered" role="document">
-    <div class="modal-content msg-container">
-      <div class="modal-header">
-        <h5 class="modal-title" id="exampleModalLongTitle">Login Required</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-        </div>
-      <div class="modal-body">
-      Login is required to view the manuscripts. Please login or register for a free account.
-        <div class="si-auth-modal-btn-block">
-          <div class="si-auth-modal-btn-group">
-            <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary' %>
-            <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary' %>
-          </div>
-          <button type="button" class="btn-base-link btn-base btn-base-link--sinai" data-dismiss="modal">Skip for Now</button>
-        </div>
-        </div>
-      <div class="modal-footer">
-      </div>
-    </div>
-  </div>
-</div>
-<% end %>
-  <!--% unless has_search_parameters? % -->
-  <% if current_page?(root_path) %>
-    <%# if there are no input/search related params,
-              display the "sitelinks_search_box" partial -%>
-    <%= render 'shared/sitelinks_search_box' %>
-    <%= render 'homepage_sinai' %>
+<% unless has_search_parameters? %>
+  <%# if there are no input/search related params,
+            display the "home" partial -%>
+  <%= render 'home' %>
 
-  <% else %>
-    <% request.original_url %>
-    <div class='content-container--index-page'>
-      <%= render 'facets' %>
-      <%= render 'search_results' %>
-    </div>
-  <% end %>
-
-<!-- URSUS -->
 <% else %>
-  <% unless has_search_parameters? %>
-    <%# if there are no input/search related params,
-              display the "home" partial -%>
-    <%= render 'home' %>
-
-  <% else %>
-    <div class='content-container--index-page'>
-      <%= render 'facets' %>
-      <%= render 'search_results' %>
-    </div>
-  <% end %>
+  <div class='content-container--index-page'>
+    <%= render 'facets' %>
+    <%= render 'search_results' %>
+  </div>
 <% end %>
 
 <!-- add Title/Shelfmark Sort -->

--- a/config/initializers/prepends.rb
+++ b/config/initializers/prepends.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
 CatalogHelper.send(:prepend, Blacklight::FacetLabelButtonBehavior)
-Blacklight::ThumbnailPresenter.send(:prepend, Ursus::ThumbnailPresenter)
 Blacklight::BlacklightHelperBehavior.send(:prepend, Blacklight::UrsusLayoutHelperBehavior)


### PR DESCRIPTION
APPS-899

When `thumbnail_url_ss` is unpopulated, insert a default based on `resource_type_ssm`. Currently only populates for the a/v types specified in https://github.com/UCLALibrary/californica/blob/main/config/authorities/resource_types.yml, anything else is left `nil`.

Also:
- Use Ursus::ThumbnailPresenter by subclassing Blacklight::ThumbnailPresenter, rather than prepending a module into it (ran into some really weird behavior trying to use byebug w/ spring in the prepended module).
- deleted some sinai code I came across

from https://ursus-dev.library.ucla.edu/catalog?f%5Bsubject_sim%5D%5B%5D=Default+thumbnail&sort=title_alpha_numeric_ssort+asc:
![Screenshot from 2021-05-28 08-31-26](https://user-images.githubusercontent.com/73365/120008570-eea5bd80-bf8f-11eb-8069-fc82a3278d77.png)