### PR TITLE
Specify date gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'sassc-rails', '>= 2.1.2' # SASS -> CSS compiler
 gem 'sidekiq', '~> 6.4'
 gem 'solrizer', '>= 4.1.0'
 gem 'sprockets', '>= 3.7.2', '< 4'
+gem 'timeout', '0.1.0'
 gem 'turbolinks', '~> 5' # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'uglifier', '>= 1.3.0' # JavaScript compressor
 gem 'whenever', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'blacklight_oai_provider', github: 'projectblacklight/blacklight_oai_provide
 gem 'blacklight_range_limit', '~> 7.0.0'
 gem 'bootstrap', '~> 4.4', '>= 4.4.1'
 gem 'coveralls', '>= 0.8.23', require: false
+gem 'date', '3.0.3'
 gem 'devise', '>= 4.7.1'
 gem 'devise-guests', '~> 0.7', '>= 0.7.0'
 gem 'dotenv-rails', '>= 2.7.5'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'blacklight_oai_provider', github: 'projectblacklight/blacklight_oai_provide
 gem 'blacklight_range_limit', '~> 7.0.0'
 gem 'bootstrap', '~> 4.4', '>= 4.4.1'
 gem 'coveralls', '>= 0.8.23', require: false
-gem 'date', '3.0.3'
+gem 'date', '3.0.3' # pin to version on RHEL 8 servers
 gem 'devise', '>= 4.7.1'
 gem 'devise-guests', '~> 0.7', '>= 0.7.0'
 gem 'dotenv-rails', '>= 2.7.5'
@@ -34,7 +34,7 @@ gem 'sassc-rails', '>= 2.1.2' # SASS -> CSS compiler
 gem 'sidekiq', '~> 6.4'
 gem 'solrizer', '>= 4.1.0'
 gem 'sprockets', '>= 3.7.2', '< 4'
-gem 'timeout', '0.1.0'
+gem 'timeout', '0.1.0' # pin to version on RHEL 8 servers
 gem 'turbolinks', '~> 5' # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'uglifier', '>= 1.3.0' # JavaScript compressor
 gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,7 +431,7 @@ GEM
       rails (>= 3.1)
     thor (1.2.1)
     tilt (2.0.10)
-    timeout (0.4.3)
+    timeout (0.1.0)
     tins (1.31.0)
       sync
     turbolinks (5.2.1)
@@ -527,6 +527,7 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   sprockets (>= 3.7.2, < 4)
+  timeout (= 0.1.0)
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   web-console (>= 3.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    date (3.4.1)
+    date (3.0.3)
     deprecation (1.1.0)
       activesupport
     devise (4.8.1)
@@ -496,6 +496,7 @@ DEPENDENCIES
   capybara (~> 3.26)
   capybara-mechanize (>= 1.11.0)
   coveralls (>= 0.8.23)
+  date (= 3.0.3)
   devise (>= 4.7.1)
   devise-guests (~> 0.7, >= 0.7.0)
   dotenv-rails (>= 2.7.5)


### PR DESCRIPTION
RHEL 8 ships with date 3.0.3. Bundler will attempt to use a newer, conflicting gem version. This change ensures the RHEL 8 provided date gem is used.

Closes: LX-1777