### PR TITLE
feat: APPS-2471 Add a "Related Records" metadata fieldadd related record field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -225,6 +225,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'resp_statement_tesim', label: 'Statement of Responsibility'
     config.add_show_field 'citation_source_tesim', label: 'References'
     config.add_show_field 'related_to_ssm', label: 'Related Items', auto_link: true # make this field url aware
+    config.add_show_field 'related_record_ssm', label: 'Related Records', auto_link: true # make this field url aware
 
     # Physical description
     config.add_show_field 'medium_tesim', label: 'Medium'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -222,10 +222,10 @@ class CatalogController < ApplicationController
     config.add_show_field 'provenance_tesim', label: 'Provenance'
     config.add_show_field 'colophon_tesim', label: 'Colophon'
     config.add_show_field 'note_tesim', label: 'Note'
-    config.add_show_field 'resp_statement_tesim', label: 'Statement of responsibility'
+    config.add_show_field 'resp_statement_tesim', label: 'Statement of Responsibility'
     config.add_show_field 'citation_source_tesim', label: 'References'
     config.add_show_field 'related_to_ssm', label: 'Related Items', auto_link: true # make this field url aware
-    config.add_show_field 'related_record_ssm', label: 'Related Records', auto_link: true # make this field url aware
+    config.add_show_field 'human_readable_related_record_title_ssm', label: 'Related Records'
 
     # Physical description
     config.add_show_field 'medium_tesim', label: 'Medium'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -222,7 +222,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'provenance_tesim', label: 'Provenance'
     config.add_show_field 'colophon_tesim', label: 'Colophon'
     config.add_show_field 'note_tesim', label: 'Note'
-    config.add_show_field 'resp_statement_tesim', label: 'Statement of Responsibility'
+    config.add_show_field 'resp_statement_tesim', label: 'Statement of responsibility'
     config.add_show_field 'citation_source_tesim', label: 'References'
     config.add_show_field 'related_to_ssm', label: 'Related Items', auto_link: true # make this field url aware
     config.add_show_field 'related_record_ssm', label: 'Related Records', auto_link: true # make this field url aware

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -137,7 +137,7 @@ en:
           publisher_tesim: 'Publisher'
           repository_sim: 'Repository'
           repository_tesim: 'Repository'
-          resp_statement_tesim: 'Statement of Responsibility'
+          resp_statement_tesim: 'Statement of responsibility'
           rights_country_tesim: 'Rights Country'
           rights_holder_tesim: 'Rights Holder'
           human_readable_rights_statement_tesim: 'Rights statement'

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -137,7 +137,7 @@ en:
           publisher_tesim: 'Publisher'
           repository_sim: 'Repository'
           repository_tesim: 'Repository'
-          resp_statement_tesim: 'Statement of responsibility'
+          resp_statement_tesim: 'Statement of Responsibility'
           rights_country_tesim: 'Rights Country'
           rights_holder_tesim: 'Rights Holder'
           human_readable_rights_statement_tesim: 'Rights statement'

--- a/config/metadata/note_metadata.yml
+++ b/config/metadata/note_metadata.yml
@@ -6,6 +6,7 @@ colophon_tesim: 'Colophon'
 provenance_tesim: 'Provenance'
 note_tesim: 'Note'
 related_to_ssm: 'Related items'
+related_record_ssm: 'Related records'
 # toc_tesim: 'Table of Contents' (render_table_of_contents_key / value)
 resp_statement_tesim: 'Statement of Responsibility'
 citation_source_tesim: 'References'

--- a/config/metadata/note_metadata.yml
+++ b/config/metadata/note_metadata.yml
@@ -6,7 +6,7 @@ colophon_tesim: 'Colophon'
 provenance_tesim: 'Provenance'
 note_tesim: 'Note'
 related_to_ssm: 'Related items'
-related_record_ssm: 'Related records'
+human_readable_related_record_title_ssm: 'Related records'
 # toc_tesim: 'Table of Contents' (render_table_of_contents_key / value)
 resp_statement_tesim: 'Statement of Responsibility'
 citation_source_tesim: 'References'

--- a/config/oai.yml
+++ b/config/oai.yml
@@ -88,6 +88,7 @@ DC:
   description:
     - content_disclaimer_ssm
     - related_to_ssm
+    - related_record_ssm
 DPLA:
   parent_schema: default
   object:

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe CatalogController, type: :controller do
        "interviewer_tesim", "interviewee_tesim", "cartographer_tesim",
        "artist_tesim", "recipient_tesim", "director_tesim", "producer_tesim", "host_tesim",
        "musician_tesim", "printer_tesim", "researcher_tesim",
-       'format_book_tesim', 'resp_statement_tesim', 'citation_source_tesim', 'related_to_ssm', "oai_set_ssim"]
+       'format_book_tesim', 'resp_statement_tesim', 'citation_source_tesim', 'related_to_ssm', 'related_record_ssm', "oai_set_ssim"]
     end
 
     it 'has exactly expected show fields' do

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe CatalogController, type: :controller do
        "interviewer_tesim", "interviewee_tesim", "cartographer_tesim",
        "artist_tesim", "recipient_tesim", "director_tesim", "producer_tesim", "host_tesim",
        "musician_tesim", "printer_tesim", "researcher_tesim",
-       'format_book_tesim', 'resp_statement_tesim', 'citation_source_tesim', 'related_to_ssm', 'related_record_ssm', "oai_set_ssim"]
+       'format_book_tesim', 'resp_statement_tesim', 'citation_source_tesim', 'related_to_ssm', 'human_readable_related_record_title_ssm', "oai_set_ssim"]
     end
 
     it 'has exactly expected show fields' do

