### PR TITLE
[NOP-115] License Displaying Incorrect CC License

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -7,23 +7,28 @@ module BlacklightHelper
   def render_license(_args = {})
     return '' unless @document
     return '' unless @document[:license_tesim]
+
     license = @document[:license_tesim].first
+
     if license.match?(/creativecommons.org/)
-      data = license_markup
+      license_data = Ursus::LicenseMetadataPresenter.new(document: @document).data
+      return license unless license_data
+
+      data = license_markup(license_data)
       data.html_safe
     else
       license
     end
   end
 
-  def license_markup
-    %( <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
-      <img alt="Creative Commons License" style="border-width:0"
-      src="https://i.creativecommons.org/l/by/4.0/88x31.png" />
-      </a><br />This work is licensed under a
+  def license_markup(license_data)
+    %( <a rel="license" href="#{license_data['id']}">
+      <img alt="#{license_data['term']}" style="border-width:0; width:120px"
+      src="#{license_data['image']}" />
+      </a>This work is licensed under a
       <a rel="license"
-      href="http://creativecommons.org/licenses/by/4.0/">
-      Creative Commons Attribution 4.0 International License
+      href="#{license_data['id']}">
+      "#{license_data['term']}"
       </a>. )
   end
 

--- a/app/presenters/ursus/license_metadata_presenter.rb
+++ b/app/presenters/ursus/license_metadata_presenter.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Ursus
+  class LicenseMetadataPresenter < BaseMetadataPresenter
+    self.config_file = 'metadata/license_metadata.yml'
+
+    def data
+      @config['terms'].find { |row| row['id'] == @document[:license_tesim].first }
+    end
+  end
+end

--- a/config/metadata/license_metadata.yml
+++ b/config/metadata/license_metadata.yml
@@ -1,0 +1,25 @@
+terms:
+    - id: https://creativecommons.org/licenses/by/4.0/
+      term: Creative Commons BY Attribution 4.0 International
+      image: https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by.png
+    - id: https://creativecommons.org/licenses/by-sa/4.0/
+      term: Creative Commons BY-SA Attribution-ShareAlike 4.0 International
+      image: https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png
+    - id: https://creativecommons.org/licenses/by-nd/4.0/
+      term: Creative Commons BY-ND Attribution-NoDerivatives 4.0 International
+      image: https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nd.png
+    - id: https://creativecommons.org/licenses/by-nc/4.0/
+      term: Creative Commons BY-NC Attribution-NonCommercial 4.0 International
+      image: https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc.png
+    - id: https://creativecommons.org/licenses/by-nc-nd/4.0/
+      term: Creative Commons BY-NC-ND Attribution-NonCommercial-NoDerivs 4.0 International
+      image: https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-nd.png
+    - id: https://creativecommons.org/licenses/by-nc-sa/4.0/
+      term: Creative Commons BY-NC-SA Attribution-NonCommercial-ShareAlike 4.0 International
+      image: https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-nc-sa.png
+    - id: http://creativecommons.org/publicdomain/zero/1.0/
+      term: Creative Commons CC0 1.0 Universal
+      image: https://mirrors.creativecommons.org/presskit/buttons/88x31/png/cc-zero.png
+    - id: http://creativecommons.org/publicdomain/mark/1.0/
+      term: Creative Commons Public Domain Mark 1.0
+      image: true

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe BlacklightHelper, type: :helper do
         SolrDocument.new(
           'title_tsim' => "A Fake Document",
           'id' => '8',
-          'license_tesim' => ["http://creativecommons.org/licenses/by/4.0/"]
+          'license_tesim' => ["https://creativecommons.org/licenses/by/4.0/"]
         )
       end
       it 'renders a cc license' do
-        expect(render_license).to match(/Creative Commons Attribution 4.0 International License/)
+        expect(render_license).to include('Creative Commons BY Attribution 4.0 International')
       end
     end
     context 'no license' do

--- a/spec/system/view_work_spec.rb
+++ b/spec/system/view_work_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe 'View a Work', type: :system, js: true do
   context 'license' do
     it 'displays the creative commons text and logo when there is a cc license' do
       visit "/catalog/#{ark}"
-      expect(page).to have_content 'License'
-      expect(page).to have_link 'Creative Commons Attribution 4.0 International License'
+      expect(page).to have_content 'LICENSE'
+      expect(page).to have_link 'Creative Commons BY Attribution 4.0 International'
     end
   end
 


### PR DESCRIPTION
https://uclalibrary.atlassian.net/browse/NOP-115

Now it's showing different content for different licenses.

<img width="972" height="522" alt="image" src="https://github.com/user-attachments/assets/6f52a0a0-fbf4-4502-af8d-2802ca8625c1" />

<img width="907" height="431" alt="image" src="https://github.com/user-attachments/assets/3dae388c-09f1-4a65-8bdd-bcf9cd3c9d8f" />

Only problem: I couldn't find image for "Public Domain Mark 1.0" on creativecommons.org, so we either don't show it, or we need to upload it somewhere. 

<img width="956" height="450" alt="image" src="https://github.com/user-attachments/assets/66dc8979-6a55-4d4e-9c65-3d75e33198c6" />
