### PR TITLE
DLSR-299: prevent private records appearing in search results

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -65,8 +65,7 @@ class CatalogController < ApplicationController
       mm: '100%',
       rows: 10,
       qf: 'title_tesim description_tesim creator_tesim keyword_tesim',
-      fq: '(ark_ssi:* AND ((has_model_ssim:Work) OR (has_model_ssim:Collection)) AND !((visibility_ssi:restricted) OR (visibility_ssi:discovery) OR (visibility_ssi:sinai)))'
-      ### we want to only return works where visibility_ssi == open (not restricted)
+      fq: 'ark_ssi:* AND (has_model_ssim:Work OR has_model_ssim:Collection) AND discover_access_group_ssim:public',
     }
 
     config.search_state_fields += [:range_end, :range_field, :range_start]

--- a/app/models/blacklight_dynamic_sitemap/sitemap.rb
+++ b/app/models/blacklight_dynamic_sitemap/sitemap.rb
@@ -10,7 +10,7 @@ module BlacklightDynamicSitemap
       index_connection.select(
         params: {
           q: "{!prefix f=#{hashed_id_field} v=#{id}}",
-          fq: '(((has_model_ssim:Work) OR (has_model_ssim:Collection)) AND !((visibility_ssi:restricted) OR (visibility_ssi:discovery) OR (visibility_ssi:sinai)))',
+          fq: 'ark_ssi:* AND (has_model_ssim:Work OR has_model_ssim:Collection) AND discover_access_group_ssim:public',
           fl: [unique_id_field, last_modified_field].join(','),
           rows: 2_000_000, # Ensure that we do not page this result
           facet: false,
@@ -42,7 +42,7 @@ module BlacklightDynamicSitemap
               q: '*:*',
               rows: 0,
               facet: false,
-              fq: '(((has_model_ssim:Work) OR (has_model_ssim:Collection)) AND !((visibility_ssi:restricted) OR (visibility_ssi:discovery) OR (visibility_ssi:sinai)))'
+              fq: 'ark_ssi:* AND (has_model_ssim:Work OR has_model_ssim:Collection) AND discover_access_group_ssim:public',
             }
           )['response']['numFound']
         end

