### PR TITLE
fix: NOP-70 Update display on Ursus collection-level page: OPAC URL

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -233,7 +233,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'note_tesim', label: 'Note' # Primary / Notes
     config.add_show_field 'oai_set_ssim'
     config.add_show_field 'oclc_ssi', label: 'OCLC Number' # Secondary / Find This Item
-    config.add_show_field 'opac_url_ssi', label: 'Opac url' # Secondary / Find This Item
+    config.add_show_field 'opac_url_ssi', label: 'Opac url', auto_link: true # Secondary / Find This Item
     config.add_show_field 'other_versions_tesim', label: 'Other version(s)' # Secondary / Find This Item
     config.add_show_field 'page_layout_ssim', label: 'Page layout' # Primary / Physical description
     config.add_show_field 'photographer_tesim', label: 'Photographer', link_to_facet: 'photographer_sim' # Primary / Item Overview


### PR DESCRIPTION
https://uclalibrary.atlassian.net/browse/NOP-70

![image](https://github.com/user-attachments/assets/78743b6c-1539-4ece-b660-51bae20ba5ef)
