### PR TITLE
DLSR-484: Fix title sort

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -387,10 +387,8 @@ class CatalogController < ApplicationController
     # (it must be asc or desc except in the relevancy case)
     # label is key, solr field is value
     config.add_sort_field 'score desc', label: 'Relevance'
-    config.add_sort_field 'exists(sort_title_tsort) desc, sort_title_tsort asc, exists(title_alpha_numeric_ssort) desc, title_alpha_numeric_ssort asc', label: 'Title (A-Z)'
-    config.add_sort_field 'exists(sort_title_tsort) desc, sort_title_tsort  desc, exists(title_alpha_numeric_ssort) desc, title_alpha_numeric_ssort desc', label: 'Title (Z-A)'
-    # config.add_sort_field 'title_alpha_numeric_ssort asc', label: 'Title (A-Z)'
-    # config.add_sort_field 'title_alpha_numeric_ssort desc', label: 'Title (Z-A)'
+    config.add_sort_field 'exists(sort_title_tsort) asc, sort_title_tsort asc, exists(title_alpha_numeric_ssort) asc, title_alpha_numeric_ssort asc', label: 'Title (A-Z)'
+    config.add_sort_field 'exists(sort_title_tsort) desc, sort_title_tsort desc, exists(title_alpha_numeric_ssort) desc, title_alpha_numeric_ssort desc', label: 'Title (Z-A)'
     config.add_sort_field 'date_dtsort desc', label: 'Date (newest)'
     config.add_sort_field 'date_dtsort asc', label: 'Date (oldest)'
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -233,8 +233,8 @@ RSpec.describe CatalogController, type: :controller do
     let(:expected_sort_fields) do
       [
         "score desc",
-        "exists(sort_title_tsort) desc, sort_title_tsort asc, exists(title_alpha_numeric_ssort) desc, title_alpha_numeric_ssort asc",
-        "exists(sort_title_tsort) desc, sort_title_tsort  desc, exists(title_alpha_numeric_ssort) desc, title_alpha_numeric_ssort desc",
+        "exists(sort_title_tsort) asc, sort_title_tsort asc, exists(title_alpha_numeric_ssort) asc, title_alpha_numeric_ssort asc",
+        "exists(sort_title_tsort) desc, sort_title_tsort desc, exists(title_alpha_numeric_ssort) desc, title_alpha_numeric_ssort desc",
         "date_dtsort desc",
         "date_dtsort asc",
       ]


### PR DESCRIPTION
This fixes a small bug in the Ursus UI, where "Sort by Title (A-Z)" specified a confusing mixture of `desc` and `asc` orders.  I think this had no real effect on functionality... but it seemed wrong, and making it consistent doesn't seem to break anything, so I changed it.

The real problem [reported on DLSR-484](https://uclalibrary.atlassian.net/browse/DLSR-484) appears to be caused by incomplete indexing, where 15K-20K records lack a `sort_title_tsort` field.  When these records are in search results, they're sorted by `title_alpha_numeric_ssort` instead, which doesn't handle non-Latin characters in the same way.  I think that can be fixed by re-indexing, but that's outside the scope of this PR.
