### PR TITLE
NOP-12 part 2 - routing error to 404

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,5 +52,7 @@ Rails.application.routes.draw do
 
   root to: "catalog#index"
 
+  match '*unmatched', to: 'errors#not_found', via: :all
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c7ab33af-6cf8-4ed3-93b7-319212eddfb4)

https://uclalibrary.atlassian.net/browse/NOP-12

> can you figure out how to the get custom error page to show up on http://digital.library.ucla.edu/no-page-here?