### PR TITLE
ci: stop auto-updating PRs after merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,10 +82,11 @@ jobs:
         docker-compose run web yarn install --frozen-lockfile
         docker-compose up --detach
         docker-compose run web bundle exec rails db:setup
-    - uses: cypress-io/github-action@v3
+    - uses: cypress-io/github-action@v6
       with:
         command-prefix: 'percy exec -- npx'
         working-directory: e2e
+        browser: chrome
       env: 
         PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
     - name: Stop docker services

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -1,4 +1,4 @@
-name: Post-merge chores
+name: On merge
 
 on:
     push:
@@ -6,15 +6,11 @@ on:
             - main
 
 jobs:
-    autoupdate:
-        name: Update outstanding PRs
+    deploy-ursus:
+        name: Deploy Ursus main branch to test
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v1
-        - name: update all prs
-          uses: maxkomarychev/pr-updater-action@92cb6e15dc3c4b9b148b65eef32836bb428587b9  # v1.0.1
-          with:
-            token: ${{ secrets.GITHUB_TOKEN }}
         - name: Jenkins webhook
           uses: enflo/curl-action@fabe347922c7a9e88bafa15c4b7d6326ea802695
           with:


### PR DESCRIPTION
Because the PR-update action uses the default GitHub user agent, it doesn't trigger ci checks to rerun. Updating the branch manually, on the other hand, does.

Also updates workflow name to match filename and job name to match ID