### PR TITLE
fix: paragraph spacing in copyright and collections page

### DIFF
--- a/app/views/static/ursus_copyright.html.erb
+++ b/app/views/static/ursus_copyright.html.erb
@@ -17,12 +17,9 @@
       <%= t('static_pages.copyright_and_collections.copyright_statement').upcase %>
     </div>
     <div class='static-page__text static-page__text--ursus'>
-      <p>
-        Materials in this collection may be protected by domestic and/or international copyright and property laws. Distribution or reproduction of copyrighted materials beyond that allowed by fair use requires the written permission of the copyright owners. To the extent that restrictions other than copyright apply, permission for distribution or reproduction from the applicable rights holder is also required. Responsibility for obtaining permission, and for any use, rests exclusively with the user.
-      </p>
-      <p>
-        Please also see <a class="ur-link" href="https://www.library.ucla.edu/about/policies/ucla-library-copyright-policies/" target="_blank">"UCLA Library Copyright Policies"</a> for more information.
-      </p>
+      Materials in this collection may be protected by domestic and/or international copyright and property laws. Distribution or reproduction of copyrighted materials beyond that allowed by fair use requires the written permission of the copyright owners. To the extent that restrictions other than copyright apply, permission for distribution or reproduction from the applicable rights holder is also required. Responsibility for obtaining permission, and for any use, rests exclusively with the user.
+      <br><br>
+      Please also see <a class="ur-link" href="https://www.library.ucla.edu/about/policies/ucla-library-copyright-policies/" target="_blank">"UCLA Library Copyright Policies"</a> for more information.
     </div>
   </div>
 


### PR DESCRIPTION
copied the markup from the break at the bottom of the page. It's hacky and in the long run we'd be better of doing this with css, but 🤷