### PR TITLE
NOP-76 Update CSS to correct error on Facets in Firefox (Ursus)

### DIFF
--- a/app/assets/stylesheets/base/components/_facets.scss
+++ b/app/assets/stylesheets/base/components/_facets.scss
@@ -254,4 +254,5 @@
   text-align: right;
   vertical-align: top;
   color: $gray-80;
+  white-space: nowrap;
 }


### PR DESCRIPTION
https://uclalibrary.atlassian.net/browse/NOP-76

Done, but this breaks alignment a little. Alternative would be to make a column with facet names a little smaller. 

![image](https://github.com/user-attachments/assets/7be93b66-b6ad-4ee8-b6da-8ebb2683ad33)
