### PR TITLE
NOP-12: show "not found" page for ActionController::RoutingError

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,6 +53,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from Blacklight::AccessControls::AccessDenied, with: :render_404
   rescue_from Blacklight::Exceptions::RecordNotFound, with: :render_404
+  rescue_from ActionController::RoutingError, with: :render_404
 
   def render_404
     render 'errors/not_found'


### PR DESCRIPTION
the custom 404 page was only displaying when a url matched one of our routes but no item was found; urls that did not match any route result in a stock rails error page. This PR should ensure that everything gets the custom page.