--- a/spec/support/works.rb
+++ b/spec/support/works.rb
@@ -45,7 +45,8 @@ FIRST_WORK = {
   support_tesim: ['Mom & Dad'],
   read_access_group_ssim: ["public"],
   thumbnail_url_ss: ["http://thumbnail/work1.jpg"],
-  visibility_ssi: ['open']
+  visibility_ssi: ['open'],
+  discover_access_group_ssim: ['public'],
 }.freeze
 
 SECOND_WORK = {
@@ -68,7 +69,8 @@ SECOND_WORK = {
   member_of_collection_ids_ssim: ['coll-123'],
   read_access_group_ssim: ["public"],
   thumbnail_url_ss: ["http://thumbnail/work2.jpg"],
-  visibility_ssi: ['open']
+  visibility_ssi: ['open'],
+  discover_access_group_ssim: ['public'],
 }.freeze
 
 THIRD_WORK = {
@@ -92,7 +94,8 @@ THIRD_WORK = {
   member_of_collection_ids_ssim: ['coll-123'],
   read_access_group_ssim: ["public"],
   thumbnail_url_ss: ["http://thumbnail/work3.jpg"],
-  visibility_ssi: ['open']
+  visibility_ssi: ['open'],
+  discover_access_group_ssim: ['public'],
 }.freeze
 
 FIRST_COLLECTION = {
@@ -103,7 +106,8 @@ FIRST_COLLECTION = {
   date_created_tesim: ["Date 1"],
   repository_tesim: ['UCLA Collection'],
   languages_tesim: ['en', 'es', 'gk'],
-  human_readable_language_tesim: ['English', 'Spanish', 'Greek']
+  human_readable_language_tesim: ['English', 'Spanish', 'Greek'],
+  discover_access_group_ssim: ['public'],
 }.freeze
 
 FOURTH_WORK = {
@@ -124,7 +128,8 @@ FOURTH_WORK = {
   location_sim: ['search_results_spec'], # to control what displays
   collection_tesim: ['Photographs', 'Digital'],
   thumbnail_url_ss: ["http://thumbnail/work4.jpg"],
-  visibility_ssi: ['open']
+  visibility_ssi: ['open'],
+  discover_access_group_ssim: ['public'],
 }.freeze
 
 WORK_A = {
@@ -145,7 +150,8 @@ WORK_A = {
   member_of_collections_ssim: ['Bennett (Walter E.) Photographic Collection, 1937-1983 (bulk 1952-1982)'],
   member_of_collection_ids_ssim: ['m8f11000zz-89112'],
   thumbnail_url_ss: ["http://thumbnail/work4.jpg"],
-  visibility_ssi: ['open']
+  visibility_ssi: ['open'],
+  discover_access_group_ssim: ['public'],
 }.freeze
 
 WORK_B = {
@@ -166,7 +172,8 @@ WORK_B = {
   member_of_collections_ssim: ['Bennett (Walter E.) Photographic Collection, 1937-1983 (bulk 1952-1982)'],
   member_of_collection_ids_ssim: ['m8f11000zz-89112'],
   thumbnail_url_ss: ["http://thumbnail/work4.jpg"],
-  visibility_ssi: ['open']
+  visibility_ssi: ['open'],
+  discover_access_group_ssim: ['public'],
 }.freeze
 
 WORK_C = {
@@ -187,7 +194,8 @@ WORK_C = {
   member_of_collections_ssim: ['Bennett (Walter E.) Photographic Collection, 1937-1983 (bulk 1952-1982)'],
   member_of_collection_ids_ssim: ['m8f11000zz-89112'],
   thumbnail_url_ss: ["http://thumbnail/work4.jpg"],
-  visibility_ssi: ['open']
+  visibility_ssi: ['open'],
+  discover_access_group_ssim: ['public'],
 }.freeze
 
 WORK_D = {
@@ -208,7 +216,8 @@ WORK_D = {
   member_of_collections_ssim: ['Bennett (Walter E.) Photographic Collection, 1937-1983 (bulk 1952-1982)'],
   member_of_collection_ids_ssim: ['m8f11000zz-89112'],
   thumbnail_url_ss: ["http://thumbnail/work4.jpg"],
-  visibility_ssi: ['open']
+  visibility_ssi: ['open'],
+  discover_access_group_ssim: ['public'],
 }.freeze
 
 WORK_E = {
@@ -229,5 +238,6 @@ WORK_E = {
   member_of_collections_ssim: ['Bennett (Walter E.) Photographic Collection, 1937-1983 (bulk 1952-1982)'],
   member_of_collection_ids_ssim: ['m8f11000zz-89112'],
   thumbnail_url_ss: ["http://thumbnail/work4.jpg"],
-  visibility_ssi: ['open']
+  visibility_ssi: ['open'],
+  discover_access_group_ssim: ['public'],
 }.freeze

--- a/spec/system/facet_by_date_spec.rb
+++ b/spec/system/facet_by_date_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe 'Search the catalog', :clean, type: :system do
       ark_ssi: 'ark:/aaa/111',
       has_model_ssim: ['Work'],
       title_tesim: ['Llama Love'],
-      year_isim: [1920]
+      year_isim: [1920],
+      discover_access_group_ssim: ["public"],
     }
   end
 
@@ -25,7 +26,8 @@ RSpec.describe 'Search the catalog', :clean, type: :system do
       ark_ssi: 'ark:/222',
       has_model_ssim: ['Work'],
       title_tesim: ['Newt Nutrition'],
-      year_isim: [1940]
+      year_isim: [1940],
+      discover_access_group_ssim: ["public"],
     }
   end
 

--- a/spec/system/facet_labels_spec.rb
+++ b/spec/system/facet_labels_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe 'The facet sidebar', :clean, type: :system do
         human_readable_language_sim: ['No linguistic content'],
         location_sim: ['Echo Park'],
         member_of_collections_ssim: ['Connell'],
-        repository_sim: ['Fowler Museum']
+        repository_sim: ['Fowler Museum'],
+      discover_access_group_ssim: ["public"],
       }
     end
 

--- a/spec/system/search_catalog_spec.rb
+++ b/spec/system/search_catalog_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       has_model_ssim: ['Work'],
       title_tesim: ['Orange Carrot'],
       photographer_tesim: ['Bittersweet Tangerine'],
-      description_tesim: ['Long description Long description Long description<br>Long description Long description Long description']
+      description_tesim: ['Long description Long description Long description<br>Long description Long description Long description'],
+      discover_access_group_ssim: ["public"],
     }
   end
 
@@ -27,7 +28,8 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       ark_ssi: 'ark:/222',
       has_model_ssim: ['Work'],
       title_tesim: ['Yellow Banana'],
-      photographer_tesim: ['Buff Saffron']
+      photographer_tesim: ['Buff Saffron'],
+      discover_access_group_ssim: ["public"],
     }
   end
 
@@ -37,7 +39,8 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       ark_ssi: 'ark:/333',
       has_model_ssim: ['Work'],
       title_tesim: 'Target in creator',
-      creator_tesim: ['3Guv4P44']
+      creator_tesim: ['3Guv4P44'],
+      discover_access_group_ssim: ["public"],
     }
   end
 
@@ -47,7 +50,8 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       ark_ssi: 'ark:/444',
       has_model_ssim: ['Work'],
       title_tesim: 'Target in contributor',
-      contributor_tesim: ['3Guv4P44']
+      contributor_tesim: ['3Guv4P44'],
+      discover_access_group_ssim: ["public"],
     }
   end
 
@@ -57,7 +61,8 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       ark_ssi: 'ark:/555',
       has_model_ssim: ['Work'],
       title_tesim: 'Target in publisher',
-      publisher_tesim: ['3Guv4P44']
+      publisher_tesim: ['3Guv4P44'],
+      discover_access_group_ssim: ["public"],
     }
   end
 
@@ -67,7 +72,8 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       ark_ssi: 'ark:/666',
       has_model_ssim: ['Work'],
       title_tesim: 'Target in genre',
-      genre_tesim: ['3Guv4P44']
+      genre_tesim: ['3Guv4P44'],
+      discover_access_group_ssim: ["public"],
     }
   end
 
