### PR TITLE
Update Arkatov text

### DIFF
--- a/app/views/catalog/_image_grid.html.erb
+++ b/app/views/catalog/_image_grid.html.erb
@@ -57,7 +57,7 @@
       <div class="collection-grid__item-content">
         <h3 class="collection-grid__item-title">Arkatov (James) Collection</h3>
         <hr class="collection-grid__item-liner align-item-start">
-        <p class="grid-summary">Photographs of jazz musicians performing in Los Angeles.</p>
+        <p class="grid-summary">Photographs of musicians and fine artists taken by the cellist, James Arkatov.</p>
         <p class="collection-grid__item-link">More about this collection</p>
       </div>
   </a>


### PR DESCRIPTION
Connected to [APPS-1273](https://jira.library.ucla.edu/browse/APPS-1273)

Correct text describing the Arkatov collection on the Digital Collections homepage (https://digital.library.ucla.edu/.

Old text: "Photographs of jazz musicians performing in Los Angeles."

- [x] New text: "Photographs of musicians and fine artists taken by the cellist, James Arkatov."

Background

Through discussion with a UCLA course instructor and the Ethnomusicology Archive's curator, I have learned that our text on the homepage of the digital library site is incorrect in the way it scopes the James Arkatov collection. The collection is not limited to images of jazz musicians. It also includes classical music performers and is not limited to performances in Los Angeles. 