### PR TITLE
remove `uv.html` from media viewer URL

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,5 +59,5 @@ Rails.application.configure do
 
   config.user_account_ui_enabled = ENV['USER_ACCOUNT_UI_ENABLED'] || 'false'
   config.iiif_url = ENV['IIIF_URL'] || ''
-  config.media_viewer_url = ENV['MEDIA_VIEWER_URL'] || 'https://p-w-dl-viewer01.library.ucla.edu/uv.html'
+  config.media_viewer_url = ENV['MEDIA_VIEWER_URL'] || 'https://p-w-dl-viewer01.library.ucla.edu/'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,5 +93,5 @@ Rails.application.configure do
 
   config.user_account_ui_enabled = ENV['USER_ACCOUNT_UI_ENABLED'] || 'false'
   config.iiif_url = ENV['IIIF_URL'] || ''
-  config.media_viewer_url = ENV['MEDIA_VIEWER_URL'] || 'https://p-w-dl-viewer01.library.ucla.edu/uv.html'
+  config.media_viewer_url = ENV['MEDIA_VIEWER_URL'] || 'https://p-w-dl-viewer01.library.ucla.edu/'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
   config.user_account_ui_enabled = ENV['USER_ACCOUNT_UI_ENABLED'] || 'false'
   config.iiif_url = ENV['IIIF_URL'] || ''
-  config.media_viewer_url = ENV['MEDIA_VIEWER_URL'] || 'https://p-w-dl-viewer01.library.ucla.edu/uv.html'
+  config.media_viewer_url = ENV['MEDIA_VIEWER_URL'] || 'https://p-w-dl-viewer01.library.ucla.edu/'
 
   config.serve_static_assets = true
 end

--- a/e2e/cypress/integration/ursus_work_show_spec.js
+++ b/e2e/cypress/integration/ursus_work_show_spec.js
@@ -7,7 +7,7 @@ describe('Work show pages', () => {
     );
     cy.frameLoaded({
       url:
-        'https://p-w-dl-viewer01.library.ucla.edu/uv.html#?manifest=https%3A%2F%2Fiiif.library.ucla.edu%2Fark%253A%252F21198%252Fzz0026hvpq%2Fmanifest',
+        'https://p-w-dl-viewer01.library.ucla.edu/#?manifest=https%3A%2F%2Fiiif.library.ucla.edu%2Fark%253A%252F21198%252Fzz0026hvpq%2Fmanifest',
     });
     cy.iframe().contains('span', 'Manuscript No.32: 00');
     cy.percySnapshot();

--- a/spec/services/iiif_service_spec.rb
+++ b/spec/services/iiif_service_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe IiifService do
       it 'links to universal viewer' do
         allow(Flipflop).to receive(:sinai?).and_return(false)
 
-        expect(src).to eq 'https://p-w-dl-viewer01.library.ucla.edu/uv.html#?manifest=https%3A%2F%2Fmanifest.store%2Fark%253A%252Fabc%252F123%2Fmanifest'
+        expect(src).to eq 'https://p-w-dl-viewer01.library.ucla.edu/#?manifest=https%3A%2F%2Fmanifest.store%2Fark%253A%252Fabc%252F123%2Fmanifest'
       end
     end
 


### PR DESCRIPTION
This will reflect the fact that we are replacing pure UV with a vue shim that loads an alternative viewer for video. The server will return `index.html` from the UCLALibrary/dl-viewer repo.