### PR TITLE
fix: NOP-96 Restore established order of fields on Item Detail View

### DIFF
--- a/app/presenters/ursus/base_metadata_presenter.rb
+++ b/app/presenters/ursus/base_metadata_presenter.rb
@@ -22,7 +22,12 @@ module Ursus
                .each do |field_name, field_config, _field_presenter|
                  result[field_name] = field_config if keys.include?(field_name)
                end
-      result
+
+      keys.map do |key|
+        next unless result[key].present?
+
+        [key, result[key]]
+      end.compact.to_h
     end
   end
 end


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/92a39a8c-2264-484b-b456-ec76dea95292)

https://uclalibrary.atlassian.net/browse/NOP-96