### PR TITLE
fix: named_subject links to combined_names facet search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -294,7 +294,7 @@ class CatalogController < ApplicationController
       )
     end
     config.add_show_field 'musician_tesim', label: 'Musician', link_to_facet: 'combined_names_ssim' # Primary / Physical description
-    config.add_show_field 'named_subject_tesim', label: 'Named subject', link_to_facet: 'named_subject_sim' # Primary / Physical description
+    config.add_show_field 'named_subject_tesim', label: 'Named subject', link_to_facet: 'combined_names_ssim' # Primary / Physical description
     config.add_show_field 'note_tesim', label: 'Note' # Primary / Notes
     config.add_show_field 'oai_set_ssim'
     config.add_show_field 'oclc_ssi', label: 'OCLC Number' # Secondary / Find This Item


### PR DESCRIPTION
Apparently in https://github.com/UCLALibrary/ursus/pull/1234 I was working off a list of name fields which I copied from feed ursus before https://github.com/UCLALibrary/feed_ursus/pull/130, and which erroneously left out named_subject.