--- a/spec/presenters/ursus/note_metadata_presenter_spec.rb
+++ b/spec/presenters/ursus/note_metadata_presenter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Ursus::NoteMetadataPresenter do
       'provenance_tesim' => 'Provenance',
       'note_tesim' => 'Note',
       'related_to_ssm' => 'Related items',
-      'related_record_ssm' => 'Related records',
+      'human_readable_related_record_title_ssm' => 'Related records',
       'resp_statement_tesim' => 'Statement of responsibility',
       'citation_source_tesim' => 'References',
       'incipit_tesim' => 'Incipit',
@@ -65,7 +65,7 @@ RSpec.describe Ursus::NoteMetadataPresenter do
       end
 
       it 'returns the Related records Key' do
-        expect(config['related_record_ssm'].to_s).to eq('Related records')
+        expect(config['human_readable_related_record_title_ssm'].to_s).to eq('Related records')
       end
 
       it 'returns the Statement of responsibility Key' do

--- a/spec/presenters/ursus/note_metadata_presenter_spec.rb
+++ b/spec/presenters/ursus/note_metadata_presenter_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Ursus::NoteMetadataPresenter do
       'provenance_tesim' => 'Provenance',
       'note_tesim' => 'Note',
       'related_to_ssm' => 'Related items',
-      'resp_statement_tesim' => 'Statement of Responsibility',
+      'related_record_ssm' => 'Related records',
+      'resp_statement_tesim' => 'Statement of responsibility',
       'citation_source_tesim' => 'References',
       'incipit_tesim' => 'Incipit',
       'explicit_tesim' => 'Explicit'
@@ -63,8 +64,12 @@ RSpec.describe Ursus::NoteMetadataPresenter do
         expect(config['related_to_ssm'].to_s).to eq('Related items')
       end
 
+      it 'returns the Related records Key' do
+        expect(config['related_record_ssm'].to_s).to eq('Related records')
+      end
+
       it 'returns the Statement of Responsibility Key' do
-        expect(config['resp_statement_tesim'].to_s).to eq('Statement of Responsibility')
+        expect(config['resp_statement_tesim'].to_s).to eq('Statement of responsibility')
       end
 
       it 'returns the References Key' do
@@ -86,7 +91,7 @@ RSpec.describe Ursus::NoteMetadataPresenter do
 
       it "returns existing keys" do
         expect(presenter_object.note_terms).to be_instance_of(Hash)
-        expect(all).to eq 12
+        expect(all).to eq 13
         expect(config.length).to eq all
       end
 

--- a/spec/presenters/ursus/note_metadata_presenter_spec.rb
+++ b/spec/presenters/ursus/note_metadata_presenter_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Ursus::NoteMetadataPresenter do
         expect(config['related_record_ssm'].to_s).to eq('Related records')
       end
 
-      it 'returns the Statement of Responsibility Key' do
+      it 'returns the Statement of responsibility Key' do
         expect(config['resp_statement_tesim'].to_s).to eq('Statement of responsibility')
       end
 

--- a/spec/presenters/ursus/note_metadata_presenter_spec.rb
+++ b/spec/presenters/ursus/note_metadata_presenter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Ursus::NoteMetadataPresenter do
       'note_tesim' => 'Note',
       'related_to_ssm' => 'Related items',
       'human_readable_related_record_title_ssm' => 'Related records',
-      'resp_statement_tesim' => 'Statement of responsibility',
+      'resp_statement_tesim' => 'Statement of Responsibility',
       'citation_source_tesim' => 'References',
       'incipit_tesim' => 'Incipit',
       'explicit_tesim' => 'Explicit'
@@ -68,8 +68,8 @@ RSpec.describe Ursus::NoteMetadataPresenter do
         expect(config['human_readable_related_record_title_ssm'].to_s).to eq('Related records')
       end
 
-      it 'returns the Statement of responsibility Key' do
-        expect(config['resp_statement_tesim'].to_s).to eq('Statement of responsibility')
+      it 'returns the Statement of Responsibility Key' do
+        expect(config['resp_statement_tesim'].to_s).to eq('Statement of Responsibility')
       end
 
       it 'returns the References Key' do


### PR DESCRIPTION
Connected to: [APPS-2471](https://uclalibrary.atlassian.net/jira/software/c/projects/APPS/boards/12?selectedIssue=APPS-2471) & [Californica PR 945](https://github.com/UCLALibrary/californica/pull/945)

<p data-pm-slice="1 1 []"><strong>Acceptance criteria:</strong></p><ul class="ak-ul"><li><p>Create a new metadata field with the label "Related Records"</p></li><li><p>This field should accept only ARKs.</p></li><li><p>On ingest to Californica, the the ARK value should just go into this field and create a human_readable_related_title field </p></li><li><p>When displaying on the Item Page in Ursus and Californica, we want to make related titles clickable   and linking to its item page</p></li><li><p>This field is only to be used to provide a URL to a related item within <span class="code" spellcheck="false">digital.library.ucla.edu</span></p></li></ul>

property | related_record
-- | --
label | Related Records
predicate | http://id.loc.gov/ontologies/bibframe/accompaniedBy
required | no
multiple | yes (new line)
type | string (accepts ARKs only)
import from | Related Record
searchable | no
faceted | no
search results | hide
item view | show
grouping | Notes
oai_dpla | dc:description
importer guide | Related Records

<p></p>

[APPS-2471]: https://uclalibrary.atlassian.net/browse/APPS-2471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