### PR TITLE
Downgrade sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'rails', '~> 5.2'
 gem 'rollbar' # Error reporting tool
 gem 'rsolr', '>= 1.0'
 gem 'sassc-rails', '>= 2.1.2' # SASS -> CSS compiler
-gem 'sidekiq', '~> 6.4'
+gem 'sidekiq', '~> 5.2'
 gem 'solrizer', '>= 4.1.0'
 gem 'sprockets', '>= 3.7.2', '< 4'
 gem 'turbolinks', '~> 5' # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,6 +297,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
+    rack-protection (2.2.0)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.7)
@@ -332,7 +334,7 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.6.0)
+    redis (4.5.1)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -387,10 +389,11 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sidekiq (6.4.1)
-      connection_pool (>= 2.2.2)
+    sidekiq (5.2.10)
+      connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
-      redis (>= 4.2.0)
+      rack-protection (>= 1.5.0)
+      redis (~> 4.5, < 4.6.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -510,7 +513,7 @@ DEPENDENCIES
   rubocop
   sassc-rails (>= 2.1.2)
   selenium-webdriver (>= 3.142.3)
-  sidekiq (~> 6.4)
+  sidekiq (~> 5.2)
   solrizer (>= 4.1.0)
   spring
   spring-commands-rspec


### PR DESCRIPTION
sidekiq 6 is not compatible with the way we are using capistrano-sidekiq, resulting in failed deployments even though everything installed successfully in development and CI.

More info:
https://github.com/seuros/capistrano-sidekiq/issues/224