### PR TITLE
Specify date gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'blacklight_oai_provider', github: 'projectblacklight/blacklight_oai_provide
 gem 'blacklight_range_limit', '~> 7.0.0'
 gem 'bootstrap', '~> 4.4', '>= 4.4.1'
 gem 'coveralls', '>= 0.8.23', require: false
+gem 'date', '3.0.3'
 gem 'devise', '>= 4.7.1'
 gem 'devise-guests', '~> 0.7', '>= 0.7.0'
 gem 'dotenv-rails', '>= 2.7.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    date (3.4.1)
+    date (3.0.3)
     deprecation (1.1.0)
       activesupport
     devise (4.8.1)
@@ -496,6 +496,7 @@ DEPENDENCIES
   capybara (~> 3.26)
   capybara-mechanize (>= 1.11.0)
   coveralls (>= 0.8.23)
+  date (= 3.0.3)
   devise (>= 4.7.1)
   devise-guests (~> 0.7, >= 0.7.0)
   dotenv-rails (>= 2.7.5)


### PR DESCRIPTION
RHEL 8 ships with date 3.0.3. Bundler will attempt to use a newer, conflicting gem version. This change ensures the RHEL 8 provided date gem is used.

Closes: LX-1777