### PR TITLE
feat: APPS-2607 Ursus: Display CC license logo on collection pages

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -220,7 +220,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'interviewer_tesim', label: 'Interviewer', link_to_facet: 'interviewee_sim' # Primary / Item Overview
     config.add_show_field 'keyword_tesim', label: 'Keyword' # Not Using
     config.add_show_field 'latitude_tesim', label: 'Latitude' # Primary / Physical description
-    config.add_show_field 'license_tesim', label: 'License' # Secondary / Access Conditions
+    config.add_show_field 'license_tesim', label: 'License', helper_method: :render_license # Secondary / Access Conditions
     config.add_show_field 'local_identifier_ssim', label: 'Local identifier' # Secondary / Find This Item
     config.add_show_field 'local_rights_statement_ssm', label: 'Local rights statement' # Secondary / Access Conditions
     config.add_show_field 'location_tesim', label: 'Location', link_to_facet: 'location_sim' # Primary / Physical description

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -4,7 +4,7 @@ module BlacklightHelper
 
   # TODO: This method should correctly render methods other than CC-BY 4.0 and
   # be able to distinguish between them.
-  def render_license
+  def render_license(_args = {})
     return '' unless @document
     return '' unless @document[:license_tesim]
     license = @document[:license_tesim].first


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dc8eecb3-b0c3-4971-9e0d-cfdf37e27654)

https://uclalibrary.atlassian.net/browse/APPS-2607

FYI: I used existing code, but comments there mention that it works only with CC license. I'm not sure if there are other types right now. 