@@ -77,7 +83,8 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       ark_ssi: 'ark:/777',
       has_model_ssim: ['Work'],
       title_tesim: 'Target in medium',
-      medium_tesim: ['3Guv4P44']
+      medium_tesim: ['3Guv4P44'],
+      discover_access_group_ssim: ["public"],
     }
   end
 
@@ -87,7 +94,8 @@ RSpec.describe 'Search the catalog', type: :system, js: false do
       ark_ssi: 'ark:/888',
       has_model_ssim: ['Work'],
       title_tesim: 'Target in named_subject',
-      named_subject_tesim: ['3Guv4P44']
+      named_subject_tesim: ['3Guv4P44'],
+      discover_access_group_ssim: ["public"],
     }
   end
 

--- a/spec/system/search_collection_results_spec.rb
+++ b/spec/system/search_collection_results_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe 'Search collection results page', type: :system, js: false do
       description_tesim: ['Description 1'],
       thumbnail_path_ss: '/assets/collection-a38b932554788aa578debf2319e8c4ba8a7db06b3ba57ecda1391a548a4b6e0a.png',
       location_tesim: ['search_collection_results_spec'], # to control what displays
-      location_sim: ['search_collection_results_spec'] # to control what displays
+      location_sim: ['search_collection_results_spec'], # to control what displays
+      discover_access_group_ssim: ["public"],
     }
   end
 


### PR DESCRIPTION
On investigation, it looks like ursus was using an incomplete blacklist of visibility values to hide. Instead, use discover_access_group_ssim:public, which is the relevant field for  blacklight-access_controls, and which feed_ursus is correctly setting based on visibility